### PR TITLE
feat(storybook): PreviewFrame + CodeTabs op alle doc pagina's

### DIFF
--- a/packages/storybook/src/Button.docs.mdx
+++ b/packages/storybook/src/Button.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as ButtonStories from './Button.stories';
 import docs from './Button.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={ButtonStories.Default} />
+<PreviewFrame>
+  <Story of={ButtonStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<Button variant="strong">Tekst</Button>`}
+  html={`<button type="button" class="dsn-button dsn-button--strong dsn-button--size-default">Tekst</button>`}
+/>
 
 <Controls of={ButtonStories.Default} />
 

--- a/packages/storybook/src/Checkbox.docs.mdx
+++ b/packages/storybook/src/Checkbox.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as CheckboxStories from './Checkbox.stories';
 import docs from './Checkbox.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,19 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={CheckboxStories.Default} />
+<PreviewFrame>
+  <Story of={CheckboxStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<Checkbox id="checkbox-1" />`}
+  html={`<div class="dsn-checkbox">
+  <input type="checkbox" class="dsn-checkbox__input" id="checkbox-1" />
+  <span class="dsn-checkbox__control" aria-hidden="true">
+    <!-- check icon -->
+  </span>
+</div>`}
+/>
 
 <Controls of={CheckboxStories.Default} />
 

--- a/packages/storybook/src/CheckboxGroup.docs.md
+++ b/packages/storybook/src/CheckboxGroup.docs.md
@@ -6,6 +6,8 @@ Een container voor meerdere CheckboxOption componenten.
 
 De CheckboxGroup component is een simpele container die meerdere CheckboxOption componenten groepeert met consistente spacing. Het is puur een presentationele lijst zonder semantische form field markup (geen fieldset/legend). Voor een volledige form field met label en beschrijving wrap je de CheckboxGroup in een FormFieldset component. De gap tussen opties is geoptimaliseerd voor leesbaarheid en touch targets.
 
+> **Codevoorbeeld met context**: De HTML/CSS tab toont `CheckboxOption` componenten als representatieve children. `CheckboxGroup` is puur een lijst-container — de children bepalen de daadwerkelijke functionaliteit.
+
 <!-- VOORBEELD -->
 
 ## Use when

--- a/packages/storybook/src/CheckboxGroup.docs.mdx
+++ b/packages/storybook/src/CheckboxGroup.docs.mdx
@@ -1,6 +1,7 @@
-import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import { Meta, Story, Markdown } from '@storybook/blocks';
 import * as CheckboxGroupStories from './CheckboxGroup.stories';
 import docs from './CheckboxGroup.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,6 +11,39 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={CheckboxGroupStories.Default} />
+<PreviewFrame>
+  <Story of={CheckboxGroupStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<CheckboxGroup>
+  <CheckboxOption label="Sport" />
+  <CheckboxOption label="Muziek" />
+  <CheckboxOption label="Reizen" />
+</CheckboxGroup>`}
+  html={`<div class="dsn-checkbox-group">
+  <label class="dsn-checkbox-option">
+    <div class="dsn-checkbox">
+      <input type="checkbox" class="dsn-checkbox__input" />
+      <span class="dsn-checkbox__control" aria-hidden="true"></span>
+    </div>
+    <span class="dsn-option-label">Sport</span>
+  </label>
+  <label class="dsn-checkbox-option">
+    <div class="dsn-checkbox">
+      <input type="checkbox" class="dsn-checkbox__input" />
+      <span class="dsn-checkbox__control" aria-hidden="true"></span>
+    </div>
+    <span class="dsn-option-label">Muziek</span>
+  </label>
+  <label class="dsn-checkbox-option">
+    <div class="dsn-checkbox">
+      <input type="checkbox" class="dsn-checkbox__input" />
+      <span class="dsn-checkbox__control" aria-hidden="true"></span>
+    </div>
+    <span class="dsn-option-label">Reizen</span>
+  </label>
+</div>`}
+/>
 
 <Markdown>{rest}</Markdown>

--- a/packages/storybook/src/CheckboxOption.docs.mdx
+++ b/packages/storybook/src/CheckboxOption.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as CheckboxOptionStories from './CheckboxOption.stories';
 import docs from './CheckboxOption.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,22 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={CheckboxOptionStories.Default} />
+<PreviewFrame>
+  <Story of={CheckboxOptionStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<CheckboxOption label="Optie label" />`}
+  html={`<label class="dsn-checkbox-option">
+  <div class="dsn-checkbox">
+    <input type="checkbox" class="dsn-checkbox__input" />
+    <span class="dsn-checkbox__control" aria-hidden="true">
+      <!-- check icon -->
+    </span>
+  </div>
+  <span class="dsn-option-label">Optie label</span>
+</label>`}
+/>
 
 <Controls of={CheckboxOptionStories.Default} />
 

