### PR TITLE
feat(ButtonLink): semantisch een <a>, visueel een Button

### DIFF
--- a/packages/components-html/src/button-link/button-link.css
+++ b/packages/components-html/src/button-link/button-link.css
@@ -1,0 +1,21 @@
+/**
+ * ButtonLink Component
+ * Resets <a> styles so the element uses dsn-button appearance.
+ * Always combine with dsn-button, dsn-button--{variant}, and dsn-button--size-{size}:
+ *   <a class="dsn-button dsn-button--strong dsn-button--size-default dsn-button-link" href="/">Label</a>
+ */
+
+.dsn-button-link {
+  /* Anchor reset — dsn-button handles most resets already */
+  text-decoration: none; /* Safety net: mocht dsn-button dit ooit weglaten */
+}
+
+/* Disabled staat via aria-disabled — <a> heeft geen native :disabled.
+   dsn-button:disabled matcht niet op <a>, dus we repliceren de stijlen handmatig.
+   pointer-events: none blokkeert ook hover/active (Button's :not(:disabled) matcht
+   altijd op <a>, dus we kunnen niet op die guards vertrouwen). */
+.dsn-button-link[aria-disabled='true'] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}

--- a/packages/components-react/src/ButtonLink/ButtonLink.css
+++ b/packages/components-react/src/ButtonLink/ButtonLink.css
@@ -1,0 +1,6 @@
+/**
+ * ButtonLink Component Styles for React
+ * Re-exports the base ButtonLink styles from components-html
+ */
+
+@import '../../../components-html/src/button-link/button-link.css';

