### PR TITLE
docs: update documentation for v4.4.0 (Select, DateInput, DateInputGroup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pnpm --filter @dsn/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (613 tests across 35 test suites)
+# Run tests (733 tests across 38 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -174,13 +174,15 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Paragraph**     | Yes      | Yes   | Yes           |
 | **UnorderedList** | Yes      | Yes   | Yes           |
 
-**Form Components (22 total)**
+**Form Components (25 total)**
 
 | Component                 | HTML/CSS | React | Web Component |
 | ------------------------- | -------- | ----- | ------------- |
 | **Checkbox**              | Yes      | Yes   | —             |
 | **CheckboxGroup**         | Yes      | Yes   | —             |
 | **CheckboxOption**        | Yes      | Yes   | —             |
+| **DateInput**             | Yes      | Yes   | —             |
+| **DateInputGroup**        | Yes      | Yes   | —             |
 | **EmailInput**            | Yes      | Yes   | —             |
 | **FormField**             | Yes      | Yes   | —             |
 | **FormFieldDescription**  | Yes      | Yes   | —             |
@@ -196,6 +198,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **RadioGroup**            | Yes      | Yes   | —             |
 | **RadioOption**           | Yes      | Yes   | —             |
 | **SearchInput**           | Yes      | Yes   | —             |
+| **Select**                | Yes      | Yes   | —             |
 | **TelephoneInput**        | Yes      | Yes   | —             |
 | **TextArea**              | Yes      | Yes   | —             |
 | **TextInput**             | Yes      | Yes   | —             |
@@ -323,7 +326,7 @@ Comprehensive documentation is available in the `/docs` folder:
 
 - **Pre-commit hooks** via Husky + lint-staged (ESLint + Prettier)
 - **Type checking** across all packages (`pnpm type-check`)
-- **613 tests** covering React components, Web Components, and utilities
+- **733 tests** covering React components, Web Components, and utilities
 - **CI/CD** via GitHub Actions (lint, type-check, test, build)
 
 ## Tech Stack

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1,6 +1,6 @@
 # Components
 
-**Last Updated:** February 14, 2026
+**Last Updated:** February 19, 2025
 
 Complete component specifications and guidelines for the Design System Starter Kit.
 
@@ -120,25 +120,33 @@ Components are designed to compose together:
 </FormField>
 
 // React — Checkbox group with fieldset/legend
-<FormField
-  label="Notification preferences"
-  isGroup
+<FormFieldset
+  legend="Notification preferences"
   description="Choose how you want to be notified"
 >
-  <CheckboxGroup legend="Notification preferences">
-    <CheckboxOption label="Email notifications" />
-    <CheckboxOption label="SMS notifications" />
-    <CheckboxOption label="Push notifications" />
+  <CheckboxGroup>
+    <CheckboxOption label="Email notifications" value="email" />
+    <CheckboxOption label="SMS notifications" value="sms" />
+    <CheckboxOption label="Push notifications" value="push" />
   </CheckboxGroup>
-</FormField>
+</FormFieldset>
 
 // React — Radio group
-<FormField label="Delivery method" isGroup>
-  <RadioGroup legend="Delivery method">
-    <RadioOption label="Standard shipping" name="delivery" />
-    <RadioOption label="Express shipping" name="delivery" />
+<FormFieldset legend="Delivery method">
+  <RadioGroup>
+    <RadioOption label="Standard shipping" name="delivery" value="standard" />
+    <RadioOption label="Express shipping" name="delivery" value="express" />
   </RadioGroup>
-</FormField>
+</FormFieldset>
+
+// React — Date input group
+<FormFieldset legend="Date of birth" description="For example: 15 3 1990">
+  <DateInputGroup
+    id="dob"
+    value={value}
+    onChange={setValue}
+  />
+</FormFieldset>
 ```
 
 ---
@@ -307,7 +315,7 @@ Components are designed to compose together:
 
 ## Form Components
 
-**Status:** Complete (HTML/CSS, React) - 19 components total
+**Status:** Complete (HTML/CSS, React) - 25 components total
 
 **Location:** `packages/components-{html|react}/src/`
 
@@ -383,9 +391,37 @@ Components are designed to compose together:
 
 **Tokens:** `tokens/components/time-input.json`, extends TextInput tokens
 
-**Features:** Native time picker in supported browsers
+**Features:** Wrapper with interactive clock button (`Button subtle small iconOnly`) at inline-end. `showPicker()` triggered via internal ref. No `width` prop — fixed `sm` width.
 
-**Props:** All TextInput props, type="time"
+**Props:** `invalid`, `disabled`, `readOnly`, and all native `<input type="time">` attributes
+
+**Tests:** React (9 tests)
+
+#### DateInput
+
+**Tokens:** `tokens/components/date-input.json`, extends TextInput tokens
+
+**Features:** Wrapper with interactive calendar button (`Button subtle small iconOnly`, `calendar-event` icon) at inline-end. Same pattern as TimeInput. `showPicker()` via internal ref + `handleRef` merge. Fixed width — no `width` prop.
+
+**Props:** `invalid`, `disabled`, `readOnly`, and all native `<input type="date">` attributes
+
+**Tests:** React (9 tests)
+
+#### Select
+
+**Tokens:** `tokens/components/select.json`, extends TextInput tokens
+
+**Features:** Wrapper with `chevron-down` icon at inline-end. Native browser arrow hidden via `appearance: none`. Icon disappears when `disabled`. Width variants on wrapper (same pattern as SearchInput).
+
+**Props:** `invalid`, `width`, and all native `<select>` attributes
+
+**Tests:** React (9 tests)
+
+#### DateInputGroup
+
+**Features:** Three separate `NumberInput` fields (dag xs, maand xs, jaar sm) with inline labels. `id` prop auto-generates `{id}-dag`, `{id}-maand`, `{id}-jaar`. `onChange` returns the full `{ day, month, year }` object. Wrap in `FormFieldset` for a complete accessible form field.
+
+**Props:** `value` (`{ day, month, year }`), `onChange`, `invalid`, `disabled`, `id`
 
 **Tests:** React (9 tests)
 
@@ -453,11 +489,9 @@ Components are designed to compose together:
 
 **Tokens:** `tokens/components/checkbox-group.json`
 
-**Features:** Fieldset/legend structure for accessible grouping
+**Features:** Simple div container for `CheckboxOption` items. Fieldset/legend structure lives in `FormFieldset` — always wrap `CheckboxGroup` in a `FormFieldset` for accessible grouping.
 
-**Legend tokens:** References `form-field-label` tokens (DRY principle)
-
-**Props:** `legend`, `hideLegend`, `children`
+**Props:** `children`, standard div attributes
 
 **Tests:** React (8 tests)
 
@@ -465,11 +499,9 @@ Components are designed to compose together:
 
 **Tokens:** `tokens/components/radio-group.json`
 
-**Features:** Fieldset/legend structure for accessible grouping
+**Features:** Simple div container for `RadioOption` items. Fieldset/legend structure lives in `FormFieldset` — always wrap `RadioGroup` in a `FormFieldset` for accessible grouping.
 
-**Legend tokens:** References `form-field-label` tokens (DRY principle)
-
-**Props:** `legend`, `hideLegend`, `children`
+**Props:** `children`, standard div attributes
 
 **Tests:** React (9 tests)
 
@@ -479,15 +511,25 @@ Components are designed to compose together:
 
 **Tokens:** `tokens/components/form-field.json`
 
-**Intelligent rendering:** Automatically uses fieldset/legend for groups, div/label for regular controls
-
-**Features:** Combines Label, Description, Control, Error, Status with automatic aria-describedby linking
+**Features:** div/label container for single-value inputs (TextInput, EmailInput, Select, etc.). Combines Label, Description, Control, Error, and Status with automatic aria-describedby linking.
 
 **Invalid state:** Red left border via `form-field.invalid` tokens
 
-**Props:** `label`, `htmlFor`, `labelSuffix`, `description`, `error`, `status`, `isGroup`, `hideLabel`, `children`, `invalid`
+**Props:** `label`, `htmlFor`, `labelSuffix`, `description`, `error`, `status`, `children`
 
 **Tests:** React (11 tests)
+
+#### FormFieldset
+
+**Tokens:** `tokens/components/form-fieldset.json`
+
+**Features:** fieldset/legend container for group controls (CheckboxGroup, RadioGroup, DateInputGroup). Combines FormFieldLegend, FormFieldDescription, FormFieldErrorMessage, and the group control.
+
+**Invalid state:** Red left border when `error` prop is set (same as FormField)
+
+**Props:** `legend`, `hideLegend`, `description`, `error`, `status`, `children`
+
+**Tests:** React (9 tests)
 
 #### FormFieldLabel
 
@@ -582,15 +624,15 @@ defineButton('my-custom-button');
 
 ## Component Statistics
 
-**Total Components:** 26
+**Total Components:** 32
 
 **Implementations:**
 
-- **HTML/CSS:** 26 components
-- **React:** 26 components (396 tests total)
+- **HTML/CSS:** 32 components
+- **React:** 32 components (733 tests total)
 - **Web Component:** 7 components (Button, Heading, Icon, Link, OrderedList, Paragraph, UnorderedList)
 
-**Test Coverage:** 396 tests across 24 test suites
+**Test Coverage:** 733 tests across 38 test suites
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,53 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 4.4.0 (February 19, 2025)
+
+### New Components: Select, DateInput, DateInputGroup + FormFieldset fix
+
+**Select Component**
+
+- **Select component** — Dropdown select with a custom `chevron-down` icon at inline-end
+- Wrapper `dsn-select-wrapper` handles width variants (same pattern as SearchInput)
+- Native browser select arrow hidden via `appearance: none`
+- Icon disappears when `disabled`
+- Props: `invalid`, `width`, and all native `<select>` attributes
+- Storybook documentation with Default, Invalid, Disabled, Width Variants, and WithFormField stories
+
+**DateInput Component**
+
+- **DateInput component** — Date input (`type="date"`) with an interactive calendar button at inline-end
+- Same pattern as TimeInput: `<Button variant="subtle" size="small" iconOnly>` with `calendar-event` icon
+- Fixed width (no `width` prop) — date inputs have a predictable content width
+- `showPicker()` triggered via internal ref + `handleRef` merge pattern
+- Native browser calendar icon hidden via `::-webkit-calendar-picker-indicator { display: none }`
+- Button disappears when `disabled` or `readOnly`
+- Props: `invalid`, and all native date input attributes
+- Storybook documentation with Default, WithValue, Invalid, Disabled, ReadOnly, and WithFormField stories
+
+**DateInputGroup Component**
+
+- **DateInputGroup component** — Three separate NumberInputs for day, month, and year
+- More accessible than native date picker: works consistently across all browsers and allows partial input
+- Day and month fields: width `xs`; year field: width `sm`
+- Inline labels above each field using `dsn-date-input-group__label`
+- `id` prop auto-generates `{id}-dag`, `{id}-maand`, `{id}-jaar` for accessible label association
+- `onChange` always returns the full `{ day, month, year }` object
+- `invalid` prop propagates to all three NumberInputs
+- Wrap in `FormFieldset` for a complete form field with legend and error message
+- Storybook documentation with Default, Controlled, Invalid, Disabled, and WithFormFieldset stories
+
+**FormFieldset Fix**
+
+- **Red left border in invalid state** — `FormFieldset` now shows a red left border when the `error` prop is set, consistent with `FormField`
+
+**Statistics**
+
+- **32 total components** (7 content + 25 form)
+- **733 tests** across 38 test suites — all passing
+
+---
+
 ## Version 4.3.0 (February 17, 2025)
 
 ### CI/CD Fixes & Interactive Design Token Explorer

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -76,7 +76,8 @@ Basis tekstuele componenten voor content structuur.
 
 Complete set van form elementen met validatie ondersteuning.
 
-- **Inputs** — TextInput, TextArea, EmailInput, PasswordInput, NumberInput, TelephoneInput, SearchInput, TimeInput
+- **Inputs** — TextInput, TextArea, EmailInput, PasswordInput, NumberInput, TelephoneInput, SearchInput, TimeInput, DateInput, Select
+- **Date** — DateInputGroup (dag/maand/jaar velden, toegankelijker dan native date picker)
 - **Options** — Checkbox, Radio, CheckboxOption, RadioOption, CheckboxGroup, RadioGroup
 - **Form Fields** — FormFieldLabel, FormFieldLegend, FormFieldDescription, FormFieldErrorMessage, FormFieldStatus
 - **Form Containers** — FormField en FormFieldset voor semantische structuur
@@ -130,4 +131,4 @@ MIT License — zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 0.1.0 | **Laatste update:** 18 februari 2025 | **Auteur:** Jeffrey Lauwers
+**Versie:** 0.1.0 | **Laatste update:** 19 februari 2025 | **Auteur:** Jeffrey Lauwers


### PR DESCRIPTION
## Summary

- **changelog.md** — nieuwe v4.4.0 entry met details over Select, DateInput, DateInputGroup en FormFieldset fix
- **docs/03-components.md** — drie nieuwe component specs toegevoegd, CheckboxGroup/RadioGroup API rechtgezet, statistieken bijgewerkt (26 → 32, 396 → 733 tests)
- **README.md** — componenttabel uitgebreid (22 → 25 form components), testcount bijgewerkt
- **Introduction.mdx** — DateInput, Select en DateInputGroup toegevoegd aan componentenlijst, datum bijgewerkt

## Test plan

- [ ] CI groen
- [ ] Storybook Introduction pagina klopt

🤖 Generated with [Claude Code](https://claude.com/claude-code)