--- a/packages/storybook/src/DateInput.docs.mdx
+++ b/packages/storybook/src/DateInput.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as DateInputStories from './DateInput.stories';
 import docs from './DateInput.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,17 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={DateInputStories.Default} />
+<PreviewFrame>
+  <Story of={DateInputStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<DateInput />`}
+  html={`<div class="dsn-date-input-wrapper">
+  <input type="date" class="dsn-text-input dsn-date-input" />
+  <!-- calendar button (niet-focusbaar, voor muisgebruikers) -->
+</div>`}
+/>
 
 <Controls of={DateInputStories.Default} />
 

--- a/packages/storybook/src/DateInputGroup.docs.md
+++ b/packages/storybook/src/DateInputGroup.docs.md
@@ -8,6 +8,8 @@ DateInputGroup biedt een toegankelijke, consistente manier om een datum in te vo
 
 Gebruik `FormFieldset` als wrapper voor een volledig formulierveld met legend, beschrijving en foutmelding.
 
+> **Codevoorbeeld met context**: De HTML/CSS tab toont de volledige drie-velden structuur (dag, maand, jaar). `DateInputGroup` rendert altijd alle drie de velden samen.
+
 <!-- VOORBEELD -->
 
 ## Use when

--- a/packages/storybook/src/DateInputGroup.docs.mdx
+++ b/packages/storybook/src/DateInputGroup.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as DateInputGroupStories from './DateInputGroup.stories';
 import docs from './DateInputGroup.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,37 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={DateInputGroupStories.Default} />
+<PreviewFrame>
+  <Story of={DateInputGroupStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<DateInputGroup
+  id="geboortedatum"
+  value={{ day: '', month: '', year: '' }}
+  onChange={(val) => console.log(val)}
+/>`}
+  html={`<div class="dsn-date-input-group">
+  <div class="dsn-date-input-group__field">
+    <label class="dsn-date-input-group__label" for="geboortedatum-dag">Dag</label>
+    <input type="text" inputmode="numeric" pattern="[0-9]*"
+      class="dsn-text-input dsn-text-input--width-xs"
+      id="geboortedatum-dag" placeholder="DD" autocomplete="off" />
+  </div>
+  <div class="dsn-date-input-group__field">
+    <label class="dsn-date-input-group__label" for="geboortedatum-maand">Maand</label>
+    <input type="text" inputmode="numeric" pattern="[0-9]*"
+      class="dsn-text-input dsn-text-input--width-xs"
+      id="geboortedatum-maand" placeholder="MM" autocomplete="off" />
+  </div>
+  <div class="dsn-date-input-group__field">
+    <label class="dsn-date-input-group__label" for="geboortedatum-jaar">Jaar</label>
+    <input type="text" inputmode="numeric" pattern="[0-9]*"
+      class="dsn-text-input dsn-text-input--width-sm"
+      id="geboortedatum-jaar" placeholder="JJJJ" autocomplete="off" />
+  </div>
+</div>`}
+/>
 
 <Controls of={DateInputGroupStories.Default} />
 

--- a/packages/storybook/src/EmailInput.docs.mdx
+++ b/packages/storybook/src/EmailInput.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as EmailInputStories from './EmailInput.stories';
 import docs from './EmailInput.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={EmailInputStories.Default} />
