### PR TITLE
feat(Select): add Select component with chevron-down icon

### DIFF
--- a/packages/components-react/src/Select/Select.css
+++ b/packages/components-react/src/Select/Select.css
@@ -1,0 +1,84 @@
+/**
+ * Select Component Styles
+ * Wrapper positions the chevron-down icon absolutely at inline-end inside the select.
+ * The select uses dsn-text-input base styles with extra padding-inline-end
+ * to prevent selected text from overlapping the icon.
+ * The native dropdown arrow is hidden via appearance: none.
+ */
+
+/* Wrapper — positions icon absolutely inside the select */
+.dsn-select-wrapper {
+  position: relative;
+  display: block;
+  inline-size: 100%;
+  max-inline-size: var(--dsn-form-control-max-inline-size);
+}
+
+/* Chevron icon — centered vertically, positioned at inline-end */
+.dsn-select__icon {
+  position: absolute;
+  inset-block-start: 50%;
+  inset-inline-end: var(--dsn-select-icon-inset-inline-end);
+  transform: translateY(-50%);
+  inline-size: var(--dsn-select-icon-size);
+  block-size: var(--dsn-select-icon-size);
+  color: var(--dsn-select-icon-color);
+  pointer-events: none;
+}
+
+/* Select — reset browser defaults, hide native arrow, add padding for custom icon */
+/* Also override :read-only styles from dsn-text-input, because browsers consider
+   <select> as :read-only (non-typeable), which incorrectly triggers those styles. */
+.dsn-select {
+  appearance: none;
+  background-color: var(--dsn-text-input-background-color);
+  border: var(--dsn-text-input-border-width) solid
+    var(--dsn-text-input-border-color);
+  color: var(--dsn-text-input-color);
+  cursor: pointer;
+  padding-inline-end: var(--dsn-select-padding-inline-end-with-icon);
+}
+
+/* Undo the :read-only styles inherited from dsn-text-input */
+.dsn-select:read-only {
+  background-color: var(--dsn-text-input-background-color);
+  border-color: var(--dsn-text-input-border-color);
+  color: var(--dsn-text-input-color);
+  cursor: pointer;
+}
+
+.dsn-select:disabled {
+  background-color: var(--dsn-text-input-disabled-background-color);
+  border-color: var(--dsn-text-input-disabled-border-color);
+  cursor: not-allowed;
+}
+
+.dsn-select[aria-invalid='true'] {
+  background-color: var(--dsn-text-input-invalid-background-color);
+  border-color: var(--dsn-text-input-invalid-border-color);
+}
+
+/* Remove native arrow in IE/Edge */
+.dsn-select::-ms-expand {
+  display: none;
+}
+
+/* Width variants on the wrapper */
+.dsn-select-wrapper--width-xs {
+  max-inline-size: var(--dsn-form-control-width-xs);
+}
+.dsn-select-wrapper--width-sm {
+  max-inline-size: var(--dsn-form-control-width-sm);
+}
+.dsn-select-wrapper--width-md {
+  max-inline-size: var(--dsn-form-control-width-md);
+}
+.dsn-select-wrapper--width-lg {
+  max-inline-size: var(--dsn-form-control-width-lg);
+}
+.dsn-select-wrapper--width-xl {
+  max-inline-size: var(--dsn-form-control-width-xl);
+}
+.dsn-select-wrapper--width-full {
+  max-inline-size: var(--dsn-form-control-width-full);
+}

