### PR TITLE
feat(core,button): dsn-visually-hidden + Button icon-only label patroon (#19)

### DIFF
--- a/packages/components-html/src/button/button.css
+++ b/packages/components-html/src/button/button.css
@@ -87,6 +87,19 @@
   padding-inline: var(--dsn-button-size-large-icon-only-padding);
 }
 
+/* Icon Only — hide text label visually, keep accessible for screen readers */
+.dsn-button--icon-only .dsn-button__label {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* =============================================================================
    Focus State (shared across all non-link variants)
    ============================================================================= */

--- a/packages/components-html/src/button/button.html
+++ b/packages/components-html/src/button/button.html
@@ -373,7 +373,6 @@
       <div class="demo-row">
         <button
           class="dsn-button dsn-button--strong dsn-button--size-default dsn-button--icon-only"
-          aria-label="Add"
         >
           <svg
             class="dsn-icon"
@@ -383,15 +382,16 @@
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
+            aria-hidden="true"
           >
             <path d="M12 5l0 14" />
             <path d="M5 12l14 0" />
           </svg>
+          <span class="dsn-button__label">Toevoegen</span>
         </button>
 
         <button
           class="dsn-button dsn-button--default dsn-button--size-default dsn-button--icon-only"
-          aria-label="Settings"
         >
           <svg
             class="dsn-icon"
@@ -401,17 +401,18 @@
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
+            aria-hidden="true"
           >
             <path
               d="M10.325 4.317c.426 -1.756 2.924 -1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543 -.94 3.31 .826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756 .426 1.756 2.924 0 3.35a1.724 1.724 0 0 0 -1.066 2.573c.94 1.543 -.826 3.31 -2.37 2.37a1.724 1.724 0 0 0 -2.572 1.065c-.426 1.756 -2.924 1.756 -3.35 0a1.724 1.724 0 0 0 -2.573 -1.066c-1.543 .94 -3.31 -.826 -2.37 -2.37a1.724 1.724 0 0 0 -1.065 -2.572c-1.756 -.426 -1.756 -2.924 0 -3.35a1.724 1.724 0 0 0 1.066 -2.573c-.94 -1.543 .826 -3.31 2.37 -2.37c1 .608 2.296 .07 2.572 -1.065z"
             />
             <path d="M9 12a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />
           </svg>
+          <span class="dsn-button__label">Instellingen</span>
         </button>
 
         <button
           class="dsn-button dsn-button--subtle dsn-button--size-default dsn-button--icon-only"
-          aria-label="Close"
         >
           <svg
             class="dsn-icon"
@@ -421,15 +422,16 @@
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
+            aria-hidden="true"
           >
             <path d="M18 6l-12 12" />
             <path d="M6 6l12 12" />
           </svg>
+          <span class="dsn-button__label">Sluiten</span>
         </button>
 
         <button
           class="dsn-button dsn-button--strong-negative dsn-button--size-default dsn-button--icon-only"
-          aria-label="Delete"
         >
           <svg
             class="dsn-icon"
@@ -439,6 +441,7 @@
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
+            aria-hidden="true"
           >
             <path d="M4 7l16 0" />
             <path d="M10 11l0 6" />
@@ -446,6 +449,7 @@
             <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12" />
             <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3" />
           </svg>
+          <span class="dsn-button__label">Verwijderen</span>
         </button>
       </div>
 
@@ -453,7 +457,6 @@
       <div class="demo-row">
         <button
           class="dsn-button dsn-button--strong dsn-button--size-small dsn-button--icon-only"
-          aria-label="Add"
         >
           <svg
             class="dsn-icon dsn-icon--sm"
@@ -463,15 +466,16 @@
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
+            aria-hidden="true"
           >
             <path d="M12 5l0 14" />
             <path d="M5 12l14 0" />
           </svg>
+          <span class="dsn-button__label">Toevoegen</span>
         </button>
 
         <button
           class="dsn-button dsn-button--default dsn-button--size-small dsn-button--icon-only"
-          aria-label="Edit"
         >
           <svg
             class="dsn-icon dsn-icon--sm"
@@ -481,6 +485,7 @@
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
+            aria-hidden="true"
           >
             <path
               d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1"
@@ -490,6 +495,7 @@
             />
             <path d="M16 5l3 3" />
           </svg>
+          <span class="dsn-button__label">Bewerken</span>
         </button>
       </div>
     </div>

--- a/packages/components-react/src/Button/Button.test.tsx
+++ b/packages/components-react/src/Button/Button.test.tsx
@@ -61,11 +61,20 @@ describe('Button', () => {
 
   it('applies icon-only class', () => {
     render(
-      <Button iconOnly aria-label="Close">
-        X
+      <Button
+        iconOnly
+        iconStart={
+          <span data-testid="icon" aria-hidden="true">
+            ★
+          </span>
+        }
+      >
+        Sluiten
       </Button>
     );
-    expect(screen.getByRole('button')).toHaveClass('dsn-button--icon-only');
+    expect(screen.getByRole('button', { name: 'Sluiten' })).toHaveClass(
+      'dsn-button--icon-only'
+    );
   });
 
   it('is disabled when disabled prop is set', () => {
@@ -147,9 +156,12 @@ describe('Button', () => {
     );
     const button = screen.getByRole('button');
     const iconStart = button.querySelector('[data-testid="icon-start"]');
+    const label = button.querySelector('.dsn-button__label');
     expect(iconStart).toBeInTheDocument();
-    // Icon should come before text
+    expect(label).toBeInTheDocument();
+    // Icon should come before label
     expect(button.firstChild).toBe(iconStart);
+    expect(button.lastChild).toBe(label);
   });
 
   it('renders iconEnd after children', () => {
@@ -158,8 +170,11 @@ describe('Button', () => {
     );
     const button = screen.getByRole('button');
     const iconEnd = button.querySelector('[data-testid="icon-end"]');
+    const label = button.querySelector('.dsn-button__label');
     expect(iconEnd).toBeInTheDocument();
-    // Icon should come after text
+    expect(label).toBeInTheDocument();
+    // Icon should come after label
+    expect(button.firstChild).toBe(label);
     expect(button.lastChild).toBe(iconEnd);
   });
 
@@ -175,16 +190,42 @@ describe('Button', () => {
     const button = screen.getByRole('button');
     const iconStart = button.querySelector('[data-testid="icon-start"]');
     const iconEnd = button.querySelector('[data-testid="icon-end"]');
+    const label = button.querySelector('.dsn-button__label');
     expect(iconStart).toBeInTheDocument();
     expect(iconEnd).toBeInTheDocument();
+    expect(label).toBeInTheDocument();
     expect(button.firstChild).toBe(iconStart);
     expect(button.lastChild).toBe(iconEnd);
   });
 
-  it('renders without icon props (backward-compatible)', () => {
+  it('wraps children in dsn-button__label span', () => {
     render(<Button>No icons</Button>);
     const button = screen.getByRole('button', { name: 'No icons' });
+    const label = button.querySelector('.dsn-button__label');
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveTextContent('No icons');
     expect(button.childNodes).toHaveLength(1);
+  });
+
+  it('renders no dsn-button__label when children is absent', () => {
+    render(<Button iconStart={<span>★</span>} />);
+    const button = screen.getByRole('button');
+    expect(button.querySelector('.dsn-button__label')).not.toBeInTheDocument();
+  });
+
+  it('icon-only button label is accessible to screen readers', () => {
+    render(
+      <Button iconOnly iconStart={<span aria-hidden="true">★</span>}>
+        Sluiten
+      </Button>
+    );
+    // The button is accessible by its text content (inside dsn-button__label)
+    expect(screen.getByRole('button', { name: 'Sluiten' })).toBeInTheDocument();
+    // The label span is present in the DOM
+    const button = screen.getByRole('button', { name: 'Sluiten' });
+    expect(button.querySelector('.dsn-button__label')).toHaveTextContent(
+      'Sluiten'
+    );
   });
 
   it('shows loader icon instead of iconStart when loading', () => {

--- a/packages/components-react/src/Button/Button.tsx
+++ b/packages/components-react/src/Button/Button.tsx
@@ -91,9 +91,9 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
  *   Confirm
  * </Button>
  *
- * // Icon only
- * <Button variant="subtle" iconOnly aria-label="Close">
- *   <Icon name="x" />
+ * // Icon only — children is the accessible text label, icon via iconStart
+ * <Button variant="subtle" iconOnly iconStart={<Icon name="x" />}>
+ *   Sluiten
  * </Button>
  *
  * // Loading state
@@ -151,7 +151,9 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         {loading ? loaderIcon : iconStart}
-        {children}
+        {children !== undefined && children !== null && (
+          <span className="dsn-button__label">{children}</span>
+        )}
         {iconEnd}
       </button>
     );

--- a/packages/components-react/src/DateInput/DateInput.css
+++ b/packages/components-react/src/DateInput/DateInput.css
@@ -22,19 +22,6 @@
   transform: translateY(-50%);
 }
 
-/* Visually hidden button label — accessible to screen readers, invisible to sighted users */
-.dsn-date-input__button-label {
-  position: absolute;
-  inline-size: 1px;
-  block-size: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
 /* Input — extra padding-inline-end to make room for the calendar button */
 /* Hide the native browser calendar/date picker indicator */
 .dsn-date-input {

--- a/packages/components-react/src/DateInput/DateInput.test.tsx
+++ b/packages/components-react/src/DateInput/DateInput.test.tsx
@@ -116,9 +116,7 @@ describe('DateInput', () => {
 
     it('calendar button has visually hidden label text', () => {
       const { container } = render(<DateInput />);
-      const hiddenLabel = container.querySelector(
-        '.dsn-date-input__button-label'
-      );
+      const hiddenLabel = container.querySelector('.dsn-button__label');
       expect(hiddenLabel).toBeInTheDocument();
       expect(hiddenLabel).toHaveTextContent('Datumkiezer openen');
     });

--- a/packages/components-react/src/DateInput/DateInput.tsx
+++ b/packages/components-react/src/DateInput/DateInput.tsx
@@ -89,15 +89,13 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
             variant="subtle"
             size="small"
             iconOnly
+            iconStart={<Icon name="calendar-event" aria-hidden />}
             className="dsn-date-input__button"
             onClick={handleButtonClick}
             tabIndex={-1}
             aria-hidden="true"
           >
-            <Icon name="calendar-event" aria-hidden />
-            <span className="dsn-date-input__button-label">
-              Datumkiezer openen
-            </span>
+            Datumkiezer openen
           </Button>
         )}
       </div>

--- a/packages/components-react/src/TimeInput/TimeInput.css
+++ b/packages/components-react/src/TimeInput/TimeInput.css
@@ -22,19 +22,6 @@
   transform: translateY(-50%);
 }
 
-/* Visually hidden button label — accessible to screen readers, invisible to sighted users */
-.dsn-time-input__button-label {
-  position: absolute;
-  inline-size: 1px;
-  block-size: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
 /* Input — extra padding-inline-end to make room for the clock button */
 /* Hide the native browser clock/time picker indicator */
 .dsn-time-input {

--- a/packages/components-react/src/TimeInput/TimeInput.test.tsx
+++ b/packages/components-react/src/TimeInput/TimeInput.test.tsx
@@ -115,9 +115,7 @@ describe('TimeInput', () => {
 
     it('clock button has visually hidden label text', () => {
       const { container } = render(<TimeInput />);
-      const hiddenLabel = container.querySelector(
-        '.dsn-time-input__button-label'
-      );
+      const hiddenLabel = container.querySelector('.dsn-button__label');
       expect(hiddenLabel).toBeInTheDocument();
       expect(hiddenLabel).toHaveTextContent('Tijdkiezer openen');
     });

--- a/packages/components-react/src/TimeInput/TimeInput.tsx
+++ b/packages/components-react/src/TimeInput/TimeInput.tsx
@@ -89,15 +89,13 @@ export const TimeInput = React.forwardRef<HTMLInputElement, TimeInputProps>(
             variant="subtle"
             size="small"
             iconOnly
+            iconStart={<Icon name="clock" aria-hidden />}
             className="dsn-time-input__button"
             onClick={handleButtonClick}
             tabIndex={-1}
             aria-hidden="true"
           >
-            <Icon name="clock" aria-hidden />
-            <span className="dsn-time-input__button-label">
-              Tijdkiezer openen
-            </span>
+            Tijdkiezer openen
           </Button>
         )}
       </div>

--- a/packages/core/src/styles/utilities.css
+++ b/packages/core/src/styles/utilities.css
@@ -3,29 +3,17 @@
  * Common utility classes for quick styling
  */
 
-/* Screen reader only - accessible but visually hidden */
-.sr-only {
+/* Visually hidden — accessible but not visible */
+.dsn-visually-hidden {
   position: absolute;
-  width: 1px;
-  height: 1px;
+  inline-size: 1px;
+  block-size: 1px;
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
-  border-width: 0;
-}
-
-/* Not screen reader only - show element */
-.not-sr-only {
-  position: static;
-  width: auto;
-  height: auto;
-  padding: 0;
-  margin: 0;
-  overflow: visible;
-  clip: auto;
-  white-space: normal;
+  border: 0;
 }
 
 /* Display utilities */

--- a/packages/storybook/src/Button.docs.md
+++ b/packages/storybook/src/Button.docs.md
@@ -28,7 +28,7 @@ De Button component biedt een consistente, toegankelijke manier om acties te tri
 - **Gebruik duidelijke, actieve labels.** Schrijf labels als werkwoorden: "Opslaan", "Verwijderen", "Volgende". Vermijd vage labels als "OK" of "Klik hier".
 - **Gebruik sentiment-varianten bewust.** Reserveer `strong-negative` voor destructieve acties (verwijderen, annuleren) en `strong-positive` voor bevestigende acties (goedkeuren, voltooien).
 - **Iconen verduidelijken, niet versieren.** Voeg alleen een icoon toe als het de betekenis van de actie versterkt. Gebruik `iconStart` voor acties (bijv. prullenbak + "Verwijderen") en `iconEnd` voor richtingen (bijv. "Volgende" + pijl).
-- **Icon-only buttons vereisen een `aria-label`.** Zonder zichtbare tekst moet een toegankelijk label aanwezig zijn.
+- **Icon-only buttons vereisen een toegankelijke tekstlabel.** Geef de tekst mee als `children` — de button verbergt dit visueel via `dsn-button__label`, maar schermlezers lezen het voor. Gebruik `iconStart` of `iconEnd` voor het icoon. Gebruik geen `aria-label` op de button — dit wordt niet vertaald door browser-vertaaltools.
 - **Gebruik `loading` voor asynchrone acties.** Toon de loading state wanneer de actie tijd kost (bijv. formulier versturen). De button wordt automatisch `disabled` tijdens loading.
 - **Respecteer minimale aanraakdoelen.** De button garandeert een minimale touch target van 48×48px (WCAG 2.5.5).
 


### PR DESCRIPTION
## Summary

- `dsn-visually-hidden` utility class toegevoegd aan `utilities.css` (hernoemt `.sr-only`, logical properties + `clip-path: inset(50%)`)
- `dsn-button__label` patroon: `children` altijd gewrapt in `<span class="dsn-button__label">`, CSS-combinator `.dsn-button--icon-only .dsn-button__label` verbergt het visueel
- TimeInput + DateInput gemigreerd naar `iconStart` voor het icoon, tekst via `children` — component-specifieke hidden label CSS verwijderd
- `button.html` demo bijgewerkt met nieuw patroon (geen `aria-label` meer op icon-only buttons)
- Button JSDoc + `Button.docs.md` bijgewerkt

Sluit #19

## Test plan

- [x] 735 tests groen (38 suites)
- [x] TypeScript schoon op `components-react`
- [x] Storybook bekijken (Button icon-only stories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)