+<PreviewFrame>
+  <Story of={EmailInputStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<EmailInput placeholder="naam@voorbeeld.nl" />`}
+  html={`<input type="email" inputmode="email" class="dsn-text-input" autocomplete="email" placeholder="naam@voorbeeld.nl" />`}
+/>
 
 <Controls of={EmailInputStories.Default} />
 

--- a/packages/storybook/src/FormField.docs.md
+++ b/packages/storybook/src/FormField.docs.md
@@ -6,6 +6,8 @@ Container component dat label, description, error message, form control en statu
 
 De FormField component is een complete form field container die alle onderdelen samenbrengt: FormFieldLabel (met optionele suffix), FormFieldDescription, FormFieldErrorMessage, de form control zelf, en FormFieldStatus. Het zorgt voor correcte volgorde, spacing en koppeling via aria-attributen. De component gebruikt een `<div>` wrapper met `<label>` element. Voor groep controls (CheckboxGroup, RadioGroup) gebruik je later de FormFieldset component die `<fieldset>` en `<legend>` gebruikt. FormField handelt automatisch ID's af voor aria-describedby koppelingen.
 
+> **Codevoorbeeld met context**: De HTML/CSS tab toont een `EmailInput` als representatief child. `FormField` is een wrapper — het form control dat je als child meegeeft bepaalt de daadwerkelijke invoer.
+
 <!-- VOORBEELD -->
 
 ## Use when

--- a/packages/storybook/src/FormField.docs.mdx
+++ b/packages/storybook/src/FormField.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as FormFieldStories from './FormField.stories';
 import docs from './FormField.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,19 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={FormFieldStories.Default} />
+<PreviewFrame>
+  <Story of={FormFieldStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<FormField label="E-mailadres" htmlFor="email">
+  <EmailInput id="email" placeholder="naam@voorbeeld.nl" />
+</FormField>`}
+  html={`<div class="dsn-form-field">
+  <label class="dsn-form-field-label" for="email">E-mailadres</label>
+  <input type="email" class="dsn-text-input" id="email" placeholder="naam@voorbeeld.nl" />
+</div>`}
+/>
 
 <Controls of={FormFieldStories.Default} />
 

--- a/packages/storybook/src/FormFieldDescription.docs.mdx
+++ b/packages/storybook/src/FormFieldDescription.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as FormFieldDescriptionStories from './FormFieldDescription.stories';
 import docs from './FormFieldDescription.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={FormFieldDescriptionStories.Default} />
+<PreviewFrame>
+  <Story of={FormFieldDescriptionStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<FormFieldDescription>Beschrijving tekst.</FormFieldDescription>`}
+  html={`<p class="dsn-form-field-description">Beschrijving tekst.</p>`}
+/>
 
 <Controls of={FormFieldDescriptionStories.Default} />
 

--- a/packages/storybook/src/FormFieldErrorMessage.docs.mdx
+++ b/packages/storybook/src/FormFieldErrorMessage.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as FormFieldErrorMessageStories from './FormFieldErrorMessage.stories';
 import docs from './FormFieldErrorMessage.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,17 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={FormFieldErrorMessageStories.Default} />
+<PreviewFrame>
+  <Story of={FormFieldErrorMessageStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<FormFieldErrorMessage>Dit veld is verplicht.</FormFieldErrorMessage>`}
+  html={`<p class="dsn-form-field-error-message">
+  <!-- exclamation-circle icon -->
+  Dit veld is verplicht.
+</p>`}
+/>
 
 <Controls of={FormFieldErrorMessageStories.Default} />
 

--- a/packages/storybook/src/FormFieldLabel.docs.mdx
+++ b/packages/storybook/src/FormFieldLabel.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as FormFieldLabelStories from './FormFieldLabel.stories';
 import docs from './FormFieldLabel.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={FormFieldLabelStories.Default} />
+<PreviewFrame>
+  <Story of={FormFieldLabelStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<FormFieldLabel htmlFor="input-1">Label</FormFieldLabel>`}
+  html={`<label class="dsn-form-field-label" for="input-1">Label</label>`}
+/>
 
 <Controls of={FormFieldLabelStories.Default} />
 

--- a/packages/storybook/src/FormFieldStatus.docs.mdx
+++ b/packages/storybook/src/FormFieldStatus.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as FormFieldStatusStories from './FormFieldStatus.stories';
 import docs from './FormFieldStatus.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={FormFieldStatusStories.Default} />
+<PreviewFrame>
+  <Story of={FormFieldStatusStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<FormFieldStatus>45 van 100 karakters</FormFieldStatus>`}
+  html={`<p class="dsn-form-field-status">45 van 100 karakters</p>`}
+/>
 
 <Controls of={FormFieldStatusStories.Default} />
 

