### PR TITLE
fix(storybook): voeg subpath export toe voor icon-registry.generated

### DIFF
--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -10,6 +10,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./icon-registry.generated": {
+      "types": "./dist/Icon/icon-registry.generated.d.ts",
+      "import": "./dist/Icon/icon-registry.generated.js",
+      "default": "./dist/Icon/icon-registry.generated.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary
- Subpath export `./icon-registry.generated` toegevoegd aan `packages/components-react/package.json`
- Fixes 11 TS2307-fouten op `@dsn/components-react/icon-registry.generated` imports in de Storybook package
- De `dist/Icon/icon-registry.generated.*` bestanden werden al gegenereerd bij de build — dit maakt ze formeel bereikbaar als subpath
- De bestaande root export (`.`) is ongewijzigd

Closes #52

## Test plan
- [x] Tests groen: 880/880
- [x] TypeScript: geen TS2307-fouten meer (ook geen `.mdx` fouten dankzij #51)
- [x] Lint schoon (0 errors, 4 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)