### PR TITLE
fix(Link): geen underline bij disabled + externe linktekst in het Nederlands

### DIFF
--- a/packages/components-html/src/link/link.css
+++ b/packages/components-html/src/link/link.css
@@ -97,6 +97,7 @@
 /* Disabled */
 .dsn-link[aria-disabled='true'] {
   color: var(--dsn-link-disabled-color);
+  text-decoration-line: none;
   cursor: not-allowed;
   pointer-events: none;
 }

--- a/packages/components-react/src/Link/Link.test.tsx
+++ b/packages/components-react/src/Link/Link.test.tsx
@@ -287,21 +287,21 @@ describe('Link', () => {
       );
     });
 
-    it('adds visible "(opens in new tab)" hint when external', () => {
+    it('adds visible "(opent nieuw tabblad)" hint when external', () => {
       render(
         <Link href="https://example.com" external>
           External
         </Link>
       );
       const link = screen.getByRole('link');
-      expect(link).toHaveTextContent('External (opens in new tab)');
+      expect(link).toHaveTextContent('External (opent nieuw tabblad)');
     });
 
     it('does not add hint text when not external', () => {
       render(<Link href="/about">About</Link>);
       const link = screen.getByRole('link');
       expect(link).toHaveTextContent('About');
-      expect(link.textContent).not.toContain('opens in new tab');
+      expect(link.textContent).not.toContain('opent nieuw tabblad');
     });
 
     it('allows overriding target when external', () => {
@@ -336,7 +336,7 @@ describe('Link', () => {
       expect(
         link.querySelector('[data-testid="custom-icon"]')
       ).toBeInTheDocument();
-      expect(link).toHaveTextContent('External (opens in new tab)');
+      expect(link).toHaveTextContent('External (opent nieuw tabblad)');
     });
   });
 });

--- a/packages/components-react/src/Link/Link.tsx
+++ b/packages/components-react/src/Link/Link.tsx
@@ -36,7 +36,7 @@ export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement>
   /**
    * Whether the link opens in a new tab.
    * Automatically adds target="_blank", rel="noopener noreferrer",
-   * and an inline "(opens in new tab)" hint.
+   * and an inline "(opent nieuw tabblad)" hint.
    * @default false
    */
   external?: boolean;
@@ -143,7 +143,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       >
         {iconStart}
         {children}
-        {external && ' (opens in new tab)'}
+        {external && ' (opent nieuw tabblad)'}
         {iconEnd}
       </a>
     );


### PR DESCRIPTION
## Summary
- `text-decoration-line: none` toegevoegd aan de disabled state — zo vertrouwen we niet alleen op kleur om de staat over te brengen
- Externe linktekst vertaald van `(opens in new tab)` naar `(opent nieuw tabblad)`
- Tests bijgewerkt voor de nieuwe Nederlandse tekst

## Test plan
- [x] Link disabled: geen underline zichtbaar
- [x] Link external: toont `(opent nieuw tabblad)`
- [x] Tests groen
- [x] Build slaagt

🤖 Generated with [Claude Code](https://claude.com/claude-code)