### PR TITLE
chore(ci): voeg Storybook test runner en Chromatic toe aan CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: pnpm build
 
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        run: pnpm --filter @dsn/storybook exec playwright install --with-deps chromium
 
       - name: Serve Storybook
         run: npx http-server packages/storybook/dist --port 6006 --silent &

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -31,6 +31,7 @@
     "@storybook/react": "^7.6.10",
     "@storybook/react-vite": "^7.6.10",
     "@storybook/test-runner": "0.16.0",
+    "playwright": "^1.58.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "storybook": "^7.6.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@storybook/test-runner':
         specifier: 0.16.0
         version: 0.16.0(@types/node@25.1.0)
+      playwright:
+        specifier: ^1.58.2
+        version: 1.58.2
       react:
         specifier: ^18.2.0
         version: 18.3.1


### PR DESCRIPTION
## Summary
- `@storybook/test-runner@0.16.0` geïnstalleerd (laatste versie compatibel met Storybook 7)
- `test-storybook` script toegevoegd aan `packages/storybook/package.json`
- Twee nieuwe jobs toegevoegd aan `.github/workflows/ci.yml`, beide parallel na de bestaande `ci` job:

**`storybook-tests`** — draait alle stories headless via Playwright:
1. Build alle packages (inclusief Storybook static site → `packages/storybook/dist`)
2. Installeer Playwright Chromium
3. Serve Storybook op poort 6006 via `http-server`
4. Wacht tot Storybook bereikbaar is via `wait-on`
5. Draai `test-storybook` — als een story crasht, faalt de CI

**`chromatic`** — visuele regressietests:
1. Checkout met `fetch-depth: 0` (Chromatic heeft volledige git history nodig)
2. Build alle packages (inclusief Storybook static site)
3. Publish naar Chromatic via `chromaui/action@v11` met `storybookBuildDir`
4. `autoAcceptChanges: main` → baseline wordt automatisch bijgewerkt op main; PRs vereisen expliciete review bij visuele wijzigingen

Closes #22

## Test plan
- [x] Bestaande tests groen: 880/880
- [x] Lint schoon (0 errors, 4 pre-existing warnings)
- [x] CI groen op de branch (storybook-tests + chromatic draaien voor het eerst)
- [ ] Chromatic baseline aangemaakt voor alle bestaande stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)