--- a/packages/storybook/src/FormFieldset.docs.md
+++ b/packages/storybook/src/FormFieldset.docs.md
@@ -6,6 +6,8 @@ Container component voor groep controls die fieldset/legend gebruikt voor semant
 
 De FormFieldset component is de fieldset/legend variant van FormField. Het combineert FormFieldLegend, FormFieldDescription, FormFieldErrorMessage, groep controls (CheckboxGroup, RadioGroup, DateInputGroup), en FormFieldStatus. Gebruikt `<fieldset>` en `<legend>` elementen voor correcte semantiek bij groep controls. De legend hergebruikt FormFieldLabel CSS classes voor consistente styling. Net als FormField krijgt het een dikke rode linker border bij invalid state. FormFieldset is specifiek voor groepen - gebruik FormField voor individuele controls.
 
+> **Codevoorbeeld met context**: De HTML/CSS tab toont een `CheckboxGroup` met `CheckboxOption` componenten als representatieve children. `FormFieldset` is een wrapper voor groep controls — de children vormen de daadwerkelijke invoergroep.
+
 <!-- VOORBEELD -->
 
 ## Use when

--- a/packages/storybook/src/FormFieldset.docs.mdx
+++ b/packages/storybook/src/FormFieldset.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as FormFieldsetStories from './FormFieldset.stories';
 import docs from './FormFieldset.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,38 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={FormFieldsetStories.Default} />
+<PreviewFrame>
+  <Story of={FormFieldsetStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<FormFieldset legend="Interesses">
+  <CheckboxGroup>
+    <CheckboxOption label="Sport" />
+    <CheckboxOption label="Muziek" />
+    <CheckboxOption label="Reizen" />
+  </CheckboxGroup>
+</FormFieldset>`}
+  html={`<fieldset class="dsn-form-field">
+  <legend class="dsn-form-field-label">Interesses</legend>
+  <div class="dsn-checkbox-group">
+    <label class="dsn-checkbox-option">
+      <div class="dsn-checkbox">
+        <input type="checkbox" class="dsn-checkbox__input" />
+        <span class="dsn-checkbox__control" aria-hidden="true"></span>
+      </div>
+      <span class="dsn-option-label">Sport</span>
+    </label>
+    <label class="dsn-checkbox-option">
+      <div class="dsn-checkbox">
+        <input type="checkbox" class="dsn-checkbox__input" />
+        <span class="dsn-checkbox__control" aria-hidden="true"></span>
+      </div>
+      <span class="dsn-option-label">Muziek</span>
+    </label>
+  </div>
+</fieldset>`}
+/>
 
 <Controls of={FormFieldsetStories.Default} />
 

--- a/packages/storybook/src/Heading.docs.mdx
+++ b/packages/storybook/src/Heading.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as HeadingStories from './Heading.stories';
 import docs from './Heading.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={HeadingStories.Default} />
+<PreviewFrame>
+  <Story of={HeadingStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<Heading level={2}>Koptekst</Heading>`}
+  html={`<h2 class="dsn-heading dsn-heading--heading-2">Koptekst</h2>`}
+/>
 
 <Controls of={HeadingStories.Default} />
 

--- a/packages/storybook/src/Icon.docs.mdx
+++ b/packages/storybook/src/Icon.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as IconStories from './Icon.stories';
 import docs from './Icon.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,16 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={IconStories.Default} />
+<PreviewFrame>
+  <Story of={IconStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<Icon name="star" />`}
+  html={`<svg class="dsn-icon" aria-hidden="true">
+  <!-- SVG pad via Tabler Icons — ingeladen via iconMap -->
+</svg>`}
+/>
 
 <Controls of={IconStories.Default} />
 

--- a/packages/storybook/src/Link.docs.mdx
+++ b/packages/storybook/src/Link.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as LinkStories from './Link.stories';
 import docs from './Link.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={LinkStories.Default} />
+<PreviewFrame>
+  <Story of={LinkStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<Link href="#">Linktekst</Link>`}
+  html={`<a href="#" class="dsn-link">Linktekst</a>`}
+/>
 
 <Controls of={LinkStories.Default} />
 

--- a/packages/storybook/src/NumberInput.docs.mdx
+++ b/packages/storybook/src/NumberInput.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as NumberInputStories from './NumberInput.stories';
 import docs from './NumberInput.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={NumberInputStories.Default} />