--- a/packages/components-react/src/ButtonLink/ButtonLink.test.tsx
+++ b/packages/components-react/src/ButtonLink/ButtonLink.test.tsx
@@ -1,0 +1,309 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { ButtonLink } from './ButtonLink';
+
+describe('ButtonLink', () => {
+  // ---------------------------------------------------------------------------
+  // Rendering
+  // ---------------------------------------------------------------------------
+
+  it('renders as an anchor element', () => {
+    render(<ButtonLink href="/test">Label</ButtonLink>);
+    expect(screen.getByRole('link')).toBeInTheDocument();
+  });
+
+  it('renders children wrapped in dsn-button__label', () => {
+    render(<ButtonLink href="/test">Label</ButtonLink>);
+    const label = screen.getByText('Label');
+    expect(label.tagName).toBe('SPAN');
+    expect(label).toHaveClass('dsn-button__label');
+  });
+
+  it('does not render dsn-button__label when children is undefined', () => {
+    const { container } = render(<ButtonLink href="/test" />);
+    expect(container.querySelector('.dsn-button__label')).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Base classes
+  // ---------------------------------------------------------------------------
+
+  it('applies base classes by default', () => {
+    render(<ButtonLink href="/test">Label</ButtonLink>);
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('dsn-button');
+    expect(link).toHaveClass('dsn-button--strong');
+    expect(link).toHaveClass('dsn-button--size-default');
+    expect(link).toHaveClass('dsn-button-link');
+  });
+
+  it('applies custom className alongside base classes', () => {
+    render(
+      <ButtonLink href="/test" className="custom-class">
+        Label
+      </ButtonLink>
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('dsn-button');
+    expect(link).toHaveClass('custom-class');
+  });
+
+  // ---------------------------------------------------------------------------
+  // href
+  // ---------------------------------------------------------------------------
+
+  it('sets href when not disabled', () => {
+    render(<ButtonLink href="/go">Label</ButtonLink>);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/go');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Variant
+  // ---------------------------------------------------------------------------
+
+  it.each([
+    'strong',
+    'strong-negative',
+    'strong-positive',
+    'default',
+    'default-negative',
+    'default-positive',
+    'subtle',
+    'subtle-negative',
+    'subtle-positive',
+  ] as const)('applies variant class for "%s"', (variant) => {
+    render(
+      <ButtonLink href="/test" variant={variant}>
+        Label
+      </ButtonLink>
+    );
+    expect(screen.getByRole('link')).toHaveClass(`dsn-button--${variant}`);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Size
+  // ---------------------------------------------------------------------------
+
+  it.each(['small', 'default', 'large'] as const)(
+    'applies size class for "%s"',
+    (size) => {
+      render(
+        <ButtonLink href="/test" size={size}>
+          Label
+        </ButtonLink>
+      );
+      expect(screen.getByRole('link')).toHaveClass(`dsn-button--size-${size}`);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // fullWidth
+  // ---------------------------------------------------------------------------
+
+  it('applies dsn-button--full-width when fullWidth is true', () => {
+    render(
+      <ButtonLink href="/test" fullWidth>
+        Label
+      </ButtonLink>
+    );
+    expect(screen.getByRole('link')).toHaveClass('dsn-button--full-width');
+  });
+
+  it('does not apply dsn-button--full-width by default', () => {
+    render(<ButtonLink href="/test">Label</ButtonLink>);
+    expect(screen.getByRole('link')).not.toHaveClass('dsn-button--full-width');
+  });
+
+  // ---------------------------------------------------------------------------
+  // iconOnly
+  // ---------------------------------------------------------------------------
+
+  it('applies dsn-button--icon-only when iconOnly is true', () => {
+    render(
+      <ButtonLink href="/test" iconOnly>
+        Label
+      </ButtonLink>
+    );
+    expect(screen.getByRole('link')).toHaveClass('dsn-button--icon-only');
+  });
+
+  it('does not apply dsn-button--icon-only by default', () => {
+    render(<ButtonLink href="/test">Label</ButtonLink>);
+    expect(screen.getByRole('link')).not.toHaveClass('dsn-button--icon-only');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Icons
+  // ---------------------------------------------------------------------------
+
+  it('renders iconStart before the label', () => {
+    const { container } = render(
+      <ButtonLink href="/test" iconStart={<svg data-testid="icon-start" />}>
+        Label
+      </ButtonLink>
+    );
+    const children = Array.from(container.querySelector('a')!.childNodes);
+    const iconIndex = children.findIndex(
+      (n) => (n as Element).getAttribute?.('data-testid') === 'icon-start'
+    );
+    const labelIndex = children.findIndex((n) =>
+      (n as Element).classList?.contains('dsn-button__label')
+    );
+    expect(iconIndex).toBeLessThan(labelIndex);
+  });
+
+  it('renders iconEnd after the label', () => {
+    const { container } = render(
+      <ButtonLink href="/test" iconEnd={<svg data-testid="icon-end" />}>
+        Label
+      </ButtonLink>
+    );
+    const children = Array.from(container.querySelector('a')!.childNodes);
+    const labelIndex = children.findIndex((n) =>
+      (n as Element).classList?.contains('dsn-button__label')
+    );
+    const iconIndex = children.findIndex(
+      (n) => (n as Element).getAttribute?.('data-testid') === 'icon-end'
+    );
+    expect(iconIndex).toBeGreaterThan(labelIndex);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Disabled
+  // ---------------------------------------------------------------------------
+
+  it('sets aria-disabled and tabIndex=-1 when disabled', () => {
+    const { container } = render(
+      <ButtonLink href="/test" disabled>
+        Label
+      </ButtonLink>
+    );
+    // <a> without href has no ARIA role "link" — query the DOM directly
+    const link = container.querySelector('a')!;
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(link).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('removes href when disabled', () => {
+    const { container } = render(
+      <ButtonLink href="/test" disabled>
+        Label
+      </ButtonLink>
+    );
+    // <a> without href has no ARIA role "link" — query the DOM directly
+    const link = container.querySelector('a')!;
+    expect(link).not.toHaveAttribute('href');
+  });
+
+  it('prevents navigation when disabled and clicked', () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <ButtonLink href="/test" disabled onClick={onClick}>
+        Label
+      </ButtonLink>
+    );
+    // pointer-events: none prevents userEvent.click — use fireEvent to test
+    // that the React onClick handler also guards against disabled clicks
+    const link = container.querySelector('a')!;
+    fireEvent.click(link);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('does not set aria-disabled when not disabled', () => {
+    render(<ButtonLink href="/test">Label</ButtonLink>);
+    expect(screen.getByRole('link')).not.toHaveAttribute('aria-disabled');
+  });
+
+  // ---------------------------------------------------------------------------
+  // External
+  // ---------------------------------------------------------------------------
+
+  it('sets target="_blank" and rel="noopener noreferrer" when external', () => {
+    render(
+      <ButtonLink href="https://example.com" external>
+        Label
+      </ButtonLink>
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders "(opent nieuw tabblad)" text when external', () => {
+    render(
+      <ButtonLink href="https://example.com" external>
+        Label
+      </ButtonLink>
+    );
+    expect(screen.getByText(/opent nieuw tabblad/)).toBeInTheDocument();
+  });
+
+  it('respects explicit target override when external', () => {
+    render(
+      <ButtonLink href="https://example.com" external target="_self">
+        Label
+      </ButtonLink>
+    );
+    expect(screen.getByRole('link')).toHaveAttribute('target', '_self');
+  });
+
+  it('respects explicit rel override when external', () => {
+    render(
+      <ButtonLink href="https://example.com" external rel="noreferrer">
+        Label
+      </ButtonLink>
+    );
+    expect(screen.getByRole('link')).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('does not render "(opent nieuw tabblad)" when not external', () => {
+    render(<ButtonLink href="/test">Label</ButtonLink>);
+    expect(screen.queryByText(/opent nieuw tabblad/)).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // onClick
+  // ---------------------------------------------------------------------------
+
+  it('calls onClick when clicked and not disabled', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <ButtonLink href="/test" onClick={onClick}>
+        Label
+      </ButtonLink>
+    );
+    await user.click(screen.getByRole('link'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Ref forwarding
+  // ---------------------------------------------------------------------------
+
+  it('forwards ref to the anchor element', () => {
+    const ref = React.createRef<HTMLAnchorElement>();
+    render(
+      <ButtonLink href="/test" ref={ref}>
+        Label
+      </ButtonLink>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Additional HTML attributes
+  // ---------------------------------------------------------------------------
+
+  it('passes additional HTML attributes to the anchor', () => {
+    render(
+      <ButtonLink href="/test" data-testid="my-link" aria-label="Go">
+        Label
+      </ButtonLink>
+    );
+    const link = screen.getByTestId('my-link');
+    expect(link).toHaveAttribute('aria-label', 'Go');
+  });
+});

--- a/packages/components-react/src/ButtonLink/ButtonLink.tsx
+++ b/packages/components-react/src/ButtonLink/ButtonLink.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import './ButtonLink.css';
+
+export type ButtonLinkVariant =
+  | 'strong'
+  | 'strong-negative'
+  | 'strong-positive'
+  | 'default'
+  | 'default-negative'
+  | 'default-positive'
+  | 'subtle'
+  | 'subtle-negative'
+  | 'subtle-positive';
+
+export type ButtonLinkSize = 'small' | 'default' | 'large';
+
+export interface ButtonLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  /**
+   * Navigation URL
+   */
+  href?: string;
+
+  /**
+   * Visual style — same variants as Button (excl. 'link')
+   * @default 'strong'
+   */
+  variant?: ButtonLinkVariant;
+
+  /**
+   * Button size
+   * @default 'default'
+   */
+  size?: ButtonLinkSize;
+
+  /**
+   * Whether the button-link takes full width of container
+   * @default false
+   */
+  fullWidth?: boolean;
+
+  /**
+   * Whether button-link contains only an icon (hides label text visually)
+   * @default false
+   */
+  iconOnly?: boolean;
+
+  /**
+   * Icon element rendered before the label text
+   */
+  iconStart?: React.ReactNode;
+
+  /**
+   * Icon element rendered after the label text
+   */
+  iconEnd?: React.ReactNode;
+
+  /**
+   * Whether the link is disabled.
+   * Maps to aria-disabled="true" + tabIndex={-1} + prevents navigation.
+   * <a> has no native disabled attribute.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * Whether the link opens in a new tab.
+   * Automatically adds target="_blank", rel="noopener noreferrer",
+   * and an inline "(opent nieuw tabblad)" hint — same behaviour as Link.
+   * @default false
+   */
+  external?: boolean;
+
+  /**
+   * Additional CSS class names
+   */
+  className?: string;
+
+  /**
+   * Link content (wrapped in dsn-button__label, same as Button)
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * ButtonLink — semantically an <a>, visually styled as a Button.
+ *
+ * Use when an action navigates to a URL but needs the visual prominence of a Button.
+ *
+ * @example
+ * ```tsx
+ * // Basic usage (strong, default size)
+ * <ButtonLink href="/volgende">Volgende stap</ButtonLink>
+ *
+ * // Subtle variant
+ * <ButtonLink href="/" variant="subtle">Terug naar overzicht</ButtonLink>
+ *
+ * // With icon
+ * <ButtonLink href="/download" iconStart={<Icon name="download" aria-hidden />}>
+ *   Download rapport
+ * </ButtonLink>
+ *
+ * // Icon-only
+ * <ButtonLink href="/info" iconOnly iconStart={<Icon name="info-circle" aria-hidden />}>
+ *   Meer informatie
+ * </ButtonLink>
+ *
+ * // Disabled
+ * <ButtonLink href="/dashboard" disabled>Niet beschikbaar</ButtonLink>
+ *
+ * // Opens in new tab with visible hint
+ * <ButtonLink href="https://example.com" external>Externe pagina</ButtonLink>
+ * ```
+ */
+export const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
+  (
+    {
+      href,
+      variant = 'strong',
+      size = 'default',
+      fullWidth = false,
+      iconOnly = false,
+      iconStart,
+      iconEnd,
+      disabled = false,
+      external = false,
+      className,
+      target,
+      rel,
+      tabIndex,
+      children,
+      onClick,
+      ...props
+    },
+    ref
+  ) => {
+    const classes = classNames(
+      'dsn-button',
+      `dsn-button--${variant}`,
+      `dsn-button--size-${size}`,
+      fullWidth && 'dsn-button--full-width',
+      iconOnly && 'dsn-button--icon-only',
+      'dsn-button-link',
+      className
+    );
+
+    const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+      if (disabled) {
+        e.preventDefault();
+        return;
+      }
+      onClick?.(e);
+    };
+
+    // External links: set target and rel automatically, unless explicitly overridden
+    const resolvedTarget = external ? (target ?? '_blank') : target;
+    const resolvedRel = external ? (rel ?? 'noopener noreferrer') : rel;
+
+    return (
+      <a
+        ref={ref}
+        className={classes}
+        href={disabled ? undefined : href}
+        target={resolvedTarget}
+        rel={resolvedRel}
+        tabIndex={disabled ? -1 : tabIndex}
+        aria-disabled={disabled || undefined}
+        onClick={handleClick}
+        {...props}
+      >
+        {iconStart}
+        {children !== undefined && children !== null && (
+          <span className="dsn-button__label">{children}</span>
+        )}
+        {external && ' (opent nieuw tabblad)'}
+        {iconEnd}
+      </a>
+    );
+  }
+);
+
+ButtonLink.displayName = 'ButtonLink';

--- a/packages/components-react/src/ButtonLink/index.ts
+++ b/packages/components-react/src/ButtonLink/index.ts
@@ -1,0 +1,6 @@
+export { ButtonLink } from './ButtonLink';
+export type {
+  ButtonLinkProps,
+  ButtonLinkVariant,
+  ButtonLinkSize,
+} from './ButtonLink';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -14,6 +14,7 @@ export * from './OrderedList';
 
 // Buttons & Icons
 export * from './Button';
+export * from './ButtonLink';
 export * from './LinkButton';
 export * from './Icon';
 

--- a/packages/storybook/src/ButtonLink.docs.md
+++ b/packages/storybook/src/ButtonLink.docs.md
@@ -1,0 +1,55 @@
+# ButtonLink
+
+Een link die semantisch een `<a>` is, maar visueel het uiterlijk van een [Button](/docs/components-button--docs) heeft.
+
+## Doel
+
+`ButtonLink` verhoogt de attentiewaarde van een navigatieactie op plekken waar een gewone [Link](/docs/components-link--docs) te weinig prominentie heeft. Gebruik het wanneer een actie naar een andere pagina of URL navigeert — dus een echte `<a href>` nodig is — maar de visuele prominentie van een Button beter aansluit bij de context.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- De actie naar een andere pagina of URL navigeert en de visuele prominentie van een Button gewenst is.
+- Je een primaire call-to-action wilt tonen die de gebruiker doorstuurt naar een volgende stap, zoals "Start aanvraag" of "Download rapport".
+- Je in een landingspagina of een meerstappenformulier een prominente CTA nodig hebt die wél een echte link is.
+
+## Don't use when
+
+- De actie een JavaScript-handler of form-submit vereist en niet navigeert — gebruik dan de [Button](/docs/components-button--docs) component.
+- Je een knop wilt met een lage attentiewaarde die navigeert — gebruik dan de [Link](/docs/components-link--docs) component.
+- Je JS-acties met een lage visuele prominentie wilt — gebruik dan de [LinkButton](/docs/components-linkbutton--docs) component.
+- Je een echte `<button>` nodig hebt maar het eruit wil laten zien als een link — gebruik dan `LinkButton`, nooit een `<button>` met `href`.
+
+## Best practices
+
+- **Gebruik beschrijvende teksten.** Vermijd "klik hier". Gebruik teksten die de bestemming of actie beschrijven, zoals "Download rapport" of "Start aanvraag".
+- **Gebruik `strong` voor primaire CTA's.** Gebruik `default` of `subtle` voor secundaire navigatieacties die minder nadruk nodig hebben.
+- **Gebruik `external` voor links die in een nieuw tabblad openen.** De prop voegt automatisch `target="_blank"`, `rel="noopener noreferrer"` en de zichtbare aanduiding "(opent nieuw tabblad)" toe.
+- **Iconen verduidelijken betekenis.** Gebruik `iconEnd` met een pijl voor "volgende stap"-acties, `iconStart` voor downloads of specifieke acties.
+- **Geen `loading` state.** `ButtonLink` navigeert naar een URL. Een laadspinner past niet bij een navigatieactie; gebruik Button als je een loading state nodig hebt.
+
+## Accessibility
+
+- Semantisch een `<a>` — screenreaders kondigen het element aan als "link", niet als "knop". Gebruikers weten daardoor dat de actie navigatie veroorzaakt.
+- `disabled` werkt via `aria-disabled="true"` + `tabIndex={-1}` — `<a>` heeft geen native `disabled` attribuut.
+- `iconOnly` via `dsn-button__label` — tekst visueel verborgen maar beschikbaar voor screenreaders. Gebruik altijd beschrijvende `children` als toegankelijke naam.
+- Iconen zijn altijd decoratief (`aria-hidden="true"`).
+- `external` voegt zichtbare tekst "(opent nieuw tabblad)" toe voor alle gebruikers, niet alleen screenreaders.
+
+## Design tokens
+
+`ButtonLink` erft alle `--dsn-button-*` tokens van het [Button](/docs/components-button--docs) component via de `dsn-button` en `dsn-button--{variant}` klassen. Er zijn geen eigen componenttokens.
+
+| Token                                   | Beschrijving                        |
+| --------------------------------------- | ----------------------------------- |
+| `--dsn-button-strong-background-color`  | Achtergrondkleur strong variant     |
+| `--dsn-button-strong-color`             | Tekstkleur strong variant           |
+| `--dsn-button-strong-border-color`      | Randkleur strong variant            |
+| `--dsn-button-default-background-color` | Achtergrondkleur default variant    |
+| `--dsn-button-default-color`            | Tekstkleur default variant          |
+| `--dsn-button-subtle-background-color`  | Achtergrondkleur subtle variant     |
+| `--dsn-button-subtle-color`             | Tekstkleur subtle variant           |
+| `--dsn-button-size-small-*`             | Grootte-tokens voor small variant   |
+| `--dsn-button-size-default-*`           | Grootte-tokens voor default variant |
+| `--dsn-button-size-large-*`             | Grootte-tokens voor large variant   |

--- a/packages/storybook/src/ButtonLink.docs.mdx
+++ b/packages/storybook/src/ButtonLink.docs.mdx
@@ -1,0 +1,25 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as ButtonLinkStories from './ButtonLink.stories';
+import docs from './ButtonLink.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={ButtonLinkStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={ButtonLinkStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={ButtonLinkStories.Default}
+  html={`<a class="dsn-button dsn-button--strong dsn-button--size-default dsn-button-link" href="/">\n  <span class="dsn-button__label">Knoptekst</span>\n</a>`}
+/>
+
+<Controls of={ButtonLinkStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/ButtonLink.stories.tsx
+++ b/packages/storybook/src/ButtonLink.stories.tsx
@@ -1,0 +1,347 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ButtonLink, Icon } from '@dsn/components-react';
+import type { IconName } from '@dsn/components-react/icon-registry.generated';
+import DocsPage from './ButtonLink.docs.mdx';
+import {
+  TEKST,
+  WEINIG_TEKST,
+  VEEL_TEKST,
+  TEKST_AR,
+  VEEL_TEKST_AR,
+  rtlDecorator,
+} from './story-helpers';
+
+const iconOptions: (IconName | undefined)[] = [
+  undefined,
+  'alert-triangle',
+  'archive',
+  'arrow-down',
+  'arrow-left',
+  'arrow-narrow-down',
+  'arrow-narrow-up',
+  'arrow-right',
+  'arrow-up',
+  'bell',
+  'calendar-event',
+  'check',
+  'chevron-down',
+  'chevron-left',
+  'chevron-right',
+  'chevron-up',
+  'circle-check',
+  'clock',
+  'dots-vertical',
+  'download',
+  'edit',
+  'exclamation-circle',
+  'external-link',
+  'eye',
+  'file-description',
+  'folder',
+  'heart-filled',
+  'heart',
+  'home',
+  'info-circle',
+  'loader',
+  'mail',
+  'menu',
+  'message-circle',
+  'minus',
+  'paperclip',
+  'plus',
+  'search',
+  'selector',
+  'settings',
+  'star-filled',
+  'star',
+  'trash',
+  'upload',
+  'user',
+  'x',
+];
+
+const meta: Meta<typeof ButtonLink> = {
+  title: 'Components/ButtonLink',
+  component: ButtonLink,
+  parameters: {
+    docs: {
+      page: DocsPage,
+    },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = [
+          'dsn-button',
+          `dsn-button--${args.variant ?? 'strong'}`,
+          `dsn-button--size-${args.size ?? 'default'}`,
+          args.fullWidth && 'dsn-button--full-width',
+          args.iconOnly && 'dsn-button--icon-only',
+          'dsn-button-link',
+        ]
+          .filter(Boolean)
+          .join(' ');
+
+        const href = !args.disabled ? ` href="${args.href ?? '/'}"` : '';
+        const disabled = args.disabled
+          ? ` aria-disabled="true" tabindex="-1"`
+          : '';
+        const target = args.external ? ` target="_blank"` : '';
+        const rel = args.external ? ` rel="noopener noreferrer"` : '';
+
+        const iconStart = args.iconStart
+          ? `\n  <svg class="dsn-icon" aria-hidden="true"><!-- icon --></svg>`
+          : '';
+        const text = args.children ?? 'Knoptekst';
+        const label = `\n  <span class="dsn-button__label">${text}</span>`;
+        const externalText = args.external ? '\n  (opent nieuw tabblad)' : '';
+        const iconEnd = args.iconEnd
+          ? `\n  <svg class="dsn-icon" aria-hidden="true"><!-- icon --></svg>`
+          : '';
+
+        return `<a class="${cls}"${href}${target}${rel}${disabled}>${iconStart}${label}${externalText}${iconEnd}\n</a>`;
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: [
+        'strong',
+        'default',
+        'subtle',
+        'strong-negative',
+        'default-negative',
+        'subtle-negative',
+        'strong-positive',
+        'default-positive',
+        'subtle-positive',
+      ],
+    },
+    size: {
+      control: 'select',
+      options: ['small', 'default', 'large'],
+    },
+    fullWidth: { control: 'boolean' },
+    iconOnly: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    external: { control: 'boolean' },
+    href: { control: 'text' },
+    iconStart: {
+      control: 'select',
+      options: iconOptions,
+      mapping: iconOptions.reduce(
+        (acc, icon) => {
+          acc[icon ?? 'undefined'] = icon ? (
+            <Icon name={icon} aria-hidden />
+          ) : undefined;
+          return acc;
+        },
+        {} as Record<string, React.ReactNode>
+      ),
+    },
+    iconEnd: {
+      control: 'select',
+      options: iconOptions,
+      mapping: iconOptions.reduce(
+        (acc, icon) => {
+          acc[icon ?? 'undefined'] = icon ? (
+            <Icon name={icon} aria-hidden />
+          ) : undefined;
+          return acc;
+        },
+        {} as Record<string, React.ReactNode>
+      ),
+    },
+  },
+  args: {
+    children: TEKST,
+    href: '/',
+    variant: 'strong',
+    size: 'default',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ButtonLink>;
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {};
+
+// =============================================================================
+// VARIANTEN
+// =============================================================================
+
+export const DefaultVariant: Story = {
+  name: 'Default variant',
+  args: { variant: 'default' },
+};
+
+export const Subtle: Story = {
+  args: { variant: 'subtle' },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const External: Story = {
+  args: { href: 'https://example.com', external: true },
+};
+
+export const WithIconStart: Story = {
+  name: 'With icon start',
+  args: { iconStart: <Icon name="arrow-left" aria-hidden /> },
+};
+
+export const WithIconEnd: Story = {
+  name: 'With icon end',
+  args: { iconEnd: <Icon name="arrow-right" aria-hidden /> },
+};
+
+export const IconOnly: Story = {
+  name: 'Icon only',
+  args: {
+    iconOnly: true,
+    iconStart: <Icon name="download" aria-hidden />,
+    children: 'Download',
+  },
+};
+
+// =============================================================================
+// OVERZICHTSSTORIES
+// =============================================================================
+
+export const AllVariants: Story = {
+  name: 'All variants',
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <div
+        style={{
+          display: 'flex',
+          gap: '0.5rem',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
+        <ButtonLink href="/">{TEKST} (strong)</ButtonLink>
+        <ButtonLink href="/" variant="default">
+          {TEKST} (default)
+        </ButtonLink>
+        <ButtonLink href="/" variant="subtle">
+          {TEKST} (subtle)
+        </ButtonLink>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          gap: '0.5rem',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
+        <ButtonLink href="/" variant="strong-negative">
+          {TEKST} (strong-negative)
+        </ButtonLink>
+        <ButtonLink href="/" variant="default-negative">
+          {TEKST} (default-negative)
+        </ButtonLink>
+        <ButtonLink href="/" variant="subtle-negative">
+          {TEKST} (subtle-negative)
+        </ButtonLink>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          gap: '0.5rem',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
+        <ButtonLink href="/" variant="strong-positive">
+          {TEKST} (strong-positive)
+        </ButtonLink>
+        <ButtonLink href="/" variant="default-positive">
+          {TEKST} (default-positive)
+        </ButtonLink>
+        <ButtonLink href="/" variant="subtle-positive">
+          {TEKST} (subtle-positive)
+        </ButtonLink>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          gap: '0.5rem',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
+        <ButtonLink href="/" size="small">
+          {TEKST} (small)
+        </ButtonLink>
+        <ButtonLink href="/">{TEKST} (default)</ButtonLink>
+        <ButtonLink href="/" size="large">
+          {TEKST} (large)
+        </ButtonLink>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          gap: '0.5rem',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
+        <ButtonLink href="/" disabled>
+          {TEKST} (disabled)
+        </ButtonLink>
+        <ButtonLink href="https://example.com" external>
+          {TEKST} (external)
+        </ButtonLink>
+      </div>
+    </div>
+  ),
+};
+
+// =============================================================================
+// TEKST VARIANTEN
+// =============================================================================
+
+export const ShortText: Story = {
+  name: 'Short text',
+  args: { children: WEINIG_TEKST },
+};
+
+export const LongText: Story = {
+  name: 'Long text',
+  args: { children: VEEL_TEKST },
+};
+
+// =============================================================================
+// RTL
+// =============================================================================
+
+export const RTL: Story = {
+  name: 'RTL',
+  decorators: [rtlDecorator],
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <ButtonLink href="/">{TEKST_AR}</ButtonLink>
+      <ButtonLink href="/" iconStart={<Icon name="arrow-right" aria-hidden />}>
+        {TEKST_AR}
+      </ButtonLink>
+      <ButtonLink href="/" iconEnd={<Icon name="arrow-left" aria-hidden />}>
+        {TEKST_AR}
+      </ButtonLink>
+    </div>
+  ),
+};
+
+export const RTLLongText: Story = {
+  name: 'RTL long text',
+  decorators: [rtlDecorator],
+  args: { children: VEEL_TEKST_AR },
+};

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -61,11 +61,12 @@ function App() {
 
 ## Componenten overzicht
 
-**36 componenten totaal** — alle beschikbaar als HTML/CSS én React.
+**37 componenten totaal** — alle beschikbaar als HTML/CSS én React.
 
-### Content Components (8)
+### Content Components (9)
 
 - **Button** — Knoppen met varianten (`strong`, `default`, `subtle`), groottes en laadstatus
+- **ButtonLink** — Semantisch een `<a>`, visueel gestyled als een Button — voor navigatieacties met hoge attentiewaarde
 - **LinkButton** — Semantisch een `<button>`, visueel gestyled als een Link — voor JS-acties met lage attentiewaarde
 - **Icon** — SVG iconen systeem met 45+ iconen
 - **Heading** — H1 t/m H6 met ontkoppelde semantische level en visuele appearance
@@ -136,4 +137,4 @@ MIT License — zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 4.8.0 | **Laatste update:** 3 maart 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 4.9.0 | **Laatste update:** 3 maart 2026 | **Auteur:** Jeffrey Lauwers


### PR DESCRIPTION
## Summary

- Nieuwe `ButtonLink` component: semantisch een `<a>`, visueel het uiterlijk van een `Button`
- Gebruik wanneer een navigatieactie (echte `href`) de visuele prominentie van een Button verdient
- CSS: `dsn-button dsn-button--{variant} dsn-button--size-{size} dsn-button-link`
- Disabled via `aria-disabled="true"` + `tabIndex={-1}` + `pointer-events: none` (geen native `:disabled` op `<a>`)
- `external` prop: auto `target="_blank"` + `rel="noopener noreferrer"` + zichtbare screenreadertekst "(opent nieuw tabblad)" — consistent met `Link`
- 27 tests, 880 totaal groen

## Test plan

- [x] Tests groen: `pnpm test`
- [x] Lint schoon: `pnpm lint`
- [x] TypeScript schoon: geen nieuwe errors
- [x] Storybook: Default, variants, Disabled, External, WithIconStart/End, IconOnly, AllVariants, RTL
- [x] Introduction.mdx bijgewerkt: 37 componenten, versie 4.9.0
- [x] Export toegevoegd aan `packages/components-react/src/index.ts`

Sluit issue #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)