### PR TITLE
chore(reset): CSS reset bijgewerkt naar moderne best practices

### DIFF
--- a/packages/core/src/styles/reset.css
+++ b/packages/core/src/styles/reset.css
@@ -21,8 +21,10 @@
 
 /* Document defaults */
 html {
-  /* Prevent font size inflation on iOS */
-  -webkit-text-size-adjust: 100%;
+  /* Prevent font size inflation on mobile browsers */
+  -webkit-text-size-adjust: none;
+  -moz-text-size-adjust: none;
+  text-size-adjust: none;
   /* Smooth scrolling */
   scroll-behavior: smooth;
 }
@@ -96,10 +98,19 @@ h6 {
   overflow-wrap: break-word;
 }
 
-/* List styles */
-ul,
-ol {
-  list-style: none;
+/* Prevent orphaned words on the last line of headings */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-wrap: balance;
+}
+
+/* Scroll margin for anchor links — prevents heading from touching the top edge */
+:target {
+  scroll-margin-block: 5ex;
 }
 
 /* Link styles */


### PR DESCRIPTION
## Summary
- `text-size-adjust: none` i.p.v. `100%` — plus `-moz-` en unprefixed variant toegevoegd voor volledige browser coverage
- `text-wrap: balance` op `h1–h6` — voorkomt losse woorden op de laatste regel van headings
- `:target { scroll-margin-block: 5ex }` — scroll-marge bij anchor links zodat de heading niet tegen de bovenkant plakt
- `ul, ol { list-style: none }` verwijderd — plain `<ul>`/`<ol>` behouden nu hun browser-standaard markers en Safari VoiceOver semantiek; `UnorderedList`/`OrderedList` componenten regelen hun eigen `list-style-type`

Gebaseerd op [A More Modern CSS Reset — Piccalilli](https://piccalil.li/blog/a-more-modern-css-reset/).

Sluit #18.

## Test plan
- [x] 733 tests groen
- [x] Lint schoon (0 errors)
- [x] Alleen `reset.css` gewijzigd

🤖 Generated with [Claude Code](https://claude.com/claude-code)