### PR TITLE
refactor(storybook): geen placeholder by default in invulvelden

### DIFF
--- a/packages/storybook/src/EmailInput.docs.md
+++ b/packages/storybook/src/EmailInput.docs.md
@@ -20,7 +20,7 @@ De EmailInput component is een gespecialiseerd invoerveld voor e-mailadressen. H
 
 ## Best practices
 
-- **Gebruik een duidelijke placeholder.** Geef een voorbeeld e-mailadres (bijv. `naam@voorbeeld.nl`).
+- **Gebruik FormFieldDescription voor formaathints.** Als het e-mailadresformaat toelichting behoeft, gebruik dan [FormFieldDescription](/docs/components-formfielddescription--docs) — niet een placeholder. Placeholder tekst verdwijnt bij typen en is daarna niet meer zichtbaar.
 - **Laat browser-autocomplete aan.** De standaard `autocomplete="email"` helpt gebruikers snel invullen. Zet alleen op `off` als daar een goede reden voor is.
 - **Combineer met FormField.** Gebruik altijd een label via `FormField` of `FormFieldLabel` voor toegankelijkheid.
 - **Geef validatie feedback.** Gebruik de `invalid` prop in combinatie met `aria-invalid` en een `FormFieldErrorMessage`.

--- a/packages/storybook/src/EmailInput.stories.tsx
+++ b/packages/storybook/src/EmailInput.stories.tsx
@@ -29,7 +29,6 @@ const meta: Meta<typeof EmailInput> = {
     },
   },
   args: {
-    placeholder: 'naam@voorbeeld.nl',
     disabled: false,
     readOnly: false,
     invalid: false,
@@ -55,6 +54,11 @@ export const WithValue: Story = {
   args: { defaultValue: 'jan@voorbeeld.nl' },
 };
 
+export const WithPlaceholder: Story = {
+  name: 'With placeholder',
+  args: { placeholder: 'naam@voorbeeld.nl' },
+};
+
 export const Disabled: Story = {
   args: { disabled: true, value: 'jan@voorbeeld.nl' },
 };
@@ -71,13 +75,21 @@ export const Invalid: Story = {
 export const Widths: Story = {
   name: 'Width variants',
   render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <EmailInput width="xs" placeholder="xs" />
-      <EmailInput width="sm" placeholder="sm" />
-      <EmailInput width="md" placeholder="md" />
-      <EmailInput width="lg" placeholder="lg" />
-      <EmailInput width="xl" placeholder="xl" />
-      <EmailInput width="full" placeholder="full" />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      {(['xs', 'sm', 'md', 'lg', 'xl', 'full'] as const).map((w) => (
+        <div key={w}>
+          <p
+            style={{
+              margin: '0 0 0.25rem',
+              fontWeight: 'bold',
+              fontSize: '0.875rem',
+            }}
+          >
+            {w}
+          </p>
+          <EmailInput width={w} />
+        </div>
+      ))}
     </div>
   ),
 };
@@ -107,7 +119,7 @@ export const AllStates: Story = {
         >
           Default
         </label>
-        <EmailInput placeholder="naam@voorbeeld.nl" />
+        <EmailInput />
       </div>
       <div>
         <label

--- a/packages/storybook/src/FormField.stories.tsx
+++ b/packages/storybook/src/FormField.stories.tsx
@@ -51,7 +51,7 @@ export const Default: Story = {
   },
   render: (args) => (
     <FormField {...args}>
-      <TextInput id="input-1" placeholder={TEKST} />
+      <TextInput id="input-1" />
     </FormField>
   ),
 };
@@ -60,7 +60,7 @@ export const WithDescription: Story = {
   name: 'With description',
   render: (args) => (
     <FormField {...args} label={TEKST} htmlFor="input-desc" description={TEKST}>
-      <TextInput id="input-desc" placeholder={TEKST} />
+      <TextInput id="input-desc" />
     </FormField>
   ),
 };
@@ -69,7 +69,7 @@ export const WithError: Story = {
   name: 'With error',
   render: (args) => (
     <FormField {...args} label={TEKST} htmlFor="input-err" error={TEKST}>
-      <TextInput id="input-err" invalid placeholder={TEKST} />
+      <TextInput id="input-err" invalid />
     </FormField>
   ),
 };
@@ -78,7 +78,7 @@ export const WithStatus: Story = {
   name: 'With status',
   render: (args) => (
     <FormField {...args} label={TEKST} htmlFor="input-status" status={TEKST}>
-      <TextInput id="input-status" placeholder={TEKST} />
+      <TextInput id="input-status" />
     </FormField>
   ),
 };
@@ -90,25 +90,25 @@ export const AllStates: Story = {
       <div>
         <h3 style={{ marginBlockEnd: '0.5rem' }}>Basic</h3>
         <FormField label={TEKST} htmlFor="s1">
-          <TextInput id="s1" placeholder={TEKST} />
+          <TextInput id="s1" />
         </FormField>
       </div>
       <div>
         <h3 style={{ marginBlockEnd: '0.5rem' }}>With description</h3>
         <FormField label={TEKST} htmlFor="s2" description={TEKST}>
-          <TextInput id="s2" placeholder={TEKST} />
+          <TextInput id="s2" />
         </FormField>
       </div>
       <div>
         <h3 style={{ marginBlockEnd: '0.5rem' }}>With optional suffix</h3>
         <FormField label={TEKST} htmlFor="s3" labelSuffix="(niet verplicht)">
-          <TextInput id="s3" placeholder={TEKST} />
+          <TextInput id="s3" />
         </FormField>
       </div>
       <div>
         <h3 style={{ marginBlockEnd: '0.5rem' }}>With error</h3>
         <FormField label={TEKST} htmlFor="s4" error={TEKST}>
-          <TextInput id="s4" invalid placeholder={TEKST} />
+          <TextInput id="s4" invalid />
         </FormField>
       </div>
       <div>
@@ -119,7 +119,7 @@ export const AllStates: Story = {
           status={TEKST}
           statusVariant="positive"
         >
-          <TextInput id="s5" placeholder={TEKST} />
+          <TextInput id="s5" />
         </FormField>
       </div>
       <div>
@@ -130,13 +130,13 @@ export const AllStates: Story = {
           status={TEKST}
           statusVariant="warning"
         >
-          <TextInput id="s6" placeholder={TEKST} />
+          <TextInput id="s6" />
         </FormField>
       </div>
       <div>
         <h3 style={{ marginBlockEnd: '0.5rem' }}>With TextArea</h3>
         <FormField label={TEKST} htmlFor="s7" description={TEKST}>
-          <TextArea id="s7" rows={4} placeholder={TEKST} />
+          <TextArea id="s7" rows={4} />
         </FormField>
       </div>
       <div>

--- a/packages/storybook/src/NumberInput.docs.md
+++ b/packages/storybook/src/NumberInput.docs.md
@@ -21,7 +21,7 @@ De NumberInput component is een gespecialiseerd invoerveld voor het invoeren van
 
 ## Best practices
 
-- **Gebruik een duidelijke placeholder.** Geef aan wat de verwachte invoer is (bijv. `0` voor gehele getallen, `0,00` voor bedragen).
+- **Gebruik FormFieldDescription voor formaathints.** Als je wilt toelichten wat de verwachte invoer is (bijv. "Voer een bedrag in, gebruik een komma voor decimalen"), gebruik dan [FormFieldDescription](/docs/components-formfielddescription--docs) — niet een placeholder. Placeholder tekst verdwijnt bij typen en is daarna niet meer zichtbaar.
 - **Gebruik `allowDecimals` voor bedragen.** Dit schakelt `inputmode="decimal"` in zodat ook een kommatoets beschikbaar is op mobiel.
 - **Combineer met FormField.** Gebruik altijd een label via `FormField` of `FormFieldLabel` voor toegankelijkheid.
 - **Geef validatie feedback.** Gebruik de `invalid` prop in combinatie met `aria-invalid` en een `FormFieldErrorMessage`.

--- a/packages/storybook/src/NumberInput.stories.tsx
+++ b/packages/storybook/src/NumberInput.stories.tsx
@@ -24,7 +24,6 @@ const meta: Meta<typeof NumberInput> = {
     },
   },
   args: {
-    placeholder: '0',
     disabled: false,
     readOnly: false,
     invalid: false,
@@ -50,9 +49,13 @@ export const WithDecimals: Story = {
   name: 'With decimals (allowDecimals)',
   args: {
     allowDecimals: true,
-    placeholder: '0,00',
     defaultValue: '1234',
   },
+};
+
+export const WithPlaceholder: Story = {
+  name: 'With placeholder',
+  args: { placeholder: '0' },
 };
 
 export const WithValue: Story = {
@@ -76,13 +79,21 @@ export const Invalid: Story = {
 export const Widths: Story = {
   name: 'Width variants',
   render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <NumberInput width="xs" placeholder="xs" />
-      <NumberInput width="sm" placeholder="sm" />
-      <NumberInput width="md" placeholder="md" />
-      <NumberInput width="lg" placeholder="lg" />
-      <NumberInput width="xl" placeholder="xl" />
-      <NumberInput width="full" placeholder="full" />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      {(['xs', 'sm', 'md', 'lg', 'xl', 'full'] as const).map((w) => (
+        <div key={w}>
+          <p
+            style={{
+              margin: '0 0 0.25rem',
+              fontWeight: 'bold',
+              fontSize: '0.875rem',
+            }}
+          >
+            {w}
+          </p>
+          <NumberInput width={w} />
+        </div>
+      ))}
     </div>
   ),
 };
@@ -112,7 +123,7 @@ export const AllStates: Story = {
         >
           Default
         </label>
-        <NumberInput placeholder="0" />
+        <NumberInput />
       </div>
       <div>
         <label

--- a/packages/storybook/src/PasswordInput.stories.tsx
+++ b/packages/storybook/src/PasswordInput.stories.tsx
@@ -27,7 +27,6 @@ const meta: Meta<typeof PasswordInput> = {
     },
   },
   args: {
-    placeholder: 'Wachtwoord',
     disabled: false,
     readOnly: false,
     invalid: false,
@@ -53,8 +52,12 @@ export const NewPassword: Story = {
   name: 'New password (registratie)',
   args: {
     passwordAutocomplete: 'new-password',
-    placeholder: 'Nieuw wachtwoord',
   },
+};
+
+export const WithPlaceholder: Story = {
+  name: 'With placeholder',
+  args: { placeholder: 'Wachtwoord' },
 };
 
 export const Disabled: Story = {
@@ -73,13 +76,21 @@ export const Invalid: Story = {
 export const Widths: Story = {
   name: 'Width variants',
   render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <PasswordInput width="xs" placeholder="xs" />
-      <PasswordInput width="sm" placeholder="sm" />
-      <PasswordInput width="md" placeholder="md" />
-      <PasswordInput width="lg" placeholder="lg" />
-      <PasswordInput width="xl" placeholder="xl" />
-      <PasswordInput width="full" placeholder="full" />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      {(['xs', 'sm', 'md', 'lg', 'xl', 'full'] as const).map((w) => (
+        <div key={w}>
+          <p
+            style={{
+              margin: '0 0 0.25rem',
+              fontWeight: 'bold',
+              fontSize: '0.875rem',
+            }}
+          >
+            {w}
+          </p>
+          <PasswordInput width={w} />
+        </div>
+      ))}
     </div>
   ),
 };
@@ -109,7 +120,7 @@ export const AllStates: Story = {
         >
           Default
         </label>
-        <PasswordInput placeholder="Wachtwoord" />
+        <PasswordInput />
       </div>
       <div>
         <label

--- a/packages/storybook/src/SearchInput.docs.md
+++ b/packages/storybook/src/SearchInput.docs.md
@@ -21,7 +21,7 @@ De SearchInput component is een gespecialiseerd invoerveld voor zoekfunctionalit
 
 ## Best practices
 
-- **Gebruik een duidelijke placeholder.** Geef aan wat gebruikers kunnen zoeken (bijv. `Zoek producten...`, `Zoek in artikelen...`).
+- **Gebruik een zichtbaar label of `aria-label`.** Voeg altijd een label toe via `FormField` of `FormFieldLabel`, of gebruik `aria-label` als het visuele design geen zichtbaar label toestaat (bijv. een zoekveld in de siteheader). Een placeholder is niet verplicht en verdwijnt bij typen — gebruik het optioneel alleen als extra context over de zoekscope nuttig is (bijv. `Zoek in producten...`).
 - **Gebruik `role="search"` op een wrapper element.** Dit helpt screen readers de zoekfunctionaliteit te identificeren.
 - **Implementeer live search of debouncing.** Update resultaten tijdens het typen, maar niet bij elke toetsaanslag.
 - **Geef feedback bij geen resultaten.** Toon een melding als er geen resultaten zijn gevonden.

--- a/packages/storybook/src/SearchInput.stories.tsx
+++ b/packages/storybook/src/SearchInput.stories.tsx
@@ -30,7 +30,6 @@ const meta: Meta<typeof SearchInput> = {
     },
   },
   args: {
-    placeholder: 'Zoeken...',
     disabled: false,
     readOnly: false,
     invalid: false,
@@ -56,6 +55,11 @@ export const WithValue: Story = {
   args: { defaultValue: TEKST },
 };
 
+export const WithPlaceholder: Story = {
+  name: 'With placeholder',
+  args: { placeholder: 'Zoeken...' },
+};
+
 export const Disabled: Story = {
   args: { disabled: true, value: TEKST },
 };
@@ -72,13 +76,21 @@ export const Invalid: Story = {
 export const Widths: Story = {
   name: 'Width variants',
   render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <SearchInput width="xs" placeholder="xs" />
-      <SearchInput width="sm" placeholder="sm" />
-      <SearchInput width="md" placeholder="md" />
-      <SearchInput width="lg" placeholder="lg" />
-      <SearchInput width="xl" placeholder="xl" />
-      <SearchInput width="full" placeholder="full" />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      {(['xs', 'sm', 'md', 'lg', 'xl', 'full'] as const).map((w) => (
+        <div key={w}>
+          <p
+            style={{
+              margin: '0 0 0.25rem',
+              fontWeight: 'bold',
+              fontSize: '0.875rem',
+            }}
+          >
+            {w}
+          </p>
+          <SearchInput width={w} />
+        </div>
+      ))}
     </div>
   ),
 };
@@ -108,7 +120,7 @@ export const AllStates: Story = {
         >
           Default
         </label>
-        <SearchInput placeholder="Zoeken..." />
+        <SearchInput />
       </div>
       <div>
         <label

--- a/packages/storybook/src/TelephoneInput.docs.md
+++ b/packages/storybook/src/TelephoneInput.docs.md
@@ -20,7 +20,7 @@ De TelephoneInput component is een gespecialiseerd invoerveld voor telefoonnumme
 
 ## Best practices
 
-- **Gebruik een duidelijke placeholder.** Geef een voorbeeld in het verwachte formaat (bijv. `06 12345678` of `+31 6 12345678`).
+- **Gebruik FormFieldDescription voor formaathints.** Als je het verwachte formaat wilt toelichten (bijv. `06 12345678` of `+31 6 12345678`), gebruik dan [FormFieldDescription](/docs/components-formfielddescription--docs) — niet een placeholder. Placeholder tekst verdwijnt bij typen en is daarna niet meer zichtbaar.
 - **Dwing geen specifiek formaat af.** Gebruikers typen telefoonnummers op verschillende manieren. Valideer lengte en tekens, maar accepteer variaties in opmaak.
 - **Laat browser-autocomplete aan.** De standaard `autocomplete="tel"` helpt gebruikers snel invullen.
 - **Combineer met FormField.** Gebruik altijd een label via `FormField` of `FormFieldLabel` voor toegankelijkheid.

--- a/packages/storybook/src/TelephoneInput.stories.tsx
+++ b/packages/storybook/src/TelephoneInput.stories.tsx
@@ -29,7 +29,6 @@ const meta: Meta<typeof TelephoneInput> = {
     },
   },
   args: {
-    placeholder: '06 12345678',
     disabled: false,
     readOnly: false,
     invalid: false,
@@ -57,7 +56,12 @@ export const WithValue: Story = {
 
 export const International: Story = {
   name: 'International format',
-  args: { defaultValue: '+31 6 12345678', placeholder: '+31 6 12345678' },
+  args: { defaultValue: '+31 6 12345678' },
+};
+
+export const WithPlaceholder: Story = {
+  name: 'With placeholder',
+  args: { placeholder: '06 12345678' },
 };
 
 export const Disabled: Story = {
@@ -76,13 +80,21 @@ export const Invalid: Story = {
 export const Widths: Story = {
   name: 'Width variants',
   render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <TelephoneInput width="xs" placeholder="xs" />
-      <TelephoneInput width="sm" placeholder="sm" />
-      <TelephoneInput width="md" placeholder="md" />
-      <TelephoneInput width="lg" placeholder="lg" />
-      <TelephoneInput width="xl" placeholder="xl" />
-      <TelephoneInput width="full" placeholder="full" />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      {(['xs', 'sm', 'md', 'lg', 'xl', 'full'] as const).map((w) => (
+        <div key={w}>
+          <p
+            style={{
+              margin: '0 0 0.25rem',
+              fontWeight: 'bold',
+              fontSize: '0.875rem',
+            }}
+          >
+            {w}
+          </p>
+          <TelephoneInput width={w} />
+        </div>
+      ))}
     </div>
   ),
 };
@@ -112,7 +124,7 @@ export const AllStates: Story = {
         >
           Default
         </label>
-        <TelephoneInput placeholder="06 12345678" />
+        <TelephoneInput />
       </div>
       <div>
         <label

--- a/packages/storybook/src/TextArea.docs.md
+++ b/packages/storybook/src/TextArea.docs.md
@@ -34,7 +34,7 @@ De TextArea component is een gestandaardiseerd invoerveld voor multi-line tekst.
 - **Labels zijn verplicht.** Wrap in FormField met FormFieldLabel voor accessibility.
 - **Resize gedrag.** Standaard vertical resizing, automatisch disabled bij disabled state.
 - **Invalid state alleen na interactie.** Toon invalid state alleen na blur of submit.
-- **Duidelijke placeholders.** Gebruik placeholders voor voorbeelden, geen instructies.
+- **Vermijd placeholders.** Placeholder tekst verdwijnt zodra de gebruiker begint te typen — daarna is de informatie niet meer zichtbaar. Bovendien kan de lage contrast van placeholders het veld er ingevuld laten uitzien. Gebruik [FormFieldDescription](/docs/components-formfielddescription--docs) voor hints over het verwachte formaat of inhoud.
 - **Character/word limits.** Overweeg een character counter te tonen bij lange teksten.
 
 ## Row height richtlijnen
@@ -100,6 +100,6 @@ De TextArea component is een gestandaardiseerd invoerveld voor multi-line tekst.
 - Invalid state wordt gecommuniceerd via `aria-invalid="true"`.
 - Gebruik `aria-describedby` om error messages te koppelen.
 - Focus state is duidelijk zichtbaar met border highlight.
-- Placeholder tekst is niet voldoende als label (verdwijnt bij typen).
+- Gebruik nooit een placeholder als vervanging van een label — placeholder tekst is niet zichtbaar zodra de gebruiker typt, en wordt slecht ondersteund door oudere screenreaders.
 - Resize handles zijn keyboard toegankelijk in moderne browsers.
 - Minimum touch target size van 24x24px volgens WCAG 2.5.5.

--- a/packages/storybook/src/TextArea.stories.tsx
+++ b/packages/storybook/src/TextArea.stories.tsx
@@ -31,7 +31,6 @@ const meta: Meta<typeof TextArea> = {
     rows: { control: 'number' },
   },
   args: {
-    placeholder: TEKST,
     rows: 4,
   },
 };
@@ -52,6 +51,11 @@ export const Default: Story = {};
 export const WithValue: Story = {
   name: 'With value',
   args: { defaultValue: TEKST, readOnly: true },
+};
+
+export const WithPlaceholder: Story = {
+  name: 'With placeholder',
+  args: { placeholder: TEKST },
 };
 
 export const Disabled: Story = {
@@ -88,7 +92,7 @@ export const RowVariants: Story = {
         >
           2 rijen
         </label>
-        <TextArea rows={2} placeholder={TEKST} />
+        <TextArea rows={2} />
       </div>
       <div>
         <label
@@ -100,7 +104,7 @@ export const RowVariants: Story = {
         >
           4 rijen (default)
         </label>
-        <TextArea rows={4} placeholder={TEKST} />
+        <TextArea rows={4} />
       </div>
       <div>
         <label
@@ -112,7 +116,7 @@ export const RowVariants: Story = {
         >
           8 rijen
         </label>
-        <TextArea rows={8} placeholder={TEKST} />
+        <TextArea rows={8} />
       </div>
     </div>
   ),
@@ -121,11 +125,21 @@ export const RowVariants: Story = {
 export const Widths: Story = {
   name: 'Width variants',
   render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <TextArea width="sm" placeholder="sm — 16ch" rows={2} />
-      <TextArea width="md" placeholder="md — 32ch" rows={2} />
-      <TextArea width="lg" placeholder="lg — 48ch" rows={2} />
-      <TextArea width="full" placeholder="full — 100%" rows={2} />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      {(['sm', 'md', 'lg', 'full'] as const).map((w) => (
+        <div key={w}>
+          <p
+            style={{
+              margin: '0 0 0.25rem',
+              fontWeight: 'bold',
+              fontSize: '0.875rem',
+            }}
+          >
+            {w}
+          </p>
+          <TextArea width={w} rows={2} />
+        </div>
+      ))}
     </div>
   ),
 };
@@ -155,7 +169,7 @@ export const AllStates: Story = {
         >
           Default
         </label>
-        <TextArea placeholder={TEKST} rows={3} />
+        <TextArea rows={3} />
       </div>
       <div>
         <label

--- a/packages/storybook/src/TextInput.docs.md
+++ b/packages/storybook/src/TextInput.docs.md
@@ -30,7 +30,7 @@ De TextInput component is een gestandaardiseerd invoerveld voor single-line teks
   - `xl` (48ch) - Langere tekst (URL)
   - `full` (100%) - Responsive, neemt volledige breedte
 - **Gebruik het juiste type.** Gebruik native input types: `email`, `url`, `tel`, `search`, etc.
-- **Duidelijke placeholders.** Gebruik placeholders voor voorbeelden, geen instructies.
+- **Vermijd placeholders.** Placeholder tekst verdwijnt zodra de gebruiker begint te typen — daarna is de informatie niet meer zichtbaar. Bovendien kan de lage contrast van placeholders het veld er ingevuld laten uitzien. Gebruik [FormFieldDescription](/docs/components-formfielddescription--docs) voor hints over het verwachte formaat of type data.
 - **Labels zijn verplicht.** Wrap in FormField met FormFieldLabel voor accessibility.
 - **Invalid state alleen na interactie.** Toon invalid state alleen na blur of submit, niet direct.
 - **Disabled vs read-only.** Gebruik `disabled` als veld niet beschikbaar is, `readOnly` als waarde niet aangepast mag worden.
@@ -91,5 +91,5 @@ De TextInput component is een gestandaardiseerd invoerveld voor single-line teks
 - Invalid state wordt gecommuniceerd via `aria-invalid="true"`.
 - Gebruik `aria-describedby` om error messages te koppelen.
 - Focus state is duidelijk zichtbaar met border highlight.
-- Placeholder tekst is niet voldoende als label (verdwijnt bij typen).
+- Gebruik nooit een placeholder als vervanging van een label — placeholder tekst is niet zichtbaar zodra de gebruiker typt, en wordt slecht ondersteund door oudere screenreaders.
 - Minimum touch target size van 24x24px volgens WCAG 2.5.5.

--- a/packages/storybook/src/TextInput.stories.tsx
+++ b/packages/storybook/src/TextInput.stories.tsx
@@ -29,9 +29,7 @@ const meta: Meta<typeof TextInput> = {
     required: { control: 'boolean' },
     placeholder: { control: 'text' },
   },
-  args: {
-    placeholder: TEKST,
-  },
+  args: {},
 };
 
 export default meta;
@@ -50,6 +48,11 @@ export const Default: Story = {};
 export const WithValue: Story = {
   name: 'With value',
   args: { defaultValue: TEKST },
+};
+
+export const WithPlaceholder: Story = {
+  name: 'With placeholder',
+  args: { placeholder: TEKST },
 };
 
 export const Disabled: Story = {
@@ -72,13 +75,21 @@ export const Required: Story = {
 export const Widths: Story = {
   name: 'Width variants',
   render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <TextInput width="xs" placeholder="xs — 10ch" />
-      <TextInput width="sm" placeholder="sm — 14ch" />
-      <TextInput width="md" placeholder="md — 20ch" />
-      <TextInput width="lg" placeholder="lg — 32ch" />
-      <TextInput width="xl" placeholder="xl — 48ch" />
-      <TextInput width="full" placeholder="full — 100%" />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      {(['xs', 'sm', 'md', 'lg', 'xl', 'full'] as const).map((w) => (
+        <div key={w}>
+          <p
+            style={{
+              margin: '0 0 0.25rem',
+              fontWeight: 'bold',
+              fontSize: '0.875rem',
+            }}
+          >
+            {w}
+          </p>
+          <TextInput width={w} />
+        </div>
+      ))}
     </div>
   ),
 };
@@ -108,7 +119,7 @@ export const AllStates: Story = {
         >
           Default
         </label>
-        <TextInput placeholder={TEKST} />
+        <TextInput />
       </div>
       <div>
         <label


### PR DESCRIPTION
## Summary

- Verwijder `placeholder` uit `meta.args` voor alle invulvelden — Default story toont nu een leeg veld
- Verwijder placeholder uit `AllStates` "Default" rij en `Width variants` renders (vervangen door `<p>` labels)
- Voeg `WithPlaceholder` story toe aan elk component om aan te tonen dat het technisch mogelijk is
- Verwijder alle `placeholder={TEKST}` uit `FormField` story renders
- Update documentatie: placeholder ontmoedigen, `FormFieldDescription` aanbevelen als alternatief voor formaathints

**Betrokken componenten:** TextInput, TextArea, SearchInput, EmailInput, PasswordInput, TelephoneInput, NumberInput, FormField

**Reden:** Placeholder tekst verdwijnt zodra de gebruiker begint te typen — daarna is die informatie niet meer zichtbaar. Bovendien voldoet placeholder tekst aan de minimale contrasteisen, waardoor het veld er ingevuld uit kan zien. Formaathints horen thuis in `FormFieldDescription`, niet in de placeholder.

## Test plan

- [x] CI groen (lint + type-check + test + build)
- [x] Storybook: Default stories tonen lege velden
- [x] Storybook: `WithPlaceholder` story toont placeholder correct
- [x] Storybook: `Width variants` tonen labels boven elk veld
- [x] Docs: Best practices consistent met stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)