### PR TITLE
fix(storybook): DateInputGroup React tab toont correcte code i.p.v. <q />

### DIFF
--- a/packages/storybook/src/DateInputGroup.stories.tsx
+++ b/packages/storybook/src/DateInputGroup.stories.tsx
@@ -95,7 +95,22 @@ function InvalidStory(args: React.ComponentProps<typeof DateInputGroup>) {
 // DEFAULT
 // =============================================================================
 
-export const Default: Story = { render: (args) => <DefaultStory {...args} /> };
+export const Default: Story = {
+  parameters: {
+    docs: {
+      source: {
+        code: `const [value, setValue] = useState<DateInputGroupValue>({
+  day: '',
+  month: '',
+  year: '',
+});
+
+<DateInputGroup id="datum" value={value} onChange={setValue} />`,
+      },
+    },
+  },
+  render: (args) => <DefaultStory {...args} />,
+};
 
 // =============================================================================
 // VARIANTEN


### PR DESCRIPTION
## Summary
- De React tab van de DateInputGroup docs pagina toonde `<q />` in plaats van leesbare React code
- **Oorzaak**: de `Default` story gebruikt `render: (args) => <DefaultStory {...args} />` — een verwijzing naar een externe helper component met `useState`. Storybook's `Source of={storyRef}` kan de code hiervan niet automatisch genereren en produceerde `<q />` als resultaat
- **Fix**: `parameters.docs.source.code` toegevoegd aan de Default story met een handgeschreven, leesbaar code voorbeeld dat laat zien hoe het gecontrolde component gebruikt wordt (incl. useState)

## Test plan
- [ ] DateInputGroup docs pagina: React tab toont nu `const [value, setValue] = useState(...)` + `<DateInputGroup .../>`
- [ ] HTML/CSS tab werkt nog zoals verwacht (statische fallback)
- [ ] CI groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)