### PR TITLE
fix(Select): chevron icon valt buiten de select box bij XL en Full width

### DIFF
--- a/packages/components-react/src/Select/Select.css
+++ b/packages/components-react/src/Select/Select.css
@@ -29,6 +29,7 @@
 /* Select — reset browser defaults, hide native arrow, add padding for custom icon */
 /* Also override :read-only styles from dsn-text-input, because browsers consider
    <select> as :read-only (non-typeable), which incorrectly triggers those styles. */
+/* max-inline-size is set to none so the wrapper controls the width, not the select itself. */
 .dsn-select {
   appearance: none;
   background-color: var(--dsn-text-input-background-color);
@@ -36,6 +37,7 @@
     var(--dsn-text-input-border-color);
   color: var(--dsn-text-input-color);
   cursor: pointer;
+  max-inline-size: none;
   padding-inline-end: var(--dsn-select-padding-inline-end-with-icon);
 }
 


### PR DESCRIPTION
## Summary
- De `<select>` erft `max-inline-size: 25rem` van `dsn-text-input`
- Bij `width-xl` (48ch) en `width-full` (100%) is de wrapper breder dan 25rem, waardoor de select korter is dan de wrapper en het chevron-icoon erbuiten valt
- Fix: `max-inline-size: none` toegevoegd aan `.dsn-select` zodat de wrapper de breedte bepaalt

## Test plan
- [x] Select width varianten visueel gecontroleerd (XS t/m Full)
- [x] Chevron-icoon staat correct binnen de select box bij alle varianten
- [x] Tests groen
- [x] Build slaagt

🤖 Generated with [Claude Code](https://claude.com/claude-code)