### PR TITLE
feat(storybook): HTML/CSS tab dynamisch via transform + htmlTemplate

### DIFF
--- a/packages/storybook/src/Button.stories.tsx
+++ b/packages/storybook/src/Button.stories.tsx
@@ -62,6 +62,25 @@ const iconOptions: (IconName | undefined)[] = [
 const meta: Meta<typeof Button> = {
   title: 'Components/Button',
   component: Button,
+  parameters: {
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = [
+          'dsn-button',
+          `dsn-button--${args.variant ?? 'strong'}`,
+          `dsn-button--size-${args.size ?? 'default'}`,
+          args.loading && 'dsn-button--loading',
+          args.fullWidth && 'dsn-button--full-width',
+          args.iconOnly && 'dsn-button--icon-only',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const disabled = args.disabled || args.loading ? ' disabled' : '';
+        return `<button type="button" class="${cls}"${disabled}>${args.children ?? 'Tekst'}</button>`;
+      },
+    },
+  },
   argTypes: {
     variant: {
       control: 'select',

--- a/packages/storybook/src/Checkbox.stories.tsx
+++ b/packages/storybook/src/Checkbox.stories.tsx
@@ -10,6 +10,29 @@ const meta: Meta<typeof Checkbox> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const inputCls = [
+          'dsn-checkbox__input',
+          args.invalid && 'dsn-checkbox__input--invalid',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const inputAttrs = [
+          args.checked && 'checked',
+          args.disabled && 'disabled',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const iconComment = args.indeterminate
+          ? '<!-- minus icon -->'
+          : '<!-- check icon -->';
+        return `<div class="dsn-checkbox">\n  <input type="checkbox" class="${inputCls}"${inputAttrs ? ' ' + inputAttrs : ''} />\n  <span class="dsn-checkbox__control" aria-hidden="true">\n    ${iconComment}\n  </span>\n</div>`;
+      },
+    },
   },
   argTypes: {
     checked: { control: 'boolean' },

--- a/packages/storybook/src/CheckboxOption.stories.tsx
+++ b/packages/storybook/src/CheckboxOption.stories.tsx
@@ -17,6 +17,35 @@ const meta: Meta<typeof CheckboxOption> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const inputCls = [
+          'dsn-checkbox__input',
+          args.invalid && 'dsn-checkbox__input--invalid',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const inputAttrs = [
+          args.checked && 'checked',
+          args.disabled && 'disabled',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const labelCls = [
+          'dsn-option-label',
+          args.disabled && 'dsn-option-label--disabled',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const iconComment = args.indeterminate
+          ? '<!-- minus icon -->'
+          : '<!-- check icon -->';
+        return `<label class="dsn-checkbox-option">\n  <div class="dsn-checkbox">\n    <input type="checkbox" class="${inputCls}"${inputAttrs ? ' ' + inputAttrs : ''} />\n    <span class="dsn-checkbox__control" aria-hidden="true">\n      ${iconComment}\n    </span>\n  </div>\n  <span class="${labelCls}">${args.label ?? 'Tekst'}</span>\n</label>`;
+      },
+    },
   },
   argTypes: {
     checked: { control: 'boolean' },

--- a/packages/storybook/src/DateInput.stories.tsx
+++ b/packages/storybook/src/DateInput.stories.tsx
@@ -10,6 +10,24 @@ const meta: Meta<typeof DateInput> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const attrs = [
+          args.disabled && 'disabled',
+          args.readOnly && 'readonly',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const button =
+          !args.disabled && !args.readOnly
+            ? '\n  <!-- calendar button (niet-focusbaar, voor muisgebruikers) -->'
+            : '';
+        return `<div class="dsn-date-input-wrapper">\n  <input type="date" class="dsn-text-input dsn-date-input"${attrs ? ' ' + attrs : ''} />${button}\n</div>`;
+      },
+    },
   },
   argTypes: {
     disabled: { control: 'boolean' },

--- a/packages/storybook/src/EmailInput.stories.tsx
+++ b/packages/storybook/src/EmailInput.stories.tsx
@@ -16,6 +16,27 @@ const meta: Meta<typeof EmailInput> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = [
+          'dsn-text-input',
+          args.width && `dsn-text-input--width-${args.width}`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const attrs = [
+          args.disabled && 'disabled',
+          args.readOnly && 'readonly',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+          args.placeholder && `placeholder="${args.placeholder}"`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return `<input type="email" inputmode="email" class="${cls}" autocomplete="email"${attrs ? ' ' + attrs : ''} />`;
+      },
+    },
   },
   argTypes: {
     placeholder: { control: 'text' },

--- a/packages/storybook/src/FormField.stories.tsx
+++ b/packages/storybook/src/FormField.stories.tsx
@@ -22,6 +22,34 @@ const meta: Meta<typeof FormField> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = ['dsn-form-field', args.error && 'dsn-form-field--invalid']
+          .filter(Boolean)
+          .join(' ');
+        const forAttr = args.htmlFor ? ` for="${args.htmlFor}"` : '';
+        const suffix = args.labelSuffix
+          ? `<span class="dsn-form-field-label-suffix">${args.labelSuffix}</span>`
+          : '';
+        let html = `<div class="${cls}">\n`;
+        html += `  <label class="dsn-form-field-label"${forAttr}>${args.label ?? 'Label'}${suffix}</label>\n`;
+        if (args.description)
+          html += `  <p class="dsn-form-field-description">${args.description}</p>\n`;
+        if (args.error)
+          html += `  <p class="dsn-form-field-error-message"><!-- exclamation-circle icon -->${args.error}</p>\n`;
+        html += `  <input type="text" class="dsn-text-input"${args.htmlFor ? ` id="${args.htmlFor}"` : ''} />\n`;
+        if (args.status) {
+          const variantCls =
+            args.statusVariant && args.statusVariant !== 'default'
+              ? ` dsn-form-field-status--${args.statusVariant}`
+              : '';
+          html += `  <p class="dsn-form-field-status${variantCls}">${args.status}</p>\n`;
+        }
+        html += `</div>`;
+        return html;
+      },
+    },
   },
   argTypes: {
     label: { control: 'text' },

--- a/packages/storybook/src/FormFieldDescription.stories.tsx
+++ b/packages/storybook/src/FormFieldDescription.stories.tsx
@@ -17,6 +17,13 @@ const meta: Meta<typeof FormFieldDescription> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const idAttr = args.id ? ` id="${args.id}"` : '';
+        return `<p class="dsn-form-field-description"${idAttr}>${args.children ?? 'Tekst'}</p>`;
+      },
+    },
   },
   argTypes: {
     id: { control: 'text' },

--- a/packages/storybook/src/FormFieldErrorMessage.stories.tsx
+++ b/packages/storybook/src/FormFieldErrorMessage.stories.tsx
@@ -17,6 +17,15 @@ const meta: Meta<typeof FormFieldErrorMessage> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const showIcon = args.showIcon !== false;
+        const idAttr = args.id ? ` id="${args.id}"` : '';
+        const icon = showIcon ? '<!-- exclamation-circle icon -->\n  ' : '';
+        return `<p class="dsn-form-field-error-message"${idAttr}>\n  ${icon}${args.children ?? 'Tekst'}\n</p>`;
+      },
+    },
   },
   argTypes: {
     showIcon: { control: 'boolean' },

--- a/packages/storybook/src/FormFieldLabel.stories.tsx
+++ b/packages/storybook/src/FormFieldLabel.stories.tsx
@@ -17,6 +17,16 @@ const meta: Meta<typeof FormFieldLabel> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const forAttr = args.htmlFor ? ` for="${args.htmlFor}"` : '';
+        const suffix = args.suffix
+          ? `<span class="dsn-form-field-label-suffix">${args.suffix}</span>`
+          : '';
+        return `<label class="dsn-form-field-label"${forAttr}>${args.children ?? 'Label'}${suffix}</label>`;
+      },
+    },
   },
   argTypes: {
     suffix: { control: 'text' },

--- a/packages/storybook/src/FormFieldStatus.stories.tsx
+++ b/packages/storybook/src/FormFieldStatus.stories.tsx
@@ -17,6 +17,29 @@ const meta: Meta<typeof FormFieldStatus> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const variant = args.variant ?? 'default';
+        const cls = [
+          'dsn-form-field-status',
+          variant !== 'default' && `dsn-form-field-status--${variant}`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const showIcon = args.showIcon !== false && variant !== 'default';
+        const iconName =
+          variant === 'positive'
+            ? 'check'
+            : variant === 'warning'
+              ? 'alert-triangle'
+              : null;
+        const idAttr = args.id ? ` id="${args.id}"` : '';
+        const icon =
+          showIcon && iconName ? `<!-- ${iconName} icon -->\n  ` : '';
+        return `<p class="${cls}"${idAttr}>\n  ${icon}${args.children ?? 'Tekst'}\n</p>`;
+      },
+    },
   },
   argTypes: {
     variant: {

--- a/packages/storybook/src/FormFieldset.stories.tsx
+++ b/packages/storybook/src/FormFieldset.stories.tsx
@@ -22,6 +22,33 @@ const meta: Meta<typeof FormFieldset> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = ['dsn-form-field', args.error && 'dsn-form-field--invalid']
+          .filter(Boolean)
+          .join(' ');
+        const suffix = args.legendSuffix
+          ? `<span class="dsn-form-field-label-suffix">${args.legendSuffix}</span>`
+          : '';
+        let html = `<fieldset class="${cls}">\n`;
+        html += `  <legend class="dsn-form-field-label">${args.legend ?? 'Legenda'}${suffix}</legend>\n`;
+        if (args.description)
+          html += `  <p class="dsn-form-field-description">${args.description}</p>\n`;
+        if (args.error)
+          html += `  <p class="dsn-form-field-error-message"><!-- exclamation-circle icon -->${args.error}</p>\n`;
+        html += `  <div class="dsn-checkbox-group">\n    <!-- CheckboxOption / RadioOption componenten -->\n  </div>\n`;
+        if (args.status) {
+          const variantCls =
+            args.statusVariant && args.statusVariant !== 'default'
+              ? ` dsn-form-field-status--${args.statusVariant}`
+              : '';
+          html += `  <p class="dsn-form-field-status${variantCls}">${args.status}</p>\n`;
+        }
+        html += `</fieldset>`;
+        return html;
+      },
+    },
   },
   argTypes: {
     legend: { control: 'text' },

--- a/packages/storybook/src/Heading.stories.tsx
+++ b/packages/storybook/src/Heading.stories.tsx
@@ -17,6 +17,14 @@ const meta: Meta<typeof Heading> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const level = args.level ?? 2;
+        const appearance = args.appearance ?? `heading-${level}`;
+        return `<h${level} class="dsn-heading dsn-heading--${appearance}">${args.children ?? 'Tekst'}</h${level}>`;
+      },
+    },
   },
   argTypes: {
     level: {

--- a/packages/storybook/src/Icon.stories.tsx
+++ b/packages/storybook/src/Icon.stories.tsx
@@ -10,6 +10,19 @@ const meta: Meta<typeof Icon> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const size = args.size ?? 'md';
+        const cls = ['dsn-icon', size !== 'md' && `dsn-icon--${size}`]
+          .filter(Boolean)
+          .join(' ');
+        const ariaAttrs = args['aria-label']
+          ? `aria-label="${args['aria-label']}" role="img"`
+          : 'aria-hidden="true"';
+        return `<svg class="${cls}" ${ariaAttrs}>\n  <!-- ${args.name ?? 'check'} icon via Tabler Icons -->\n</svg>`;
+      },
+    },
   },
   argTypes: {
     name: {

--- a/packages/storybook/src/Link.stories.tsx
+++ b/packages/storybook/src/Link.stories.tsx
@@ -67,6 +67,26 @@ const meta: Meta<typeof Link> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = [
+          'dsn-link',
+          args.size && args.size !== 'default' && `dsn-link--size-${args.size}`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const attrParts: string[] = [`class="${cls}"`];
+        if (!args.disabled) attrParts.push(`href="${args.href ?? '#'}"`);
+        if (args.external)
+          attrParts.push('target="_blank"', 'rel="noopener noreferrer"');
+        if (args.disabled)
+          attrParts.push('aria-disabled="true"', 'tabindex="-1"');
+        if (args.current) attrParts.push('aria-current="page"');
+        const text = `${args.children ?? 'Linktekst'}${args.external ? ' (opens in new tab)' : ''}`;
+        return `<a ${attrParts.join(' ')}>${text}</a>`;
+      },
+    },
   },
   argTypes: {
     size: {

--- a/packages/storybook/src/NumberInput.stories.tsx
+++ b/packages/storybook/src/NumberInput.stories.tsx
@@ -10,6 +10,29 @@ const meta: Meta<typeof NumberInput> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = [
+          'dsn-text-input',
+          args.width && `dsn-text-input--width-${args.width}`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const inputMode = args.allowDecimals ? 'decimal' : 'numeric';
+        const pattern = args.allowDecimals ? '' : ' pattern="[0-9]*"';
+        const attrs = [
+          args.disabled && 'disabled',
+          args.readOnly && 'readonly',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+          args.placeholder && `placeholder="${args.placeholder}"`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return `<input type="text" inputmode="${inputMode}"${pattern} class="${cls}" autocomplete="off"${attrs ? ' ' + attrs : ''} />`;
+      },
+    },
   },
   argTypes: {
     placeholder: { control: 'text' },

--- a/packages/storybook/src/OptionLabel.stories.tsx
+++ b/packages/storybook/src/OptionLabel.stories.tsx
@@ -17,6 +17,18 @@ const meta: Meta<typeof OptionLabel> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = [
+          'dsn-option-label',
+          args.disabled && 'dsn-option-label--disabled',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return `<span class="${cls}">${args.children ?? 'Tekst'}</span>`;
+      },
+    },
   },
   argTypes: {
     disabled: { control: 'boolean' },

--- a/packages/storybook/src/OrderedList.stories.tsx
+++ b/packages/storybook/src/OrderedList.stories.tsx
@@ -17,6 +17,18 @@ const meta: Meta<typeof OrderedList> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const attrs = [
+          args.start && `start="${args.start}"`,
+          args.reversed && 'reversed',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return `<ol class="dsn-ordered-list"${attrs ? ' ' + attrs : ''}>\n  <li>Item één</li>\n  <li>Item twee</li>\n  <li>Item drie</li>\n</ol>`;
+      },
+    },
   },
   argTypes: {
     start: { control: 'number' },

--- a/packages/storybook/src/Paragraph.stories.tsx
+++ b/packages/storybook/src/Paragraph.stories.tsx
@@ -17,6 +17,13 @@ const meta: Meta<typeof Paragraph> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const variant = args.variant ?? 'default';
+        return `<p class="dsn-paragraph dsn-paragraph--${variant}">${args.children ?? 'Tekst'}</p>`;
+      },
+    },
   },
   argTypes: {
     variant: {

--- a/packages/storybook/src/PasswordInput.stories.tsx
+++ b/packages/storybook/src/PasswordInput.stories.tsx
@@ -10,6 +10,28 @@ const meta: Meta<typeof PasswordInput> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = [
+          'dsn-text-input',
+          args.width && `dsn-text-input--width-${args.width}`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const autocomplete = args.passwordAutocomplete ?? 'current-password';
+        const attrs = [
+          args.disabled && 'disabled',
+          args.readOnly && 'readonly',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+          args.placeholder && `placeholder="${args.placeholder}"`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return `<input type="password" class="${cls}" autocomplete="${autocomplete}"${attrs ? ' ' + attrs : ''} />`;
+      },
+    },
   },
   argTypes: {
     placeholder: { control: 'text' },

--- a/packages/storybook/src/Radio.stories.tsx
+++ b/packages/storybook/src/Radio.stories.tsx
@@ -10,6 +10,26 @@ const meta: Meta<typeof Radio> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const inputCls = [
+          'dsn-radio__input',
+          args.invalid && 'dsn-radio__input--invalid',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const inputAttrs = [
+          args.checked && 'checked',
+          args.disabled && 'disabled',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return `<div class="dsn-radio">\n  <input type="radio" class="${inputCls}"${inputAttrs ? ' ' + inputAttrs : ''} />\n  <span class="dsn-radio__control" aria-hidden="true">\n    <span class="dsn-radio__inner-circle"></span>\n  </span>\n</div>`;
+      },
+    },
   },
   argTypes: {
     checked: { control: 'boolean' },

--- a/packages/storybook/src/RadioOption.stories.tsx
+++ b/packages/storybook/src/RadioOption.stories.tsx
@@ -17,6 +17,33 @@ const meta: Meta<typeof RadioOption> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const inputCls = [
+          'dsn-radio__input',
+          args.invalid && 'dsn-radio__input--invalid',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const nameAttr = args.name ? ` name="${args.name}"` : '';
+        const inputAttrs = [
+          args.checked && 'checked',
+          args.disabled && 'disabled',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const labelCls = [
+          'dsn-option-label',
+          args.disabled && 'dsn-option-label--disabled',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return `<label class="dsn-radio-option">\n  <div class="dsn-radio">\n    <input type="radio" class="${inputCls}"${nameAttr}${inputAttrs ? ' ' + inputAttrs : ''} />\n    <span class="dsn-radio__control" aria-hidden="true">\n      <span class="dsn-radio__inner-circle"></span>\n    </span>\n  </div>\n  <span class="${labelCls}">${args.label ?? 'Tekst'}</span>\n</label>`;
+      },
+    },
   },
   argTypes: {
     checked: { control: 'boolean' },

--- a/packages/storybook/src/SearchInput.stories.tsx
+++ b/packages/storybook/src/SearchInput.stories.tsx
@@ -17,6 +17,27 @@ const meta: Meta<typeof SearchInput> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const wrapperCls = [
+          'dsn-search-input-wrapper',
+          args.width && `dsn-search-input-wrapper--width-${args.width}`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const attrs = [
+          args.disabled && 'disabled',
+          args.readOnly && 'readonly',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+          args.placeholder && `placeholder="${args.placeholder}"`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return `<div class="${wrapperCls}">\n  <!-- search icon (decoratief) -->\n  <input type="search" class="dsn-text-input dsn-search-input"${attrs ? ' ' + attrs : ''} />\n</div>`;
+      },
+    },
   },
   argTypes: {
     placeholder: { control: 'text' },

--- a/packages/storybook/src/Select.stories.tsx
+++ b/packages/storybook/src/Select.stories.tsx
@@ -32,6 +32,28 @@ const meta: Meta<typeof Select> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const wrapperCls = [
+          'dsn-select-wrapper',
+          args.width && `dsn-select-wrapper--width-${args.width}`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const inputAttrs = [
+          args.disabled && 'disabled',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const icon = !args.disabled
+          ? '\n  <!-- chevron-down icon (decoratief) -->'
+          : '';
+        return `<div class="${wrapperCls}">\n  <select class="dsn-text-input dsn-select"${inputAttrs ? ' ' + inputAttrs : ''}>\n    <option value="">Kies een optie</option>\n    <option value="1">Optie 1</option>\n    <option value="2">Optie 2</option>\n  </select>${icon}\n</div>`;
+      },
+    },
   },
   argTypes: {
     disabled: { control: 'boolean' },

--- a/packages/storybook/src/TelephoneInput.stories.tsx
+++ b/packages/storybook/src/TelephoneInput.stories.tsx
@@ -16,6 +16,27 @@ const meta: Meta<typeof TelephoneInput> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = [
+          'dsn-text-input',
+          args.width && `dsn-text-input--width-${args.width}`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const attrs = [
+          args.disabled && 'disabled',
+          args.readOnly && 'readonly',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+          args.placeholder && `placeholder="${args.placeholder}"`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return `<input type="tel" inputmode="tel" class="${cls}" autocomplete="tel"${attrs ? ' ' + attrs : ''} />`;
+      },
+    },
   },
   argTypes: {
     placeholder: { control: 'text' },

--- a/packages/storybook/src/TextArea.stories.tsx
+++ b/packages/storybook/src/TextArea.stories.tsx
@@ -17,6 +17,29 @@ const meta: Meta<typeof TextArea> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = [
+          'dsn-text-area',
+          args.width && `dsn-text-area--width-${args.width}`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const rows = args.rows ?? 4;
+        const attrs = [
+          `rows="${rows}"`,
+          args.disabled && 'disabled',
+          args.readOnly && 'readonly',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+          args.placeholder && `placeholder="${args.placeholder}"`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return `<textarea class="${cls}" ${attrs}></textarea>`;
+      },
+    },
   },
   argTypes: {
     width: {

--- a/packages/storybook/src/TextInput.stories.tsx
+++ b/packages/storybook/src/TextInput.stories.tsx
@@ -17,6 +17,27 @@ const meta: Meta<typeof TextInput> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = [
+          'dsn-text-input',
+          args.width && `dsn-text-input--width-${args.width}`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const attrs = [
+          args.disabled && 'disabled',
+          args.readOnly && 'readonly',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+          args.placeholder && `placeholder="${args.placeholder}"`,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return `<input type="text" class="${cls}"${attrs ? ' ' + attrs : ''} />`;
+      },
+    },
   },
   argTypes: {
     width: {

--- a/packages/storybook/src/TimeInput.stories.tsx
+++ b/packages/storybook/src/TimeInput.stories.tsx
@@ -10,6 +10,24 @@ const meta: Meta<typeof TimeInput> = {
     docs: {
       page: DocsPage,
     },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const attrs = [
+          args.disabled && 'disabled',
+          args.readOnly && 'readonly',
+          args.required && 'required',
+          args.invalid && 'aria-invalid="true"',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const button =
+          !args.disabled && !args.readOnly
+            ? '\n  <!-- clock button (niet-focusbaar, voor muisgebruikers) -->'
+            : '';
+        return `<div class="dsn-time-input-wrapper">\n  <input type="time" class="dsn-text-input dsn-time-input"${attrs ? ' ' + attrs : ''} />${button}\n</div>`;
+      },
+    },
   },
   argTypes: {
     disabled: { control: 'boolean' },

--- a/packages/storybook/src/components/CodeTabs.tsx
+++ b/packages/storybook/src/components/CodeTabs.tsx
@@ -17,7 +17,11 @@ interface CodeTabsProps {
    * No longer used. The React tab reads live code from the story referenced by `of`.
    */
   react?: string;
-  /** HTML/CSS markup snippet for the HTML/CSS tab */
+  /**
+   * Fallback HTML/CSS markup shown in the HTML/CSS tab when the story does not define
+   * `parameters.dsn.htmlTemplate`. When a template is defined, the tab renders
+   * dynamic HTML derived from the current story args (updates with Controls).
+   */
   html: string;
 }
 
@@ -26,7 +30,8 @@ type Tab = 'react' | 'html';
 /**
  * CodeTabs — two-tab code viewer shown below PreviewFrame on every doc page.
  * - React tab (default): shows live story code via `Source of={story}`, updates with Controls
- * - HTML/CSS tab: shows the equivalent vanilla HTML markup (static)
+ * - HTML/CSS tab: shows dynamic HTML via `transform` using `parameters.dsn.htmlTemplate`,
+ *   falls back to the static `html` prop when no htmlTemplate is defined on the story
  *
  * Syntax highlighting via Storybook's built-in Source block from @storybook/blocks.
  * The tab bar uses design token CSS variables so it responds to dark mode.
@@ -93,7 +98,21 @@ export function CodeTabs({ of: storyRef, html }: CodeTabsProps) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           <Source of={storyRef as any} dark />
         ) : (
-          <Source code={html} language="html" dark />
+          // HTML tab: uses `of` for live subscription to STORY_ARGS_UPDATED,
+          // and `transform` to generate HTML from story args via the
+          // `parameters.dsn.htmlTemplate` function defined in each story file.
+          // Falls back to the static `html` prop when no template is defined.
+          <Source
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            of={storyRef as any}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            transform={(_: string, ctx: any) => {
+              const template = ctx?.parameters?.dsn?.htmlTemplate;
+              return typeof template === 'function' ? template(ctx.args) : html;
+            }}
+            language="html"
+            dark
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- `CodeTabs.tsx` bijgewerkt: de HTML/CSS tab gebruikt nu `Source of={storyRef}` met een `transform` callback die `parameters.dsn.htmlTemplate(ctx.args)` aanroept als die beschikbaar is, anders fallback naar de statische `html` prop
- `parameters.dsn.htmlTemplate` toegevoegd aan 27 story files — alle componenten met zinvolle Controls (Button, Icon, Heading, Paragraph, Link, TextInput, TextArea, Checkbox, Radio, OptionLabel, CheckboxOption, RadioOption, FormFieldLabel, FormFieldDescription, FormFieldErrorMessage, FormFieldStatus, FormField, FormFieldset, OrderedList, NumberInput, EmailInput, TelephoneInput, PasswordInput, SearchInput, TimeInput, Select, DateInput)
- Wrapper componenten zonder zinvolle dynamische HTML (CheckboxGroup, RadioGroup, DateInputGroup, UnorderedList) blijven de statische `html` prop gebruiken

## Hoe het werkt

De HTML/CSS tab abonneert via `of={storyRef}` op `STORY_ARGS_UPDATED` (net als de React tab). Bij elke update wordt `transform` aangeroepen met de huidige story context:

```tsx
transform={(_: string, ctx: any) => {
  const template = ctx?.parameters?.dsn?.htmlTemplate;
  return typeof template === 'function' ? template(ctx.args) : html;
}}
```

Elke story file definieert zijn eigen `htmlTemplate`:

```tsx
parameters: {
  dsn: {
    htmlTemplate: (args: any) => {
      const cls = ['dsn-button', `dsn-button--${args.variant ?? 'strong'}`].filter(Boolean).join(' ');
      return `<button type="button" class="${cls}">${args.children ?? 'Tekst'}</button>`;
    },
  },
},
```

## Test plan

- [ ] Storybook bouwen slaagt (CI build)
- [ ] Lint + type-check groen
- [ ] Tests groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)