### PR TITLE
fix(storybook): los TS7053 op voor globalThis string-index in preview.ts

### DIFF
--- a/packages/storybook/.storybook/preview.ts
+++ b/packages/storybook/.storybook/preview.ts
@@ -77,8 +77,13 @@ const preview: Preview = {
     },
     options: {
       // @ts-expect-error storySort is serialized to manager, avoid TS annotations
-      storySort: (story1, story2) =>
-        globalThis['storybook-multilevel-sort:storySort'](story1, story2),
+      storySort: (story1, story2) => {
+        // @ts-expect-error: storybook-multilevel-sort registreert zichzelf op globalThis, buiten TS-controle
+        return globalThis['storybook-multilevel-sort:storySort'](
+          story1,
+          story2
+        );
+      },
     },
   },
   globalTypes: {


### PR DESCRIPTION
## Summary
- `storySort` arrow function omgezet naar block body in `.storybook/preview.ts`
- `@ts-expect-error` comment toegevoegd direct boven de `globalThis['storybook-multilevel-sort:storySort']` aanroep
- `pnpm --filter storybook exec tsc --noEmit` geeft nu een volledig schone output (0 fouten)

Dit is de derde en laatste fix in de reeks: #51 (MDX declarations) → #52 (icon-registry subpath export) → #53 (globalThis TS7053).

Closes #53

## Test plan
- [x] Tests groen: 880/880
- [x] TypeScript: volledig schone output (geen TS2307, geen TS7053)
- [x] Lint schoon (0 errors, 4 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)