### PR TITLE
fix(storybook): voeg ambient module declaration toe voor *.mdx imports

### DIFF
--- a/packages/storybook/src/mdx.d.ts
+++ b/packages/storybook/src/mdx.d.ts
@@ -1,0 +1,5 @@
+declare module '*.mdx' {
+  import type { ComponentType } from 'react';
+  const component: ComponentType;
+  export default component;
+}


### PR DESCRIPTION
## Summary
- Nieuw bestand `packages/storybook/src/mdx.d.ts` met ambient module declaration voor `*.mdx` imports
- Fixes 36 TS2307-fouten op `.mdx` imports in `pnpm --filter storybook exec tsc --noEmit`
- Zelfde patroon als `packages/components-react/src/svg.d.ts` voor `*.svg?react` imports
- Geen bestaande bestanden aangepast

Closes #51

## Test plan
- [x] Tests groen: 880/880
- [x] TypeScript: geen TS2307-fouten meer op `.mdx` imports
- [x] Lint schoon (0 errors, 4 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)