+<PreviewFrame>
+  <Story of={NumberInputStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<NumberInput placeholder="0" />`}
+  html={`<input type="text" inputmode="numeric" pattern="[0-9]*" class="dsn-text-input" autocomplete="off" placeholder="0" />`}
+/>
 
 <Controls of={NumberInputStories.Default} />
 

--- a/packages/storybook/src/OptionLabel.docs.mdx
+++ b/packages/storybook/src/OptionLabel.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as OptionLabelStories from './OptionLabel.stories';
 import docs from './OptionLabel.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={OptionLabelStories.Default} />
+<PreviewFrame>
+  <Story of={OptionLabelStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<OptionLabel>Label</OptionLabel>`}
+  html={`<span class="dsn-option-label">Label</span>`}
+/>
 
 <Controls of={OptionLabelStories.Default} />
 

--- a/packages/storybook/src/OrderedList.docs.mdx
+++ b/packages/storybook/src/OrderedList.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as OrderedListStories from './OrderedList.stories';
 import docs from './OrderedList.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,22 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={OrderedListStories.Default} />
+<PreviewFrame>
+  <Story of={OrderedListStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<OrderedList>
+  <li>Stap één</li>
+  <li>Stap twee</li>
+  <li>Stap drie</li>
+</OrderedList>`}
+  html={`<ol class="dsn-ordered-list">
+  <li>Stap één</li>
+  <li>Stap twee</li>
+  <li>Stap drie</li>
+</ol>`}
+/>
 
 <Controls of={OrderedListStories.Default} />
 

--- a/packages/storybook/src/Paragraph.docs.mdx
+++ b/packages/storybook/src/Paragraph.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as ParagraphStories from './Paragraph.stories';
 import docs from './Paragraph.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={ParagraphStories.Default} />
+<PreviewFrame>
+  <Story of={ParagraphStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<Paragraph>Dit is een alinea tekst.</Paragraph>`}
+  html={`<p class="dsn-paragraph dsn-paragraph--default">Dit is een alinea tekst.</p>`}
+/>
 
 <Controls of={ParagraphStories.Default} />
 

--- a/packages/storybook/src/PasswordInput.docs.mdx
+++ b/packages/storybook/src/PasswordInput.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as PasswordInputStories from './PasswordInput.stories';
 import docs from './PasswordInput.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={PasswordInputStories.Default} />
+<PreviewFrame>
+  <Story of={PasswordInputStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<PasswordInput placeholder="Wachtwoord" />`}
+  html={`<input type="password" class="dsn-text-input" autocomplete="current-password" placeholder="Wachtwoord" />`}
+/>
 
 <Controls of={PasswordInputStories.Default} />
 

--- a/packages/storybook/src/Radio.docs.mdx
+++ b/packages/storybook/src/Radio.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as RadioStories from './Radio.stories';
 import docs from './Radio.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,19 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={RadioStories.Default} />
+<PreviewFrame>
+  <Story of={RadioStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<Radio id="radio-1" name="radio-groep" />`}
+  html={`<div class="dsn-radio">
+  <input type="radio" class="dsn-radio__input" id="radio-1" name="radio-groep" />
+  <span class="dsn-radio__control" aria-hidden="true">
+    <span class="dsn-radio__inner-circle"></span>
+  </span>
+</div>`}
+/>
 
 <Controls of={RadioStories.Default} />
 

--- a/packages/storybook/src/RadioGroup.docs.md
+++ b/packages/storybook/src/RadioGroup.docs.md
@@ -6,6 +6,8 @@ Een container voor meerdere RadioOption componenten.
 
 De RadioGroup component is een simpele container die meerdere RadioOption componenten groepeert met consistente spacing. Het is puur een presentationele lijst zonder semantische form field markup (geen fieldset/legend). Voor een volledige form field met label en beschrijving wrap je de RadioGroup in een FormFieldset component. De gap tussen opties is geoptimaliseerd voor leesbaarheid en touch targets. Radio buttons in dezelfde groep moeten hetzelfde `name` attribuut hebben zodat slechts één optie tegelijk geselecteerd kan zijn.
 
