### PR TITLE
fix(FormFieldset): show red left border in invalid state

### DIFF
--- a/packages/components-react/src/FormFieldset/FormFieldset.css
+++ b/packages/components-react/src/FormFieldset/FormFieldset.css
@@ -8,8 +8,17 @@
 /* Additional fieldset-specific styles if needed can be added here */
 
 fieldset.dsn-form-field {
-  border: none;
+  border-block-start: none;
+  border-block-end: none;
+  border-inline-end: none;
+  border-inline-start: none;
   margin: 0;
   padding: 0;
   min-inline-size: 0; /* Reset fieldset min-width */
+}
+
+fieldset.dsn-form-field--invalid {
+  border-inline-start: var(--dsn-form-field-invalid-border-inline-start-width)
+    solid var(--dsn-form-field-invalid-border-inline-start-color);
+  padding-inline-start: var(--dsn-form-field-invalid-padding-inline-start);
 }


### PR DESCRIPTION
## Summary
- Vervang `border: none` reset door per-kant properties zodat de `--invalid` modifier de inline-start border kan tonen
- Zelfde visuele patroon als FormField: rode linkerborder wanneer er een foutmelding aanwezig is
- Van toepassing op alle stories met een invalid FormFieldset (FormFieldset, DateInputGroup)

## Test plan
- [x] Tests groen
- [x] Build slaagt
- [x] FormFieldset AllStates → "With error message" toont rode linkerborder
- [x] DateInputGroup Invalid toont rode linkerborder
- [x] Andere states (default, description, status) ongewijzigd

🤖 Generated with [Claude Code](https://claude.com/claude-code)