--- a/packages/components-react/src/Select/Select.test.tsx
+++ b/packages/components-react/src/Select/Select.test.tsx
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Select } from './Select';
+
+describe('Select', () => {
+  it('renders a wrapper div', () => {
+    const { container } = render(
+      <Select data-testid="select">
+        <option value="1">Optie 1</option>
+      </Select>
+    );
+    expect(container.querySelector('.dsn-select-wrapper')).toBeInTheDocument();
+  });
+
+  it('renders a select element inside wrapper', () => {
+    render(
+      <Select data-testid="select">
+        <option value="1">Optie 1</option>
+      </Select>
+    );
+    expect(screen.getByTestId('select').tagName).toBe('SELECT');
+  });
+
+  it('always has base dsn-text-input class on select', () => {
+    render(
+      <Select data-testid="select">
+        <option value="1">Optie 1</option>
+      </Select>
+    );
+    expect(screen.getByTestId('select')).toHaveClass('dsn-text-input');
+  });
+
+  it('always has dsn-select class on select', () => {
+    render(
+      <Select data-testid="select">
+        <option value="1">Optie 1</option>
+      </Select>
+    );
+    expect(screen.getByTestId('select')).toHaveClass('dsn-select');
+  });
+
+  it('applies custom className to select', () => {
+    render(
+      <Select className="custom" data-testid="select">
+        <option value="1">Optie 1</option>
+      </Select>
+    );
+    const el = screen.getByTestId('select');
+    expect(el).toHaveClass('dsn-text-input');
+    expect(el).toHaveClass('dsn-select');
+    expect(el).toHaveClass('custom');
+  });
+
+  it('forwards ref to select element', () => {
+    const ref = { current: null as HTMLSelectElement | null };
+    render(
+      <Select ref={ref}>
+        <option value="1">Optie 1</option>
+      </Select>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLSelectElement);
+  });
+
+  it('spreads additional HTML attributes to select', () => {
+    render(
+      <Select id="my-select" data-testid="select">
+        <option value="1">Optie 1</option>
+      </Select>
+    );
+    expect(screen.getByTestId('select')).toHaveAttribute('id', 'my-select');
+  });
+
+  it('renders children (options) inside select', () => {
+    render(
+      <Select data-testid="select">
+        <option value="1">Optie 1</option>
+        <option value="2">Optie 2</option>
+      </Select>
+    );
+    const select = screen.getByTestId('select') as HTMLSelectElement;
+    expect(select.options).toHaveLength(2);
+  });
+
+  describe('chevron icon', () => {
+    it('renders a chevron-down icon', () => {
+      const { container } = render(
+        <Select>
+          <option value="1">Optie 1</option>
+        </Select>
+      );
+      expect(container.querySelector('.dsn-select__icon')).toBeInTheDocument();
+    });
+
+    it('chevron icon has aria-hidden', () => {
+      const { container } = render(
+        <Select>
+          <option value="1">Optie 1</option>
+        </Select>
+      );
+      const icon = container.querySelector('.dsn-select__icon');
+      expect(icon).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('does not render chevron icon when disabled', () => {
+      const { container } = render(
+        <Select disabled>
+          <option value="1">Optie 1</option>
+        </Select>
+      );
+      expect(
+        container.querySelector('.dsn-select__icon')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('width variants', () => {
+    it('wrapper has no width class by default', () => {
+      const { container } = render(
+        <Select>
+          <option value="1">Optie 1</option>
+        </Select>
+      );
+      const wrapper = container.querySelector('.dsn-select-wrapper');
+      expect(wrapper?.className).toBe('dsn-select-wrapper');
+    });
+
+    it.each(['xs', 'sm', 'md', 'lg', 'xl', 'full'] as const)(
+      'applies width-%s class to wrapper',
+      (width) => {
+        const { container } = render(
+          <Select width={width}>
+            <option value="1">Optie 1</option>
+          </Select>
+        );
+        expect(
+          container.querySelector(`.dsn-select-wrapper--width-${width}`)
+        ).toBeInTheDocument();
+      }
+    );
+  });
+
+  it('can be disabled', () => {
+    render(
+      <Select disabled data-testid="select">
+        <option value="1">Optie 1</option>
+      </Select>
+    );
+    expect(screen.getByTestId('select')).toBeDisabled();
+  });
+
+  it('can be required', () => {
+    render(
+      <Select required data-testid="select">
+        <option value="1">Optie 1</option>
+      </Select>
+    );
+    expect(screen.getByTestId('select')).toBeRequired();
+  });
+
+  describe('invalid state', () => {
+    it('sets aria-invalid when invalid prop is true', () => {
+      render(
+        <Select invalid data-testid="select">
+          <option value="1">Optie 1</option>
+        </Select>
+      );
+      expect(screen.getByTestId('select')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+    });
+
+    it('does not set aria-invalid when invalid prop is false', () => {
+      render(
+        <Select invalid={false} data-testid="select">
+          <option value="1">Optie 1</option>
+        </Select>
+      );
+      expect(screen.getByTestId('select')).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('does not set aria-invalid by default', () => {
+      render(
+        <Select data-testid="select">
+          <option value="1">Optie 1</option>
+        </Select>
+      );
+      expect(screen.getByTestId('select')).not.toHaveAttribute('aria-invalid');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('can have aria-describedby', () => {
+      render(
+        <Select aria-describedby="help-text" data-testid="select">
+          <option value="1">Optie 1</option>
+        </Select>
+      );
+      expect(screen.getByTestId('select')).toHaveAttribute(
+        'aria-describedby',
+        'help-text'
+      );
+    });
+
+    it('can have aria-labelledby', () => {
+      render(
+        <Select aria-labelledby="label-id" data-testid="select">
+          <option value="1">Optie 1</option>
+        </Select>
+      );
+      expect(screen.getByTestId('select')).toHaveAttribute(
+        'aria-labelledby',
+        'label-id'
+      );
+    });
+  });
+});

--- a/packages/components-react/src/Select/Select.tsx
+++ b/packages/components-react/src/Select/Select.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { classNames, FormControlWidth } from '@dsn/core';
+import { Icon } from '../Icon';
+import '../TextInput/TextInput.css';
+import './Select.css';
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  /**
+   * Whether the select is in an invalid state
+   * @default false
+   */
+  invalid?: boolean;
+
+  /**
+   * Width variant for the select
+   * @default undefined (uses default max-width from form-control)
+   */
+  width?: FormControlWidth;
+
+  /**
+   * Additional CSS class names
+   */
+  className?: string;
+}
+
+/**
+ * Select component
+ * Dropdown select with a custom chevron-down icon at inline-end.
+ * The native select arrow is hidden; the custom icon is decorative and non-interactive.
+ *
+ * @example
+ * ```tsx
+ * // Basic usage
+ * <Select>
+ *   <option value="">Kies een optie</option>
+ *   <option value="1">Optie 1</option>
+ *   <option value="2">Optie 2</option>
+ * </Select>
+ *
+ * // With label
+ * <FormField label="Land" htmlFor="land">
+ *   <Select id="land">
+ *     <option value="">Kies een land</option>
+ *     <option value="nl">Nederland</option>
+ *     <option value="be">België</option>
+ *   </Select>
+ * </FormField>
+ *
+ * // Width variant
+ * <Select width="lg">...</Select>
+ *
+ * // Invalid state
+ * <Select invalid aria-invalid="true" aria-describedby="error">...</Select>
+ * ```
+ */
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, invalid, width, disabled, children, ...props }, ref) => {
+    const wrapperClasses = classNames(
+      'dsn-select-wrapper',
+      width && `dsn-select-wrapper--width-${width}`
+    );
+
+    const selectClasses = classNames('dsn-text-input', 'dsn-select', className);
+
+    return (
+      <div className={wrapperClasses}>
+        <select
+          ref={ref}
+          className={selectClasses}
+          aria-invalid={invalid || undefined}
+          disabled={disabled}
+          {...props}
+        >
+          {children}
+        </select>
+        {!disabled && (
+          <Icon name="chevron-down" className="dsn-select__icon" aria-hidden />
+        )}
+      </div>
+    );
+  }
+);
+
+Select.displayName = 'Select';

--- a/packages/components-react/src/Select/index.ts
+++ b/packages/components-react/src/Select/index.ts
@@ -1,0 +1,2 @@
+export { Select } from './Select';
+export type { SelectProps } from './Select';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -25,6 +25,7 @@ export * from './TelephoneInput';
 export * from './SearchInput';
 export * from './TimeInput';
 export * from './DateInput';
+export * from './Select';
 export * from './TextArea';
 
 // Form Options

--- a/packages/design-tokens/src/tokens/components/select.json
+++ b/packages/design-tokens/src/tokens/components/select.json
@@ -1,0 +1,31 @@
+{
+  "dsn": {
+    "select": {
+      "icon-size": {
+        "value": "{dsn.icon.size.md}",
+        "type": "dimension",
+        "comment": "Chevron-down icon size — matches the medium icon size"
+      },
+      "icon-gap": {
+        "value": "{dsn.space.text.md}",
+        "type": "dimension",
+        "comment": "Gap between chevron icon and select text"
+      },
+      "icon-inset-inline-end": {
+        "value": "{dsn.space.inline.md}",
+        "type": "dimension",
+        "comment": "Distance from the inline-end border to the chevron icon (8px)"
+      },
+      "icon-color": {
+        "value": "{dsn.color.action-1.color-default}",
+        "type": "color",
+        "comment": "Chevron icon color — same as subtle button icon color"
+      },
+      "padding-inline-end-with-icon": {
+        "value": "calc({dsn.select.icon-size} + {dsn.select.icon-gap} + {dsn.select.icon-inset-inline-end})",
+        "type": "dimension",
+        "comment": "Right padding when icon is present: icon-size + gap + inset"
+      }
+    }
+  }
+}

--- a/packages/storybook/src/Select.docs.md
+++ b/packages/storybook/src/Select.docs.md
@@ -1,0 +1,52 @@
+# Select
+
+Een dropdown selectiemenu waarmee gebruikers één optie kunnen kiezen uit een lijst.
+
+## Doel
+
+Select is een formuliercomponent op basis van het native `<select>` element. Het heeft een aangepast chevron-down icoon aan de rechterkant, consistent met de actiekleur van de Button subtle variant. De native browser pijl is verborgen zodat het icoon uniform eruitziet in alle browsers.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- De gebruiker één keuze moet maken uit een vooraf bepaalde lijst
+- Er meer dan 5 opties zijn (minder opties kunnen beter als RadioGroup worden weergegeven)
+- Ruimte beperkt is en een uitklaplijst handiger is dan losse radio buttons
+
+## Don't use when
+
+- Er maar 2-4 opties zijn — gebruik dan RadioOption/RadioGroup
+- Meerdere opties tegelijk geselecteerd mogen worden — gebruik dan CheckboxGroup
+- De opties dynamisch gefilterd of doorzocht moeten worden — gebruik dan een autocomplete of combobox pattern
+
+## Best practices
+
+- Geef altijd een eerste lege optie of placeholder-optie (bijv. "Kies een optie") zodat de gebruiker bewust een keuze maakt
+- Gebruik een `<FormField>` wrapper met een duidelijk label
+- Zorg dat opties kort en onderscheidend zijn
+- Groepeer gerelateerde opties met `<optgroup>` bij lange lijsten
+
+## Accessibility
+
+- Het `<select>` element is van nature toegankelijk voor toetsenbord en screenreaders
+- Gebruik altijd een zichtbaar label via `<FormField>` of `<FormFieldLabel htmlFor="...">`
+- De `invalid` prop zet `aria-invalid="true"` — combineer dit met `<FormFieldErrorMessage>` en `aria-describedby`
+- Het chevron-icoon heeft `aria-hidden="true"` en is voor screenreaders onzichtbaar
+
+## States
+
+- **Default** — lege selectie of placeholder
+- **With value** — een optie is geselecteerd
+- **Disabled** — niet bewerkbaar, gereduceerde opaciteit
+- **Invalid** — rode border, gebruik samen met foutmelding
+
+## Design tokens
+
+| Token                                       | Beschrijving                                     |
+| ------------------------------------------- | ------------------------------------------------ |
+| `--dsn-select-icon-size`                    | Grootte van het chevron-icoon                    |
+| `--dsn-select-icon-gap`                     | Ruimte tussen icoon en tekst                     |
+| `--dsn-select-icon-inset-inline-end`        | Afstand van icoon tot de rechterrand             |
+| `--dsn-select-icon-color`                   | Kleur van het chevron-icoon                      |
+| `--dsn-select-padding-inline-end-with-icon` | Padding rechts van de select (ruimte voor icoon) |

--- a/packages/storybook/src/Select.docs.mdx
+++ b/packages/storybook/src/Select.docs.mdx
@@ -1,0 +1,17 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as SelectStories from './Select.stories';
+import docs from './Select.docs.md?raw';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={SelectStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<Story of={SelectStories.Default} />
+
+<Controls of={SelectStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/Select.stories.tsx
+++ b/packages/storybook/src/Select.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Select } from '@dsn/components-react';
+import DocsPage from './Select.docs.mdx';
+
+const OPTIONS = (
+  <>
+    <option value="">Kies een optie</option>
+    <option value="nl">Nederland</option>
+    <option value="be">België</option>
+    <option value="de">Duitsland</option>
+    <option value="fr">Frankrijk</option>
+    <option value="gb">Verenigd Koninkrijk</option>
+  </>
+);
+
+const meta: Meta<typeof Select> = {
+  title: 'Components/Select',
+  component: Select,
+  parameters: {
+    docs: {
+      page: DocsPage,
+    },
+  },
+  argTypes: {
+    disabled: { control: 'boolean' },
+    invalid: { control: 'boolean' },
+    required: { control: 'boolean' },
+    width: {
+      control: 'select',
+      options: [undefined, 'xs', 'sm', 'md', 'lg', 'xl', 'full'],
+    },
+  },
+  args: {
+    disabled: false,
+    invalid: false,
+    required: false,
+    children: OPTIONS,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+export const Default: Story = {};
+
+export const WithValue: Story = {
+  name: 'With value',
+  args: {
+    defaultValue: 'nl',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    defaultValue: 'nl',
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    invalid: true,
+  },
+};
+
+export const Widths: Story = {
+  name: 'Width variants',
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <Select width="xs">{OPTIONS}</Select>
+      <Select width="sm">{OPTIONS}</Select>
+      <Select width="md">{OPTIONS}</Select>
+      <Select width="lg">{OPTIONS}</Select>
+      <Select width="xl">{OPTIONS}</Select>
+      <Select width="full">{OPTIONS}</Select>
+    </div>
+  ),
+};
+
+export const AllStates: Story = {
+  name: 'All states',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+        maxWidth: '400px',
+      }}
+    >
+      <div>
+        <label
+          style={{
+            display: 'block',
+            marginBottom: '0.5rem',
+            fontWeight: 'bold',
+          }}
+        >
+          Default
+        </label>
+        <Select>{OPTIONS}</Select>
+      </div>
+      <div>
+        <label
+          style={{
+            display: 'block',
+            marginBottom: '0.5rem',
+            fontWeight: 'bold',
+          }}
+        >
+          With value
+        </label>
+        <Select defaultValue="nl">{OPTIONS}</Select>
+      </div>
+      <div>
+        <label
+          style={{
+            display: 'block',
+            marginBottom: '0.5rem',
+            fontWeight: 'bold',
+          }}
+        >
+          Disabled
+        </label>
+        <Select disabled defaultValue="nl">
+          {OPTIONS}
+        </Select>
+      </div>
+      <div>
+        <label
+          style={{
+            display: 'block',
+            marginBottom: '0.5rem',
+            fontWeight: 'bold',
+          }}
+        >
+          Invalid
+        </label>
+        <Select invalid>{OPTIONS}</Select>
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary
- Wrapper + native `<select>` patroon met `width` prop (zoals SearchInput)
- Chevron-down icoon niet-interactief aan inline-end, consistent met actiekleur van Button subtle (zelfde als TimeInput/DateInput)
- `appearance: none` om native browser pijl te verbergen
- `:read-only` override om te voorkomen dat browsers `<select>` ten onrechte als read-only behandelen
- Icoon verdwijnt bij `disabled` — consistent met TimeInput/DateInput
- 5 design tokens in `select.json`
- 25 tests, Storybook stories + documentatie

## Test plan
- [x] 25 tests groen
- [x] TypeScript build slaagt
- [x] CI groen
- [x] Storybook bekeken

🤖 Generated with [Claude Code](https://claude.com/claude-code)