### PR TITLE
docs(Link): documentatie bijwerken na disabled underline + externe linktekst fixes

### DIFF
--- a/packages/storybook/src/Link.docs.md
+++ b/packages/storybook/src/Link.docs.md
@@ -25,7 +25,7 @@ De Link component biedt een consistente, toegankelijke manier om hyperlinks weer
 
 - **Gebruik beschrijvende linkteksten.** Vermijd "klik hier" of "lees meer". Gebruik in plaats daarvan beschrijvende tekst zoals "Bekijk onze prijzen" of "Lees de volledige documentatie".
 - **Markeer de huidige pagina.** Gebruik de `current` prop voor links die naar de huidige pagina wijzen (bijv. in navigatie).
-- **External links krijgen automatisch een hint.** De `external` prop voegt automatisch "(opens in new tab)" toe. Dit is belangrijk voor toegankelijkheid — gebruikers moeten weten dat ze de huidige context verlaten.
+- **External links krijgen automatisch een hint.** De `external` prop voegt automatisch "(opent nieuw tabblad)" toe. Dit is belangrijk voor toegankelijkheid — gebruikers moeten weten dat ze de huidige context verlaten.
 - **Iconen verduidelijken betekenis.** Gebruik `iconStart` voor acties (download, external link) en `iconEnd` voor richtingen (volgende pagina, externe site).
 - **Gebruik inline links zonder size.** Voor links in lopende tekst, laat de `size` prop weg zodat de link de lettergrootte van de omliggende tekst erft.
 - **Test keyboard navigatie.** Links moeten focusbaar zijn met Tab en activeerbaar met Enter.
@@ -61,6 +61,6 @@ De Link component biedt een consistente, toegankelijke manier om hyperlinks weer
 - Links gebruiken het semantische `<a>` HTML element met correcte `href` attributen.
 - Disabled links krijgen `aria-disabled="true"` en `tabIndex={-1}` om ze uit de tab order te halen.
 - Current page links krijgen `aria-current="page"` zodat screenreaders de huidige locatie kunnen aankondigen.
-- External links bevatten zichtbare tekst "(opens in new tab)" voor alle gebruikers, niet alleen screenreaders.
+- External links bevatten zichtbare tekst "(opent nieuw tabblad)" voor alle gebruikers, niet alleen screenreaders.
 - Links hebben een duidelijke focus state met outline voor keyboard navigatie.
-- De onderlijning helpt gebruikers met kleurenblindheid om links te herkennen.
+- De onderlijning helpt gebruikers met kleurenblindheid om links te herkennen. Disabled links hebben geen onderlijning — zo wordt de disabled staat niet alleen via kleur overgebracht.

--- a/packages/storybook/src/Link.stories.tsx
+++ b/packages/storybook/src/Link.stories.tsx
@@ -83,7 +83,7 @@ const meta: Meta<typeof Link> = {
         if (args.disabled)
           attrParts.push('aria-disabled="true"', 'tabindex="-1"');
         if (args.current) attrParts.push('aria-current="page"');
-        const text = `${args.children ?? 'Linktekst'}${args.external ? ' (opens in new tab)' : ''}`;
+        const text = `${args.children ?? 'Linktekst'}${args.external ? ' (opent nieuw tabblad)' : ''}`;
         return `<a ${attrParts.join(' ')}>${text}</a>`;
       },
     },


### PR DESCRIPTION
## Summary
- `(opens in new tab)` vervangen door `(opent nieuw tabblad)` in docs en htmlTemplate
- Accessibility sectie uitgebreid: disabled links hebben geen onderlijning zodat de staat niet alleen via kleur wordt overgebracht

Documentatie follow-up op #44.

## Test plan
- [x] Link docs in Storybook tonen de juiste Nederlandse tekst
- [x] Build slaagt

🤖 Generated with [Claude Code](https://claude.com/claude-code)