+> **Codevoorbeeld met context**: De HTML/CSS tab toont `RadioOption` componenten als representatieve children. `RadioGroup` is puur een lijst-container — de children bepalen de daadwerkelijke functionaliteit.
+
 <!-- VOORBEELD -->
 
 ## Use when

--- a/packages/storybook/src/RadioGroup.docs.mdx
+++ b/packages/storybook/src/RadioGroup.docs.mdx
@@ -1,6 +1,7 @@
-import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import { Meta, Story, Markdown } from '@storybook/blocks';
 import * as RadioGroupStories from './RadioGroup.stories';
 import docs from './RadioGroup.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,6 +11,45 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={RadioGroupStories.Default} />
+<PreviewFrame>
+  <Story of={RadioGroupStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<RadioGroup>
+  <RadioOption name="groep" label="Optie één" />
+  <RadioOption name="groep" label="Optie twee" />
+  <RadioOption name="groep" label="Optie drie" />
+</RadioGroup>`}
+  html={`<div class="dsn-radio-group">
+  <label class="dsn-radio-option">
+    <div class="dsn-radio">
+      <input type="radio" class="dsn-radio__input" name="groep" />
+      <span class="dsn-radio__control" aria-hidden="true">
+        <span class="dsn-radio__inner-circle"></span>
+      </span>
+    </div>
+    <span class="dsn-option-label">Optie één</span>
+  </label>
+  <label class="dsn-radio-option">
+    <div class="dsn-radio">
+      <input type="radio" class="dsn-radio__input" name="groep" />
+      <span class="dsn-radio__control" aria-hidden="true">
+        <span class="dsn-radio__inner-circle"></span>
+      </span>
+    </div>
+    <span class="dsn-option-label">Optie twee</span>
+  </label>
+  <label class="dsn-radio-option">
+    <div class="dsn-radio">
+      <input type="radio" class="dsn-radio__input" name="groep" />
+      <span class="dsn-radio__control" aria-hidden="true">
+        <span class="dsn-radio__inner-circle"></span>
+      </span>
+    </div>
+    <span class="dsn-option-label">Optie drie</span>
+  </label>
+</div>`}
+/>
 
 <Markdown>{rest}</Markdown>

--- a/packages/storybook/src/RadioOption.docs.mdx
+++ b/packages/storybook/src/RadioOption.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as RadioOptionStories from './RadioOption.stories';
 import docs from './RadioOption.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,22 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={RadioOptionStories.Default} />
+<PreviewFrame>
+  <Story of={RadioOptionStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<RadioOption name="radio-groep" label="Optie label" />`}
+  html={`<label class="dsn-radio-option">
+  <div class="dsn-radio">
+    <input type="radio" class="dsn-radio__input" name="radio-groep" />
+    <span class="dsn-radio__control" aria-hidden="true">
+      <span class="dsn-radio__inner-circle"></span>
+    </span>
+  </div>
+  <span class="dsn-option-label">Optie label</span>
+</label>`}
+/>
 
 <Controls of={RadioOptionStories.Default} />
 

--- a/packages/storybook/src/SearchInput.docs.mdx
+++ b/packages/storybook/src/SearchInput.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as SearchInputStories from './SearchInput.stories';
 import docs from './SearchInput.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,17 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={SearchInputStories.Default} />
+<PreviewFrame>
+  <Story of={SearchInputStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<SearchInput placeholder="Zoeken..." />`}
+  html={`<div class="dsn-search-input-wrapper">
+  <!-- search icon (decoratief, niet-interactief) -->
+  <input type="search" class="dsn-text-input dsn-search-input" placeholder="Zoeken..." />
+</div>`}
+/>
 
 <Controls of={SearchInputStories.Default} />
 

--- a/packages/storybook/src/Select.docs.mdx
+++ b/packages/storybook/src/Select.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as SelectStories from './Select.stories';
 import docs from './Select.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,25 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={SelectStories.Default} />
+<PreviewFrame>
+  <Story of={SelectStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<Select>
+  <option value="">Kies een optie</option>
+  <option value="1">Optie 1</option>
+  <option value="2">Optie 2</option>
+</Select>`}
+  html={`<div class="dsn-select-wrapper">
+  <select class="dsn-text-input dsn-select">
+    <option value="">Kies een optie</option>
+    <option value="1">Optie 1</option>
+    <option value="2">Optie 2</option>
+  </select>
+  <!-- chevron-down icon (decoratief, niet-interactief) -->
+</div>`}
+/>
 
 <Controls of={SelectStories.Default} />
 

