### PR TITLE
feat(design-tokens): use Comic Neue (Google Fonts) for wireframe theme

### DIFF
--- a/packages/design-tokens/src/tokens/themes/wireframe/base.json
+++ b/packages/design-tokens/src/tokens/themes/wireframe/base.json
@@ -3,8 +3,8 @@
     "text": {
       "font-family": {
         "default": {
-          "value": "'Comic Sans MS', 'Comic Sans', cursive",
-          "comment": "Comic Sans font stack for wireframe"
+          "value": "'Comic Neue', 'Comic Sans MS', 'Comic Sans', cursive",
+          "comment": "Comic Neue (Google Fonts) with Comic Sans MS fallback for wireframe"
         },
         "monospace": {
           "value": "ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace",
@@ -54,8 +54,8 @@
     },
     "heading": {
       "font-family": {
-        "value": "'Comic Sans MS', 'Comic Sans', cursive",
-        "comment": "Comic Sans font for headings"
+        "value": "'Comic Neue', 'Comic Sans MS', 'Comic Sans', cursive",
+        "comment": "Comic Neue (Google Fonts) with Comic Sans MS fallback for headings"
       },
       "font-weight": {
         "value": "600",

--- a/packages/storybook/.storybook/preview-head.html
+++ b/packages/storybook/.storybook/preview-head.html
@@ -1,3 +1,6 @@
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Comic+Neue:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" rel="stylesheet">
 <script>
   // Dynamic token loading script for Storybook
   // This runs in the preview iframe and handles theme/mode/density switching


### PR DESCRIPTION
## Summary
- Comic Sans MS is niet beschikbaar op Android (Samsung/AOSP)
- Wireframe thema gebruikt nu Comic Neue via Google Fonts als primair lettertype
- Font stack: `'Comic Neue', 'Comic Sans MS', 'Comic Sans', cursive`
- Google Fonts `<link>` tags toegevoegd aan Storybook `preview-head.html`
- Design tokens opnieuw gebuild — alle 4 wireframe CSS files bijgewerkt

## Test plan
- [x] Tests groen
- [x] Build slaagt
- [x] Wireframe thema in Storybook toont Comic Neue

🤖 Generated with [Claude Code](https://claude.com/claude-code)