--- a/packages/storybook/src/TelephoneInput.docs.mdx
+++ b/packages/storybook/src/TelephoneInput.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as TelephoneInputStories from './TelephoneInput.stories';
 import docs from './TelephoneInput.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={TelephoneInputStories.Default} />
+<PreviewFrame>
+  <Story of={TelephoneInputStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<TelephoneInput placeholder="06 12345678" />`}
+  html={`<input type="tel" inputmode="tel" class="dsn-text-input" autocomplete="tel" placeholder="06 12345678" />`}
+/>
 
 <Controls of={TelephoneInputStories.Default} />
 

--- a/packages/storybook/src/TextArea.docs.mdx
+++ b/packages/storybook/src/TextArea.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as TextAreaStories from './TextArea.stories';
 import docs from './TextArea.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={TextAreaStories.Default} />
+<PreviewFrame>
+  <Story of={TextAreaStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<TextArea placeholder="Voer uw bericht in" rows={4} />`}
+  html={`<textarea class="dsn-text-area" rows="4" placeholder="Voer uw bericht in"></textarea>`}
+/>
 
 <Controls of={TextAreaStories.Default} />
 

--- a/packages/storybook/src/TextInput.docs.mdx
+++ b/packages/storybook/src/TextInput.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as TextInputStories from './TextInput.stories';
 import docs from './TextInput.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,14 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={TextInputStories.Default} />
+<PreviewFrame>
+  <Story of={TextInputStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<TextInput placeholder="Voer tekst in" />`}
+  html={`<input type="text" class="dsn-text-input" placeholder="Voer tekst in" />`}
+/>
 
 <Controls of={TextInputStories.Default} />
 

--- a/packages/storybook/src/TimeInput.docs.mdx
+++ b/packages/storybook/src/TimeInput.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as TimeInputStories from './TimeInput.stories';
 import docs from './TimeInput.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,17 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={TimeInputStories.Default} />
+<PreviewFrame>
+  <Story of={TimeInputStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<TimeInput />`}
+  html={`<div class="dsn-time-input-wrapper">
+  <input type="time" class="dsn-text-input dsn-time-input" />
+  <!-- clock button (niet-focusbaar, voor muisgebruikers) -->
+</div>`}
+/>
 
 <Controls of={TimeInputStories.Default} />
 

--- a/packages/storybook/src/UnorderedList.docs.mdx
+++ b/packages/storybook/src/UnorderedList.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
 import * as UnorderedListStories from './UnorderedList.stories';
 import docs from './UnorderedList.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
 
 export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
@@ -10,7 +11,22 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 ## Voorbeeld
 
-<Story of={UnorderedListStories.Default} />
+<PreviewFrame>
+  <Story of={UnorderedListStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  react={`<UnorderedList>
+  <li>Item één</li>
+  <li>Item twee</li>
+  <li>Item drie</li>
+</UnorderedList>`}
+  html={`<ul class="dsn-unordered-list">
+  <li>Item één</li>
+  <li>Item twee</li>
+  <li>Item drie</li>
+</ul>`}
+/>
 
 <Controls of={UnorderedListStories.Default} />
 

--- a/packages/storybook/src/components/CodeTabs.tsx
+++ b/packages/storybook/src/components/CodeTabs.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { Source } from '@storybook/blocks';
+
+interface CodeTabsProps {
+  /** JSX/TSX code snippet for the React tab */
+  react: string;
+  /** HTML/CSS markup snippet for the HTML/CSS tab */
+  html: string;
+}
+
+type Tab = 'react' | 'html';
+
+/**
+ * CodeTabs — two-tab code viewer shown below PreviewFrame on every doc page.
+ * - React tab (default): shows the JSX/TSX snippet
+ * - HTML/CSS tab: shows the equivalent vanilla HTML markup
+ *
+ * Syntax highlighting via Storybook's built-in Source block from @storybook/blocks.
+ * The tab bar uses design token CSS variables so it responds to dark mode.
+ */
+export function CodeTabs({ react, html }: CodeTabsProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('react');
+
+  const tabBarStyle: React.CSSProperties = {
+    display: 'flex',
+    borderTop: '1px solid var(--dsn-color-neutral-border-subtle, #C4C4C4)',
+    borderLeft: '1px solid var(--dsn-color-neutral-border-subtle, #C4C4C4)',
+    borderRight: '1px solid var(--dsn-color-neutral-border-subtle, #C4C4C4)',
+    background: 'var(--dsn-color-neutral-bg-default, #F1F1F1)',
+    marginBottom: '0',
+  };
+
+  const tabButtonStyle = (isActive: boolean): React.CSSProperties => ({
+    padding: '8px 16px',
+    border: 'none',
+    borderBottom: `2px solid ${isActive ? 'var(--dsn-link-color, #1d70b8)' : 'transparent'}`,
+    background: 'transparent',
+    cursor: 'pointer',
+    fontFamily: 'var(--dsn-text-font-family-base, sans-serif)',
+    fontSize: '13px',
+    fontWeight: isActive ? '600' : '400',
+    color: isActive
+      ? 'var(--dsn-link-color, #1d70b8)'
+      : 'var(--dsn-color-neutral-color-document, #1B1B1B)',
+    lineHeight: '1.5',
+  });
+
+  const codeWrapperStyle: React.CSSProperties = {
+    border: '1px solid var(--dsn-color-neutral-border-subtle, #C4C4C4)',
+    borderTop: 'none',
+    borderRadius: '0 0 4px 4px',
+    overflow: 'hidden',
+    marginBottom: '24px',
+  };
+
+  return (
+    <div>
+      <div style={tabBarStyle}>
+        <button
+          type="button"
+          style={tabButtonStyle(activeTab === 'react')}
+          onClick={() => setActiveTab('react')}
+          aria-pressed={activeTab === 'react'}
+        >
+          React
+        </button>
+        <button
+          type="button"
+          style={tabButtonStyle(activeTab === 'html')}
+          onClick={() => setActiveTab('html')}
+          aria-pressed={activeTab === 'html'}
+        >
+          HTML/CSS
+        </button>
+      </div>
+      <div style={codeWrapperStyle}>
+        {activeTab === 'react' ? (
+          <Source code={react} language="tsx" dark />
+        ) : (
+          <Source code={html} language="html" dark />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/storybook/src/components/PreviewFrame.tsx
+++ b/packages/storybook/src/components/PreviewFrame.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface PreviewFrameProps {
+  children: React.ReactNode;
+}
+
+/**
+ * PreviewFrame — wraps a Storybook Story on the docs page with a styled border and
+ * a background that uses design token CSS variables so it automatically responds to
+ * dark mode and theme switching (just like the individual story canvases do).
+ */
+export function PreviewFrame({ children }: PreviewFrameProps) {
+  return (
+    <div
+      style={{
+        border: '1px solid var(--dsn-color-neutral-border-subtle, #C4C4C4)',
+        borderRadius: '4px 4px 0 0',
+        borderBottom: 'none',
+        padding: '32px 24px',
+        background: 'var(--dsn-color-neutral-bg-document, #FCFCFC)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/storybook/src/components/index.ts
+++ b/packages/storybook/src/components/index.ts
@@ -1,0 +1,2 @@
+export { PreviewFrame } from './PreviewFrame';
+export { CodeTabs } from './CodeTabs';


### PR DESCRIPTION
## Summary

- Nieuwe `PreviewFrame` component: visueel kader rondom de story preview op doc pagina's, met token-based achtergrond die reageert op dark mode
- Nieuwe `CodeTabs` component: twee schakelbare tabs (React standaard actief, HTML/CSS) met `Source`-based syntax highlighting
- Alle 31 `.docs.mdx` bestanden bijgewerkt met `<PreviewFrame>` + `<CodeTabs>` inclusief statische code snippets per component
- Contextnotities toegevoegd in 5 wrapper component `.docs.md` bestanden (CheckboxGroup, RadioGroup, FormField, FormFieldset, DateInputGroup) die uitleggen dat de code voorbeelden representatieve children tonen

Sluit issue #16.

## Test plan

- [ ] Lint groen (`pnpm lint`)
- [ ] Type-check groen (`pnpm type-check`)
- [ ] Tests groen (`pnpm test`)
- [ ] Storybook build slaagt (`pnpm build`)
- [ ] Alle 31 doc pagina's tonen PreviewFrame + CodeTabs in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)