### PR TITLE
fix(storybook): pas tokenvolgorde aan in alle .docs.md tabellen (#63)

### DIFF
--- a/packages/storybook/src/Alert.docs.md
+++ b/packages/storybook/src/Alert.docs.md
@@ -66,9 +66,9 @@ De Alert component toont een prominent bericht op de pagina — bij een succesvo
 | `--dsn-alert-border-radius`  | Border radius (0px by default; thema-overschrijfbaar) |
 | `--dsn-alert-border-width`   | Breedte van de linkerborder                           |
 | `--dsn-alert-column-gap`     | Ruimte tussen icoon en tekst                          |
-| `--dsn-alert-row-gap`        | Ruimte tussen heading en body content                 |
 | `--dsn-alert-padding-block`  | Verticale padding                                     |
 | `--dsn-alert-padding-inline` | Horizontale padding                                   |
+| `--dsn-alert-row-gap`        | Ruimte tussen heading en body content                 |
 
 De kleur-tokens zijn lokale CSS custom properties en worden niet als globale tokens gepubliceerd:
 

--- a/packages/storybook/src/Button.docs.md
+++ b/packages/storybook/src/Button.docs.md
@@ -43,114 +43,114 @@ De Button component biedt een consistente, toegankelijke manier om acties te tri
 | `--dsn-border-radius-md`                                | Hoekafronding (8px)                             |
 | `--dsn-pointer-target-min-block-size`                   | Minimale hoogte voor touch target (48px)        |
 | `--dsn-pointer-target-min-inline-size`                  | Minimale breedte voor touch target              |
-| `--dsn-button-strong-background-color`                  | Achtergrondkleur strong variant                 |
-| `--dsn-button-strong-color`                             | Tekstkleur strong variant                       |
-| `--dsn-button-strong-border-color`                      | Borderkleur strong variant                      |
-| `--dsn-button-strong-hover-background-color`            | Achtergrondkleur strong hover                   |
-| `--dsn-button-strong-hover-color`                       | Tekstkleur strong hover                         |
-| `--dsn-button-strong-hover-border-color`                | Borderkleur strong hover                        |
-| `--dsn-button-strong-active-background-color`           | Achtergrondkleur strong active                  |
-| `--dsn-button-strong-active-color`                      | Tekstkleur strong active                        |
-| `--dsn-button-strong-active-border-color`               | Borderkleur strong active                       |
 | `--dsn-button-default-background-color`                 | Achtergrondkleur default variant                |
-| `--dsn-button-default-color`                            | Tekstkleur default variant                      |
 | `--dsn-button-default-border-color`                     | Borderkleur default variant                     |
-| `--dsn-button-default-hover-background-color`           | Achtergrondkleur default hover                  |
-| `--dsn-button-default-hover-color`                      | Tekstkleur default hover                        |
-| `--dsn-button-default-hover-border-color`               | Borderkleur default hover                       |
+| `--dsn-button-default-color`                            | Tekstkleur default variant                      |
 | `--dsn-button-default-active-background-color`          | Achtergrondkleur default active                 |
-| `--dsn-button-default-active-color`                     | Tekstkleur default active                       |
 | `--dsn-button-default-active-border-color`              | Borderkleur default active                      |
-| `--dsn-button-subtle-background-color`                  | Achtergrondkleur subtle variant                 |
-| `--dsn-button-subtle-color`                             | Tekstkleur subtle variant                       |
-| `--dsn-button-subtle-border-color`                      | Borderkleur subtle variant                      |
-| `--dsn-button-subtle-hover-background-color`            | Achtergrondkleur subtle hover                   |
-| `--dsn-button-subtle-hover-color`                       | Tekstkleur subtle hover                         |
-| `--dsn-button-subtle-hover-border-color`                | Borderkleur subtle hover                        |
-| `--dsn-button-subtle-active-background-color`           | Achtergrondkleur subtle active                  |
-| `--dsn-button-subtle-active-color`                      | Tekstkleur subtle active                        |
-| `--dsn-button-subtle-active-border-color`               | Borderkleur subtle active                       |
-| `--dsn-button-link-background-color`                    | Achtergrondkleur link variant                   |
-| `--dsn-button-link-color`                               | Tekstkleur link variant                         |
-| `--dsn-button-link-border-color`                        | Borderkleur link variant                        |
-| `--dsn-button-link-hover-background-color`              | Achtergrondkleur link hover                     |
-| `--dsn-button-link-hover-color`                         | Tekstkleur link hover                           |
-| `--dsn-button-link-hover-border-color`                  | Borderkleur link hover                          |
-| `--dsn-button-link-active-background-color`             | Achtergrondkleur link active                    |
-| `--dsn-button-link-active-color`                        | Tekstkleur link active                          |
-| `--dsn-button-link-active-border-color`                 | Borderkleur link active                         |
-| `--dsn-button-strong-negative-background-color`         | Achtergrondkleur strong-negative variant        |
-| `--dsn-button-strong-negative-color`                    | Tekstkleur strong-negative variant              |
-| `--dsn-button-strong-negative-border-color`             | Borderkleur strong-negative variant             |
-| `--dsn-button-strong-negative-hover-background-color`   | Achtergrondkleur strong-negative hover          |
-| `--dsn-button-strong-negative-hover-color`              | Tekstkleur strong-negative hover                |
-| `--dsn-button-strong-negative-hover-border-color`       | Borderkleur strong-negative hover               |
-| `--dsn-button-strong-negative-active-background-color`  | Achtergrondkleur strong-negative active         |
-| `--dsn-button-strong-negative-active-color`             | Tekstkleur strong-negative active               |
-| `--dsn-button-strong-negative-active-border-color`      | Borderkleur strong-negative active              |
+| `--dsn-button-default-active-color`                     | Tekstkleur default active                       |
+| `--dsn-button-default-hover-background-color`           | Achtergrondkleur default hover                  |
+| `--dsn-button-default-hover-border-color`               | Borderkleur default hover                       |
+| `--dsn-button-default-hover-color`                      | Tekstkleur default hover                        |
 | `--dsn-button-default-negative-background-color`        | Achtergrondkleur default-negative variant       |
-| `--dsn-button-default-negative-color`                   | Tekstkleur default-negative variant             |
 | `--dsn-button-default-negative-border-color`            | Borderkleur default-negative variant            |
-| `--dsn-button-default-negative-hover-background-color`  | Achtergrondkleur default-negative hover         |
-| `--dsn-button-default-negative-hover-color`             | Tekstkleur default-negative hover               |
-| `--dsn-button-default-negative-hover-border-color`      | Borderkleur default-negative hover              |
+| `--dsn-button-default-negative-color`                   | Tekstkleur default-negative variant             |
 | `--dsn-button-default-negative-active-background-color` | Achtergrondkleur default-negative active        |
-| `--dsn-button-default-negative-active-color`            | Tekstkleur default-negative active              |
 | `--dsn-button-default-negative-active-border-color`     | Borderkleur default-negative active             |
-| `--dsn-button-subtle-negative-background-color`         | Achtergrondkleur subtle-negative variant        |
-| `--dsn-button-subtle-negative-color`                    | Tekstkleur subtle-negative variant              |
-| `--dsn-button-subtle-negative-border-color`             | Borderkleur subtle-negative variant             |
-| `--dsn-button-subtle-negative-hover-background-color`   | Achtergrondkleur subtle-negative hover          |
-| `--dsn-button-subtle-negative-hover-color`              | Tekstkleur subtle-negative hover                |
-| `--dsn-button-subtle-negative-hover-border-color`       | Borderkleur subtle-negative hover               |
-| `--dsn-button-subtle-negative-active-background-color`  | Achtergrondkleur subtle-negative active         |
-| `--dsn-button-subtle-negative-active-color`             | Tekstkleur subtle-negative active               |
-| `--dsn-button-subtle-negative-active-border-color`      | Borderkleur subtle-negative active              |
-| `--dsn-button-strong-positive-background-color`         | Achtergrondkleur strong-positive variant        |
-| `--dsn-button-strong-positive-color`                    | Tekstkleur strong-positive variant              |
-| `--dsn-button-strong-positive-border-color`             | Borderkleur strong-positive variant             |
-| `--dsn-button-strong-positive-hover-background-color`   | Achtergrondkleur strong-positive hover          |
-| `--dsn-button-strong-positive-hover-color`              | Tekstkleur strong-positive hover                |
-| `--dsn-button-strong-positive-hover-border-color`       | Borderkleur strong-positive hover               |
-| `--dsn-button-strong-positive-active-background-color`  | Achtergrondkleur strong-positive active         |
-| `--dsn-button-strong-positive-active-color`             | Tekstkleur strong-positive active               |
-| `--dsn-button-strong-positive-active-border-color`      | Borderkleur strong-positive active              |
+| `--dsn-button-default-negative-active-color`            | Tekstkleur default-negative active              |
+| `--dsn-button-default-negative-hover-background-color`  | Achtergrondkleur default-negative hover         |
+| `--dsn-button-default-negative-hover-border-color`      | Borderkleur default-negative hover              |
+| `--dsn-button-default-negative-hover-color`             | Tekstkleur default-negative hover               |
 | `--dsn-button-default-positive-background-color`        | Achtergrondkleur default-positive variant       |
-| `--dsn-button-default-positive-color`                   | Tekstkleur default-positive variant             |
 | `--dsn-button-default-positive-border-color`            | Borderkleur default-positive variant            |
-| `--dsn-button-default-positive-hover-background-color`  | Achtergrondkleur default-positive hover         |
-| `--dsn-button-default-positive-hover-color`             | Tekstkleur default-positive hover               |
-| `--dsn-button-default-positive-hover-border-color`      | Borderkleur default-positive hover              |
+| `--dsn-button-default-positive-color`                   | Tekstkleur default-positive variant             |
 | `--dsn-button-default-positive-active-background-color` | Achtergrondkleur default-positive active        |
-| `--dsn-button-default-positive-active-color`            | Tekstkleur default-positive active              |
 | `--dsn-button-default-positive-active-border-color`     | Borderkleur default-positive active             |
+| `--dsn-button-default-positive-active-color`            | Tekstkleur default-positive active              |
+| `--dsn-button-default-positive-hover-background-color`  | Achtergrondkleur default-positive hover         |
+| `--dsn-button-default-positive-hover-border-color`      | Borderkleur default-positive hover              |
+| `--dsn-button-default-positive-hover-color`             | Tekstkleur default-positive hover               |
+| `--dsn-button-link-background-color`                    | Achtergrondkleur link variant                   |
+| `--dsn-button-link-border-color`                        | Borderkleur link variant                        |
+| `--dsn-button-link-color`                               | Tekstkleur link variant                         |
+| `--dsn-button-link-active-background-color`             | Achtergrondkleur link active                    |
+| `--dsn-button-link-active-border-color`                 | Borderkleur link active                         |
+| `--dsn-button-link-active-color`                        | Tekstkleur link active                          |
+| `--dsn-button-link-hover-background-color`              | Achtergrondkleur link hover                     |
+| `--dsn-button-link-hover-border-color`                  | Borderkleur link hover                          |
+| `--dsn-button-link-hover-color`                         | Tekstkleur link hover                           |
+| `--dsn-button-strong-background-color`                  | Achtergrondkleur strong variant                 |
+| `--dsn-button-strong-border-color`                      | Borderkleur strong variant                      |
+| `--dsn-button-strong-color`                             | Tekstkleur strong variant                       |
+| `--dsn-button-strong-active-background-color`           | Achtergrondkleur strong active                  |
+| `--dsn-button-strong-active-border-color`               | Borderkleur strong active                       |
+| `--dsn-button-strong-active-color`                      | Tekstkleur strong active                        |
+| `--dsn-button-strong-hover-background-color`            | Achtergrondkleur strong hover                   |
+| `--dsn-button-strong-hover-border-color`                | Borderkleur strong hover                        |
+| `--dsn-button-strong-hover-color`                       | Tekstkleur strong hover                         |
+| `--dsn-button-strong-negative-background-color`         | Achtergrondkleur strong-negative variant        |
+| `--dsn-button-strong-negative-border-color`             | Borderkleur strong-negative variant             |
+| `--dsn-button-strong-negative-color`                    | Tekstkleur strong-negative variant              |
+| `--dsn-button-strong-negative-active-background-color`  | Achtergrondkleur strong-negative active         |
+| `--dsn-button-strong-negative-active-border-color`      | Borderkleur strong-negative active              |
+| `--dsn-button-strong-negative-active-color`             | Tekstkleur strong-negative active               |
+| `--dsn-button-strong-negative-hover-background-color`   | Achtergrondkleur strong-negative hover          |
+| `--dsn-button-strong-negative-hover-border-color`       | Borderkleur strong-negative hover               |
+| `--dsn-button-strong-negative-hover-color`              | Tekstkleur strong-negative hover                |
+| `--dsn-button-strong-positive-background-color`         | Achtergrondkleur strong-positive variant        |
+| `--dsn-button-strong-positive-border-color`             | Borderkleur strong-positive variant             |
+| `--dsn-button-strong-positive-color`                    | Tekstkleur strong-positive variant              |
+| `--dsn-button-strong-positive-active-background-color`  | Achtergrondkleur strong-positive active         |
+| `--dsn-button-strong-positive-active-border-color`      | Borderkleur strong-positive active              |
+| `--dsn-button-strong-positive-active-color`             | Tekstkleur strong-positive active               |
+| `--dsn-button-strong-positive-hover-background-color`   | Achtergrondkleur strong-positive hover          |
+| `--dsn-button-strong-positive-hover-border-color`       | Borderkleur strong-positive hover               |
+| `--dsn-button-strong-positive-hover-color`              | Tekstkleur strong-positive hover                |
+| `--dsn-button-subtle-background-color`                  | Achtergrondkleur subtle variant                 |
+| `--dsn-button-subtle-border-color`                      | Borderkleur subtle variant                      |
+| `--dsn-button-subtle-color`                             | Tekstkleur subtle variant                       |
+| `--dsn-button-subtle-active-background-color`           | Achtergrondkleur subtle active                  |
+| `--dsn-button-subtle-active-border-color`               | Borderkleur subtle active                       |
+| `--dsn-button-subtle-active-color`                      | Tekstkleur subtle active                        |
+| `--dsn-button-subtle-hover-background-color`            | Achtergrondkleur subtle hover                   |
+| `--dsn-button-subtle-hover-border-color`                | Borderkleur subtle hover                        |
+| `--dsn-button-subtle-hover-color`                       | Tekstkleur subtle hover                         |
+| `--dsn-button-subtle-negative-background-color`         | Achtergrondkleur subtle-negative variant        |
+| `--dsn-button-subtle-negative-border-color`             | Borderkleur subtle-negative variant             |
+| `--dsn-button-subtle-negative-color`                    | Tekstkleur subtle-negative variant              |
+| `--dsn-button-subtle-negative-active-background-color`  | Achtergrondkleur subtle-negative active         |
+| `--dsn-button-subtle-negative-active-border-color`      | Borderkleur subtle-negative active              |
+| `--dsn-button-subtle-negative-active-color`             | Tekstkleur subtle-negative active               |
+| `--dsn-button-subtle-negative-hover-background-color`   | Achtergrondkleur subtle-negative hover          |
+| `--dsn-button-subtle-negative-hover-border-color`       | Borderkleur subtle-negative hover               |
+| `--dsn-button-subtle-negative-hover-color`              | Tekstkleur subtle-negative hover                |
 | `--dsn-button-subtle-positive-background-color`         | Achtergrondkleur subtle-positive variant        |
-| `--dsn-button-subtle-positive-color`                    | Tekstkleur subtle-positive variant              |
 | `--dsn-button-subtle-positive-border-color`             | Borderkleur subtle-positive variant             |
-| `--dsn-button-subtle-positive-hover-background-color`   | Achtergrondkleur subtle-positive hover          |
-| `--dsn-button-subtle-positive-hover-color`              | Tekstkleur subtle-positive hover                |
-| `--dsn-button-subtle-positive-hover-border-color`       | Borderkleur subtle-positive hover               |
+| `--dsn-button-subtle-positive-color`                    | Tekstkleur subtle-positive variant              |
 | `--dsn-button-subtle-positive-active-background-color`  | Achtergrondkleur subtle-positive active         |
-| `--dsn-button-subtle-positive-active-color`             | Tekstkleur subtle-positive active               |
 | `--dsn-button-subtle-positive-active-border-color`      | Borderkleur subtle-positive active              |
-| `--dsn-button-size-small-font-size`                     | Font size small variant                         |
-| `--dsn-button-size-small-padding-block`                 | Verticale padding small variant                 |
-| `--dsn-button-size-small-padding-inline`                | Horizontale padding small variant               |
-| `--dsn-button-size-small-gap`                           | Ruimte tussen icoon en tekst small variant      |
-| `--dsn-button-size-small-icon-size`                     | Icoonformaat small variant                      |
-| `--dsn-button-size-small-icon-only-padding`             | Padding voor icon-only small variant            |
+| `--dsn-button-subtle-positive-active-color`             | Tekstkleur subtle-positive active               |
+| `--dsn-button-subtle-positive-hover-background-color`   | Achtergrondkleur subtle-positive hover          |
+| `--dsn-button-subtle-positive-hover-border-color`       | Borderkleur subtle-positive hover               |
+| `--dsn-button-subtle-positive-hover-color`              | Tekstkleur subtle-positive hover                |
 | `--dsn-button-size-default-font-size`                   | Font size default variant                       |
+| `--dsn-button-size-default-gap`                         | Ruimte tussen icoon en tekst default variant    |
+| `--dsn-button-size-default-icon-only-padding`           | Padding voor icon-only default variant          |
+| `--dsn-button-size-default-icon-size`                   | Icoonformaat default variant                    |
 | `--dsn-button-size-default-padding-block`               | Verticale padding default variant               |
 | `--dsn-button-size-default-padding-inline`              | Horizontale padding default variant             |
-| `--dsn-button-size-default-gap`                         | Ruimte tussen icoon en tekst default variant    |
-| `--dsn-button-size-default-icon-size`                   | Icoonformaat default variant                    |
-| `--dsn-button-size-default-icon-only-padding`           | Padding voor icon-only default variant          |
 | `--dsn-button-size-large-font-size`                     | Font size large variant                         |
+| `--dsn-button-size-large-gap`                           | Ruimte tussen icoon en tekst large variant      |
+| `--dsn-button-size-large-icon-only-padding`             | Padding voor icon-only large variant            |
+| `--dsn-button-size-large-icon-size`                     | Icoonformaat large variant                      |
 | `--dsn-button-size-large-padding-block`                 | Verticale padding large variant                 |
 | `--dsn-button-size-large-padding-inline`                | Horizontale padding large variant               |
-| `--dsn-button-size-large-gap`                           | Ruimte tussen icoon en tekst large variant      |
-| `--dsn-button-size-large-icon-size`                     | Icoonformaat large variant                      |
-| `--dsn-button-size-large-icon-only-padding`             | Padding voor icon-only large variant            |
+| `--dsn-button-size-small-font-size`                     | Font size small variant                         |
+| `--dsn-button-size-small-gap`                           | Ruimte tussen icoon en tekst small variant      |
+| `--dsn-button-size-small-icon-only-padding`             | Padding voor icon-only small variant            |
+| `--dsn-button-size-small-icon-size`                     | Icoonformaat small variant                      |
+| `--dsn-button-size-small-padding-block`                 | Verticale padding small variant                 |
+| `--dsn-button-size-small-padding-inline`                | Horizontale padding small variant               |
 | `--dsn-focus-background-color`                          | Achtergrondkleur bij focus                      |
 | `--dsn-focus-color`                                     | Tekstkleur bij focus                            |
 | `--dsn-focus-outline-width`                             | Dikte van de focus outline                      |

--- a/packages/storybook/src/ButtonLink.docs.md
+++ b/packages/storybook/src/ButtonLink.docs.md
@@ -43,13 +43,13 @@ Een link die semantisch een `<a>` is, maar visueel het uiterlijk van een [Button
 
 | Token                                   | Beschrijving                        |
 | --------------------------------------- | ----------------------------------- |
-| `--dsn-button-strong-background-color`  | Achtergrondkleur strong variant     |
-| `--dsn-button-strong-color`             | Tekstkleur strong variant           |
-| `--dsn-button-strong-border-color`      | Randkleur strong variant            |
 | `--dsn-button-default-background-color` | Achtergrondkleur default variant    |
 | `--dsn-button-default-color`            | Tekstkleur default variant          |
+| `--dsn-button-strong-background-color`  | Achtergrondkleur strong variant     |
+| `--dsn-button-strong-border-color`      | Randkleur strong variant            |
+| `--dsn-button-strong-color`             | Tekstkleur strong variant           |
 | `--dsn-button-subtle-background-color`  | Achtergrondkleur subtle variant     |
 | `--dsn-button-subtle-color`             | Tekstkleur subtle variant           |
-| `--dsn-button-size-small-*`             | Grootte-tokens voor small variant   |
 | `--dsn-button-size-default-*`           | Grootte-tokens voor default variant |
 | `--dsn-button-size-large-*`             | Grootte-tokens voor large variant   |
+| `--dsn-button-size-small-*`             | Grootte-tokens voor small variant   |

--- a/packages/storybook/src/Checkbox.docs.md
+++ b/packages/storybook/src/Checkbox.docs.md
@@ -34,36 +34,36 @@ De Checkbox component is een standalone checkbox zonder label - alleen het vierk
 
 | Token                                      | Beschrijving                                             |
 | ------------------------------------------ | -------------------------------------------------------- |
-| `--dsn-checkbox-size`                      | Grootte van de checkbox (fluid, gekoppeld aan text size) |
-| `--dsn-checkbox-icon-size`                 | Grootte van het check icoon (67% van checkbox size)      |
+| `--dsn-checkbox-background-color`          | Achtergrondkleur default state                           |
+| `--dsn-checkbox-border-color`              | Border kleur default state                               |
 | `--dsn-checkbox-border-radius`             | Hoekafronding (0px - vierkant)                           |
 | `--dsn-checkbox-border-width`              | Border dikte default state                               |
-| `--dsn-checkbox-border-color`              | Border kleur default state                               |
-| `--dsn-checkbox-background-color`          | Achtergrondkleur default state                           |
-| `--dsn-checkbox-hover-border-width`        | Border dikte hover state                                 |
-| `--dsn-checkbox-hover-border-color`        | Border kleur hover state                                 |
-| `--dsn-checkbox-hover-background-color`    | Achtergrondkleur hover state                             |
-| `--dsn-checkbox-focus-border-width`        | Border dikte focus state                                 |
-| `--dsn-checkbox-focus-border-color`        | Border kleur focus state                                 |
-| `--dsn-checkbox-focus-background-color`    | Achtergrondkleur focus state                             |
-| `--dsn-checkbox-active-border-width`       | Border dikte active state                                |
-| `--dsn-checkbox-active-border-color`       | Border kleur active state                                |
+| `--dsn-checkbox-size`                      | Grootte van de checkbox (fluid, gekoppeld aan text size) |
 | `--dsn-checkbox-active-background-color`   | Achtergrondkleur active state                            |
-| `--dsn-checkbox-checked-border-width`      | Border dikte checked state                               |
-| `--dsn-checkbox-checked-border-color`      | Border kleur checked state (transparent)                 |
+| `--dsn-checkbox-active-border-color`       | Border kleur active state                                |
+| `--dsn-checkbox-active-border-width`       | Border dikte active state                                |
 | `--dsn-checkbox-checked-background-color`  | Achtergrondkleur checked state (accent)                  |
+| `--dsn-checkbox-checked-border-color`      | Border kleur checked state (transparent)                 |
+| `--dsn-checkbox-checked-border-width`      | Border dikte checked state                               |
 | `--dsn-checkbox-checked-color`             | Icoon kleur checked state (wit)                          |
-| `--dsn-checkbox-checked-hover-*`           | Checked + hover combinatie                               |
-| `--dsn-checkbox-checked-active-*`          | Checked + active combinatie                              |
-| `--dsn-checkbox-checked-focus-*`           | Checked + focus combinatie                               |
-| `--dsn-checkbox-indeterminate-*`           | Indeterminate state (alle combinaties)                   |
-| `--dsn-checkbox-disabled-border-color`     | Border kleur disabled state                              |
 | `--dsn-checkbox-disabled-background-color` | Achtergrondkleur disabled state                          |
-| `--dsn-checkbox-checked-disabled-*`        | Checked + disabled combinatie                            |
-| `--dsn-checkbox-indeterminate-disabled-*`  | Indeterminate + disabled combinatie                      |
-| `--dsn-checkbox-invalid-border-width`      | Border dikte invalid state                               |
-| `--dsn-checkbox-invalid-border-color`      | Border kleur invalid state                               |
+| `--dsn-checkbox-disabled-border-color`     | Border kleur disabled state                              |
+| `--dsn-checkbox-focus-background-color`    | Achtergrondkleur focus state                             |
+| `--dsn-checkbox-focus-border-color`        | Border kleur focus state                                 |
+| `--dsn-checkbox-focus-border-width`        | Border dikte focus state                                 |
+| `--dsn-checkbox-hover-background-color`    | Achtergrondkleur hover state                             |
+| `--dsn-checkbox-hover-border-color`        | Border kleur hover state                                 |
+| `--dsn-checkbox-hover-border-width`        | Border dikte hover state                                 |
 | `--dsn-checkbox-invalid-background-color`  | Achtergrondkleur invalid state                           |
+| `--dsn-checkbox-invalid-border-color`      | Border kleur invalid state                               |
+| `--dsn-checkbox-invalid-border-width`      | Border dikte invalid state                               |
+| `--dsn-checkbox-checked-active-*`          | Checked + active combinatie                              |
+| `--dsn-checkbox-checked-disabled-*`        | Checked + disabled combinatie                            |
+| `--dsn-checkbox-checked-focus-*`           | Checked + focus combinatie                               |
+| `--dsn-checkbox-checked-hover-*`           | Checked + hover combinatie                               |
+| `--dsn-checkbox-indeterminate-*`           | Indeterminate state (alle combinaties)                   |
+| `--dsn-checkbox-indeterminate-disabled-*`  | Indeterminate + disabled combinatie                      |
+| `--dsn-checkbox-icon-size`                 | Grootte van het check icoon (67% van checkbox size)      |
 
 ## Accessibility
 

--- a/packages/storybook/src/FormFieldDescription.docs.md
+++ b/packages/storybook/src/FormFieldDescription.docs.md
@@ -35,11 +35,11 @@ De FormFieldDescription component toont aanvullende informatie of instructies vo
 
 | Token                                           | Beschrijving                              |
 | ----------------------------------------------- | ----------------------------------------- |
+| `--dsn-form-field-description-color`            | Text color (subtle)                       |
 | `--dsn-form-field-description-font-family`      | Font family                               |
 | `--dsn-form-field-description-font-size`        | Font size (medium)                        |
 | `--dsn-form-field-description-font-weight`      | Font weight (normal)                      |
 | `--dsn-form-field-description-line-height`      | Line height (medium)                      |
-| `--dsn-form-field-description-color`            | Text color (subtle)                       |
 | `--dsn-form-field-description-margin-block-end` | Margin below description (medium spacing) |
 
 ## Accessibility

--- a/packages/storybook/src/FormFieldErrorMessage.docs.md
+++ b/packages/storybook/src/FormFieldErrorMessage.docs.md
@@ -46,14 +46,14 @@ De FormFieldErrorMessage component toont validatie foutmeldingen bij form fields
 
 | Token                                             | Beschrijving                                |
 | ------------------------------------------------- | ------------------------------------------- |
+| `--dsn-form-field-error-message-color`            | Text color (negative/error red)             |
 | `--dsn-form-field-error-message-font-family`      | Font family                                 |
 | `--dsn-form-field-error-message-font-size`        | Font size (medium)                          |
 | `--dsn-form-field-error-message-font-weight`      | Font weight (normal)                        |
-| `--dsn-form-field-error-message-line-height`      | Line height (medium)                        |
-| `--dsn-form-field-error-message-color`            | Text color (negative/error red)             |
 | `--dsn-form-field-error-message-gap`              | Space between icon and text (small)         |
-| `--dsn-form-field-error-message-margin-block-end` | Margin below error message (medium spacing) |
 | `--dsn-form-field-error-message-icon-size`        | Icon size (medium)                          |
+| `--dsn-form-field-error-message-line-height`      | Line height (medium)                        |
+| `--dsn-form-field-error-message-margin-block-end` | Margin below error message (medium spacing) |
 
 ## Accessibility
 

--- a/packages/storybook/src/FormFieldLabel.docs.md
+++ b/packages/storybook/src/FormFieldLabel.docs.md
@@ -51,18 +51,18 @@ De FormFieldLabel component is een gestandaardiseerd label element voor form con
 
 | Token                                                      | Beschrijving                                                |
 | ---------------------------------------------------------- | ----------------------------------------------------------- |
+| `--dsn-form-field-label-color`                             | Text color                                                  |
 | `--dsn-form-field-label-font-family`                       | Font family                                                 |
 | `--dsn-form-field-label-font-size`                         | Font size (medium)                                          |
 | `--dsn-form-field-label-font-weight`                       | Font weight (bold)                                          |
 | `--dsn-form-field-label-line-height`                       | Line height (medium)                                        |
-| `--dsn-form-field-label-color`                             | Text color                                                  |
 | `--dsn-form-field-label-margin-block-end`                  | Margin below label (medium spacing)                         |
 | `--dsn-form-field-label-margin-block-end-with-description` | Margin below label when description follows (small spacing) |
+| `--dsn-form-field-label-suffix-color`                      | Suffix text color                                           |
 | `--dsn-form-field-label-suffix-font-family`                | Suffix font family                                          |
 | `--dsn-form-field-label-suffix-font-size`                  | Suffix font size (same as label)                            |
 | `--dsn-form-field-label-suffix-font-weight`                | Suffix font weight (normal, not bold)                       |
 | `--dsn-form-field-label-suffix-line-height`                | Suffix line height                                          |
-| `--dsn-form-field-label-suffix-color`                      | Suffix text color                                           |
 | `--dsn-form-field-label-suffix-margin-inline-start`        | Space between label and suffix (small)                      |
 
 ## Accessibility

--- a/packages/storybook/src/FormFieldStatus.docs.md
+++ b/packages/storybook/src/FormFieldStatus.docs.md
@@ -69,11 +69,11 @@ De FormFieldStatus component toont status informatie onder een form control. Het
 
 | Token                                        | Beschrijving                            |
 | -------------------------------------------- | --------------------------------------- |
+| `--dsn-form-field-status-color`              | Text color default variant (subtle)     |
 | `--dsn-form-field-status-font-family`        | Font family                             |
 | `--dsn-form-field-status-font-size`          | Font size (medium)                      |
 | `--dsn-form-field-status-font-weight`        | Font weight (normal)                    |
 | `--dsn-form-field-status-line-height`        | Line height (medium)                    |
-| `--dsn-form-field-status-color`              | Text color default variant (subtle)     |
 | `--dsn-form-field-status-margin-block-start` | Margin above status (medium spacing)    |
 | `--dsn-color-positive-color-default`         | Text color positive variant (green)     |
 | `--dsn-color-warning-color-default`          | Text color warning variant (orange)     |

--- a/packages/storybook/src/Heading.docs.md
+++ b/packages/storybook/src/Heading.docs.md
@@ -34,9 +34,9 @@ De Heading component biedt een consistente, toegankelijke manier om koppen weer 
 
 | Token                                    | Beschrijving                                         |
 | ---------------------------------------- | ---------------------------------------------------- |
+| `--dsn-heading-color`                    | Tekstkleur voor alle headings                        |
 | `--dsn-heading-font-family`              | Lettertypefamilie voor alle headings (IBM Plex Sans) |
 | `--dsn-heading-font-weight`              | Font weight voor alle headings (700 - bold)          |
-| `--dsn-heading-color`                    | Tekstkleur voor alle headings                        |
 | `--dsn-heading-level-1-font-size`        | Font size heading 1 (3xl - 40px-53px fluid)          |
 | `--dsn-heading-level-1-line-height`      | Line height heading 1                                |
 | `--dsn-heading-level-1-margin-block-end` | Bottom margin heading 1                              |

--- a/packages/storybook/src/Link.docs.md
+++ b/packages/storybook/src/Link.docs.md
@@ -35,25 +35,25 @@ De Link component biedt een consistente, toegankelijke manier om hyperlinks weer
 | Token                                   | Beschrijving                               |
 | --------------------------------------- | ------------------------------------------ |
 | `--dsn-link-color`                      | Tekstkleur van de link                     |
-| `--dsn-link-hover-color`                | Tekstkleur bij hover                       |
-| `--dsn-link-active-color`               | Tekstkleur bij active (klik)               |
-| `--dsn-link-disabled-color`             | Tekstkleur disabled state                  |
-| `--dsn-link-text-decoration-line`       | Onderlijning (underline)                   |
-| `--dsn-link-text-decoration-color`      | Kleur van de onderlijning                  |
-| `--dsn-link-text-decoration-thickness`  | Dikte van de onderlijning                  |
-| `--dsn-link-text-underline-offset`      | Afstand tussen tekst en onderlijning (4px) |
-| `--dsn-link-hover-text-decoration-line` | Onderlijning bij hover (none)              |
 | `--dsn-link-gap`                        | Ruimte tussen icoon en tekst               |
 | `--dsn-link-icon-size`                  | Icoongrootte standaard                     |
-| `--dsn-link-size-small-font-size`       | Font size small variant                    |
-| `--dsn-link-size-small-gap`             | Gap small variant                          |
-| `--dsn-link-size-small-icon-size`       | Icon size small variant                    |
+| `--dsn-link-text-decoration-color`      | Kleur van de onderlijning                  |
+| `--dsn-link-text-decoration-line`       | Onderlijning (underline)                   |
+| `--dsn-link-text-decoration-thickness`  | Dikte van de onderlijning                  |
+| `--dsn-link-text-underline-offset`      | Afstand tussen tekst en onderlijning (4px) |
+| `--dsn-link-active-color`               | Tekstkleur bij active (klik)               |
+| `--dsn-link-disabled-color`             | Tekstkleur disabled state                  |
+| `--dsn-link-hover-color`                | Tekstkleur bij hover                       |
+| `--dsn-link-hover-text-decoration-line` | Onderlijning bij hover (none)              |
 | `--dsn-link-size-default-font-size`     | Font size default variant                  |
 | `--dsn-link-size-default-gap`           | Gap default variant                        |
 | `--dsn-link-size-default-icon-size`     | Icon size default variant                  |
 | `--dsn-link-size-large-font-size`       | Font size large variant                    |
 | `--dsn-link-size-large-gap`             | Gap large variant                          |
 | `--dsn-link-size-large-icon-size`       | Icon size large variant                    |
+| `--dsn-link-size-small-font-size`       | Font size small variant                    |
+| `--dsn-link-size-small-gap`             | Gap small variant                          |
+| `--dsn-link-size-small-icon-size`       | Icon size small variant                    |
 
 ## Accessibility
 

--- a/packages/storybook/src/Note.docs.md
+++ b/packages/storybook/src/Note.docs.md
@@ -66,10 +66,10 @@ Bij `as="nav"`, `as="aside"` of `as="section"` + een `heading` prop: de Note kop
 | -------------------------------------- | ----------------------------- |
 | `--dsn-note-border-inline-start-width` | Breedte van de linkerborder   |
 | `--dsn-note-column-gap`                | Ruimte tussen icoon en tekst  |
-| `--dsn-note-row-gap`                   | Ruimte tussen heading en body |
 | `--dsn-note-padding-block`             | Verticale padding             |
-| `--dsn-note-padding-inline-start`      | Horizontale padding links     |
 | `--dsn-note-padding-inline-end`        | Horizontale padding rechts    |
+| `--dsn-note-padding-inline-start`      | Horizontale padding links     |
+| `--dsn-note-row-gap`                   | Ruimte tussen heading en body |
 
 De kleur-tokens zijn lokale CSS custom properties per variant:
 

--- a/packages/storybook/src/OptionLabel.docs.md
+++ b/packages/storybook/src/OptionLabel.docs.md
@@ -31,11 +31,11 @@ De OptionLabel component is een gespecialiseerd label element voor gebruik met c
 
 | Token                               | Beschrijving                             |
 | ----------------------------------- | ---------------------------------------- |
+| `--dsn-option-label-color`          | Tekstkleur default state                 |
 | `--dsn-option-label-font-family`    | Font family voor option labels           |
 | `--dsn-option-label-font-size`      | Font size voor option labels (medium)    |
 | `--dsn-option-label-font-weight`    | Font weight voor option labels (default) |
 | `--dsn-option-label-line-height`    | Line height voor option labels (medium)  |
-| `--dsn-option-label-color`          | Tekstkleur default state                 |
 | `--dsn-option-label-disabled-color` | Tekstkleur disabled state                |
 
 ## Accessibility

--- a/packages/storybook/src/OrderedList.docs.md
+++ b/packages/storybook/src/OrderedList.docs.md
@@ -33,15 +33,15 @@ De OrderedList component biedt een consistente, toegankelijke manier om lijsten 
 
 | Token                                     | Beschrijving                     |
 | ----------------------------------------- | -------------------------------- |
-| `--dsn-ordered-list-font-family`          | Lettertypefamilie                |
-| `--dsn-ordered-list-font-weight`          | Font weight                      |
 | `--dsn-ordered-list-color`                | Tekstkleur                       |
+| `--dsn-ordered-list-font-family`          | Lettertypefamilie                |
 | `--dsn-ordered-list-font-size`            | Font size (md)                   |
-| `--dsn-ordered-list-line-height`          | Line height                      |
-| `--dsn-ordered-list-padding-inline-start` | Linker inspringing voor de lijst |
-| `--dsn-ordered-list-margin-block-end`     | Bottom margin van de lijst       |
+| `--dsn-ordered-list-font-weight`          | Font weight                      |
 | `--dsn-ordered-list-gap`                  | Ruimte tussen list items         |
+| `--dsn-ordered-list-line-height`          | Line height                      |
+| `--dsn-ordered-list-margin-block-end`     | Bottom margin van de lijst       |
 | `--dsn-ordered-list-marker-color`         | Kleur van de nummers             |
+| `--dsn-ordered-list-padding-inline-start` | Linker inspringing voor de lijst |
 
 ## Accessibility
 

--- a/packages/storybook/src/Paragraph.docs.md
+++ b/packages/storybook/src/Paragraph.docs.md
@@ -34,9 +34,9 @@ De Paragraph component biedt een consistente, toegankelijke manier om tekstblokk
 
 | Token                                          | Beschrijving                      |
 | ---------------------------------------------- | --------------------------------- |
+| `--dsn-paragraph-color`                        | Tekstkleur                        |
 | `--dsn-paragraph-font-family`                  | Lettertypefamilie (standaard)     |
 | `--dsn-paragraph-font-weight`                  | Font weight (standaard)           |
-| `--dsn-paragraph-color`                        | Tekstkleur                        |
 | `--dsn-paragraph-max-inline-size`              | Maximale regelbreedte (65ch)      |
 | `--dsn-paragraph-default-font-size`            | Font size default variant         |
 | `--dsn-paragraph-default-line-height`          | Line height default variant       |

--- a/packages/storybook/src/Radio.docs.md
+++ b/packages/storybook/src/Radio.docs.md
@@ -35,34 +35,34 @@ De Radio component is een standalone radio button zonder label - alleen het rond
 
 | Token                                   | Beschrijving                                                 |
 | --------------------------------------- | ------------------------------------------------------------ |
-| `--dsn-radio-size`                      | Grootte van de radio button (fluid, gekoppeld aan text size) |
-| `--dsn-radio-icon-size`                 | Grootte van de inner circle (33% van radio size)             |
-| `--dsn-radio-border-width`              | Border dikte default state                                   |
-| `--dsn-radio-border-color`              | Border kleur default state                                   |
 | `--dsn-radio-background-color`          | Achtergrondkleur default state                               |
+| `--dsn-radio-border-color`              | Border kleur default state                                   |
+| `--dsn-radio-border-width`              | Border dikte default state                                   |
 | `--dsn-radio-color`                     | Inner circle kleur default state                             |
-| `--dsn-radio-hover-border-width`        | Border dikte hover state                                     |
-| `--dsn-radio-hover-border-color`        | Border kleur hover state                                     |
-| `--dsn-radio-hover-background-color`    | Achtergrondkleur hover state                                 |
-| `--dsn-radio-focus-border-width`        | Border dikte focus state                                     |
-| `--dsn-radio-focus-border-color`        | Border kleur focus state                                     |
-| `--dsn-radio-focus-background-color`    | Achtergrondkleur focus state                                 |
-| `--dsn-radio-active-border-width`       | Border dikte active state                                    |
-| `--dsn-radio-active-border-color`       | Border kleur active state                                    |
+| `--dsn-radio-size`                      | Grootte van de radio button (fluid, gekoppeld aan text size) |
 | `--dsn-radio-active-background-color`   | Achtergrondkleur active state                                |
-| `--dsn-radio-checked-border-width`      | Border dikte checked state                                   |
-| `--dsn-radio-checked-border-color`      | Border kleur checked state (transparent)                     |
+| `--dsn-radio-active-border-color`       | Border kleur active state                                    |
+| `--dsn-radio-active-border-width`       | Border dikte active state                                    |
 | `--dsn-radio-checked-background-color`  | Achtergrondkleur checked state (accent)                      |
+| `--dsn-radio-checked-border-color`      | Border kleur checked state (transparent)                     |
+| `--dsn-radio-checked-border-width`      | Border dikte checked state                                   |
 | `--dsn-radio-checked-color`             | Inner circle kleur checked state (wit)                       |
-| `--dsn-radio-checked-hover-*`           | Checked + hover combinatie                                   |
-| `--dsn-radio-checked-active-*`          | Checked + active combinatie                                  |
-| `--dsn-radio-checked-focus-*`           | Checked + focus combinatie                                   |
-| `--dsn-radio-disabled-border-color`     | Border kleur disabled state                                  |
 | `--dsn-radio-disabled-background-color` | Achtergrondkleur disabled state                              |
-| `--dsn-radio-checked-disabled-*`        | Checked + disabled combinatie                                |
-| `--dsn-radio-invalid-border-width`      | Border dikte invalid state                                   |
-| `--dsn-radio-invalid-border-color`      | Border kleur invalid state                                   |
+| `--dsn-radio-disabled-border-color`     | Border kleur disabled state                                  |
+| `--dsn-radio-focus-background-color`    | Achtergrondkleur focus state                                 |
+| `--dsn-radio-focus-border-color`        | Border kleur focus state                                     |
+| `--dsn-radio-focus-border-width`        | Border dikte focus state                                     |
+| `--dsn-radio-hover-background-color`    | Achtergrondkleur hover state                                 |
+| `--dsn-radio-hover-border-color`        | Border kleur hover state                                     |
+| `--dsn-radio-hover-border-width`        | Border dikte hover state                                     |
 | `--dsn-radio-invalid-background-color`  | Achtergrondkleur invalid state                               |
+| `--dsn-radio-invalid-border-color`      | Border kleur invalid state                                   |
+| `--dsn-radio-invalid-border-width`      | Border dikte invalid state                                   |
+| `--dsn-radio-checked-active-*`          | Checked + active combinatie                                  |
+| `--dsn-radio-checked-disabled-*`        | Checked + disabled combinatie                                |
+| `--dsn-radio-checked-focus-*`           | Checked + focus combinatie                                   |
+| `--dsn-radio-checked-hover-*`           | Checked + hover combinatie                                   |
+| `--dsn-radio-icon-size`                 | Grootte van de inner circle (33% van radio size)             |
 
 ## Accessibility
 

--- a/packages/storybook/src/SearchInput.docs.md
+++ b/packages/storybook/src/SearchInput.docs.md
@@ -55,8 +55,8 @@ Een SearchInput bestaat uit:
 
 | Token                                               | Beschrijving                                                           |
 | --------------------------------------------------- | ---------------------------------------------------------------------- |
-| `--dsn-search-input-icon-size`                      | Grootte van het zoekicoon                                              |
 | `--dsn-search-input-icon-gap`                       | Ruimte tussen icoon en tekst                                           |
+| `--dsn-search-input-icon-size`                      | Grootte van het zoekicoon                                              |
 | `--dsn-search-input-padding-inline-start-with-icon` | Berekende padding links: `icon-size + icon-gap + padding-inline-start` |
 
 SearchInput erft verder alle tokens van [TextInput](/docs/components-textinput--docs):

--- a/packages/storybook/src/Select.docs.md
+++ b/packages/storybook/src/Select.docs.md
@@ -45,8 +45,8 @@ Select is een formuliercomponent op basis van het native `<select>` element. Het
 
 | Token                                       | Beschrijving                                     |
 | ------------------------------------------- | ------------------------------------------------ |
-| `--dsn-select-icon-size`                    | Grootte van het chevron-icoon                    |
+| `--dsn-select-icon-color`                   | Kleur van het chevron-icoon                      |
 | `--dsn-select-icon-gap`                     | Ruimte tussen icoon en tekst                     |
 | `--dsn-select-icon-inset-inline-end`        | Afstand van icoon tot de rechterrand             |
-| `--dsn-select-icon-color`                   | Kleur van het chevron-icoon                      |
+| `--dsn-select-icon-size`                    | Grootte van het chevron-icoon                    |
 | `--dsn-select-padding-inline-end-with-icon` | Padding rechts van de select (ruimte voor icoon) |

--- a/packages/storybook/src/StatusBadge.docs.md
+++ b/packages/storybook/src/StatusBadge.docs.md
@@ -49,25 +49,25 @@ De StatusBadge component toont een statusaanduiding naast tabelrijen, koppen of 
 
 | Token                                          | Beschrijving                                                 |
 | ---------------------------------------------- | ------------------------------------------------------------ |
-| `--dsn-status-badge-font-size`                 | Font size (sm)                                               |
-| `--dsn-status-badge-line-height`               | Line height (sm)                                             |
+| `--dsn-status-badge-border-color`              | Border color (transparent — zichtbaar in High Contrast mode) |
 | `--dsn-status-badge-border-radius`             | Border radius (sm — 4px)                                     |
 | `--dsn-status-badge-border-width`              | Border width (thin — 1px)                                    |
-| `--dsn-status-badge-border-color`              | Border color (transparent — zichtbaar in High Contrast mode) |
-| `--dsn-status-badge-text-transform`            | Text transform (none — thema-overschrijfbaar)                |
+| `--dsn-status-badge-font-size`                 | Font size (sm)                                               |
 | `--dsn-status-badge-gap`                       | Ruimte tussen icoon en tekst                                 |
+| `--dsn-status-badge-line-height`               | Line height (sm)                                             |
 | `--dsn-status-badge-padding-block`             | Verticale padding                                            |
 | `--dsn-status-badge-padding-inline`            | Horizontale padding                                          |
-| `--dsn-status-badge-neutral-color`             | Tekstkleur neutral variant                                   |
-| `--dsn-status-badge-neutral-background-color`  | Achtergrond neutral variant                                  |
-| `--dsn-status-badge-info-color`                | Tekstkleur info variant                                      |
+| `--dsn-status-badge-text-transform`            | Text transform (none — thema-overschrijfbaar)                |
 | `--dsn-status-badge-info-background-color`     | Achtergrond info variant                                     |
-| `--dsn-status-badge-positive-color`            | Tekstkleur positive variant                                  |
-| `--dsn-status-badge-positive-background-color` | Achtergrond positive variant                                 |
-| `--dsn-status-badge-negative-color`            | Tekstkleur negative variant                                  |
+| `--dsn-status-badge-info-color`                | Tekstkleur info variant                                      |
 | `--dsn-status-badge-negative-background-color` | Achtergrond negative variant                                 |
-| `--dsn-status-badge-warning-color`             | Tekstkleur warning variant                                   |
+| `--dsn-status-badge-negative-color`            | Tekstkleur negative variant                                  |
+| `--dsn-status-badge-neutral-background-color`  | Achtergrond neutral variant                                  |
+| `--dsn-status-badge-neutral-color`             | Tekstkleur neutral variant                                   |
+| `--dsn-status-badge-positive-background-color` | Achtergrond positive variant                                 |
+| `--dsn-status-badge-positive-color`            | Tekstkleur positive variant                                  |
 | `--dsn-status-badge-warning-background-color`  | Achtergrond warning variant                                  |
+| `--dsn-status-badge-warning-color`             | Tekstkleur warning variant                                   |
 
 ## Accessibility
 

--- a/packages/storybook/src/TextArea.docs.md
+++ b/packages/storybook/src/TextArea.docs.md
@@ -58,35 +58,35 @@ De TextArea component is een gestandaardiseerd invoerveld voor multi-line tekst.
 
 | Token                                        | Beschrijving                                       |
 | -------------------------------------------- | -------------------------------------------------- |
+| `--dsn-text-area-background-color`           | Background color                                   |
+| `--dsn-text-area-border-color`               | Border color                                       |
+| `--dsn-text-area-border-radius`              | Border radius                                      |
+| `--dsn-text-area-border-width`               | Border width                                       |
+| `--dsn-text-area-color`                      | Text color                                         |
 | `--dsn-text-area-font-family`                | Font family                                        |
 | `--dsn-text-area-font-size`                  | Font size                                          |
 | `--dsn-text-area-font-weight`                | Font weight                                        |
 | `--dsn-text-area-line-height`                | Line height                                        |
-| `--dsn-text-area-color`                      | Text color                                         |
-| `--dsn-text-area-background-color`           | Background color                                   |
-| `--dsn-text-area-border-color`               | Border color                                       |
-| `--dsn-text-area-border-width`               | Border width                                       |
-| `--dsn-text-area-border-radius`              | Border radius                                      |
-| `--dsn-text-area-placeholder-color`          | Placeholder text color                             |
-| `--dsn-text-area-padding-block-start`        | Top padding                                        |
-| `--dsn-text-area-padding-block-end`          | Bottom padding                                     |
-| `--dsn-text-area-padding-inline-start`       | Left padding                                       |
-| `--dsn-text-area-padding-inline-end`         | Right padding                                      |
 | `--dsn-text-area-min-block-size`             | Minimum height (WCAG 24px touch target)            |
 | `--dsn-text-area-min-inline-size`            | Minimum width (WCAG 24px touch target)             |
+| `--dsn-text-area-padding-block-end`          | Bottom padding                                     |
+| `--dsn-text-area-padding-block-start`        | Top padding                                        |
+| `--dsn-text-area-padding-inline-end`         | Right padding                                      |
+| `--dsn-text-area-padding-inline-start`       | Left padding                                       |
 | `--dsn-text-area-resize`                     | Resize behavior (vertical, horizontal, both, none) |
-| `--dsn-text-area-focus-color`                | Focus text color                                   |
-| `--dsn-text-area-focus-background-color`     | Focus background color                             |
-| `--dsn-text-area-focus-border-color`         | Focus border color                                 |
-| `--dsn-text-area-disabled-color`             | Disabled text color                                |
 | `--dsn-text-area-disabled-background-color`  | Disabled background color                          |
 | `--dsn-text-area-disabled-border-color`      | Disabled border color                              |
-| `--dsn-text-area-read-only-color`            | Read-only text color                               |
-| `--dsn-text-area-read-only-background-color` | Read-only background color                         |
-| `--dsn-text-area-read-only-border-color`     | Read-only border color                             |
-| `--dsn-text-area-invalid-color`              | Invalid text color                                 |
+| `--dsn-text-area-disabled-color`             | Disabled text color                                |
+| `--dsn-text-area-focus-background-color`     | Focus background color                             |
+| `--dsn-text-area-focus-border-color`         | Focus border color                                 |
+| `--dsn-text-area-focus-color`                | Focus text color                                   |
 | `--dsn-text-area-invalid-background-color`   | Invalid background color                           |
 | `--dsn-text-area-invalid-border-color`       | Invalid border color                               |
+| `--dsn-text-area-invalid-color`              | Invalid text color                                 |
+| `--dsn-text-area-placeholder-color`          | Placeholder text color                             |
+| `--dsn-text-area-read-only-background-color` | Read-only background color                         |
+| `--dsn-text-area-read-only-border-color`     | Read-only border color                             |
+| `--dsn-text-area-read-only-color`            | Read-only text color                               |
 | `--dsn-form-control-width-xs`                | Extra small width (8ch)                            |
 | `--dsn-form-control-width-sm`                | Small width (16ch)                                 |
 | `--dsn-form-control-width-md`                | Medium width (32ch)                                |

--- a/packages/storybook/src/TextInput.docs.md
+++ b/packages/storybook/src/TextInput.docs.md
@@ -50,34 +50,34 @@ De TextInput component is een gestandaardiseerd invoerveld voor single-line teks
 
 | Token                                         | Beschrijving                            |
 | --------------------------------------------- | --------------------------------------- |
+| `--dsn-text-input-background-color`           | Background color                        |
+| `--dsn-text-input-border-color`               | Border color                            |
+| `--dsn-text-input-border-radius`              | Border radius                           |
+| `--dsn-text-input-border-width`               | Border width                            |
+| `--dsn-text-input-color`                      | Text color                              |
 | `--dsn-text-input-font-family`                | Font family                             |
 | `--dsn-text-input-font-size`                  | Font size                               |
 | `--dsn-text-input-font-weight`                | Font weight                             |
 | `--dsn-text-input-line-height`                | Line height                             |
-| `--dsn-text-input-color`                      | Text color                              |
-| `--dsn-text-input-background-color`           | Background color                        |
-| `--dsn-text-input-border-color`               | Border color                            |
-| `--dsn-text-input-border-width`               | Border width                            |
-| `--dsn-text-input-border-radius`              | Border radius                           |
-| `--dsn-text-input-placeholder-color`          | Placeholder text color                  |
-| `--dsn-text-input-padding-block-start`        | Top padding                             |
-| `--dsn-text-input-padding-block-end`          | Bottom padding                          |
-| `--dsn-text-input-padding-inline-start`       | Left padding                            |
-| `--dsn-text-input-padding-inline-end`         | Right padding                           |
 | `--dsn-text-input-min-block-size`             | Minimum height (WCAG 24px touch target) |
 | `--dsn-text-input-min-inline-size`            | Minimum width (WCAG 24px touch target)  |
-| `--dsn-text-input-focus-color`                | Focus text color                        |
-| `--dsn-text-input-focus-background-color`     | Focus background color                  |
-| `--dsn-text-input-focus-border-color`         | Focus border color                      |
-| `--dsn-text-input-disabled-color`             | Disabled text color                     |
+| `--dsn-text-input-padding-block-end`          | Bottom padding                          |
+| `--dsn-text-input-padding-block-start`        | Top padding                             |
+| `--dsn-text-input-padding-inline-end`         | Right padding                           |
+| `--dsn-text-input-padding-inline-start`       | Left padding                            |
 | `--dsn-text-input-disabled-background-color`  | Disabled background color               |
 | `--dsn-text-input-disabled-border-color`      | Disabled border color                   |
-| `--dsn-text-input-read-only-color`            | Read-only text color                    |
-| `--dsn-text-input-read-only-background-color` | Read-only background color              |
-| `--dsn-text-input-read-only-border-color`     | Read-only border color                  |
-| `--dsn-text-input-invalid-color`              | Invalid text color                      |
+| `--dsn-text-input-disabled-color`             | Disabled text color                     |
+| `--dsn-text-input-focus-background-color`     | Focus background color                  |
+| `--dsn-text-input-focus-border-color`         | Focus border color                      |
+| `--dsn-text-input-focus-color`                | Focus text color                        |
 | `--dsn-text-input-invalid-background-color`   | Invalid background color                |
 | `--dsn-text-input-invalid-border-color`       | Invalid border color                    |
+| `--dsn-text-input-invalid-color`              | Invalid text color                      |
+| `--dsn-text-input-placeholder-color`          | Placeholder text color                  |
+| `--dsn-text-input-read-only-background-color` | Read-only background color              |
+| `--dsn-text-input-read-only-border-color`     | Read-only border color                  |
+| `--dsn-text-input-read-only-color`            | Read-only text color                    |
 | `--dsn-form-control-width-xs`                 | Extra small width (10ch)                |
 | `--dsn-form-control-width-sm`                 | Small width (14ch)                      |
 | `--dsn-form-control-width-md`                 | Medium width (20ch)                     |

--- a/packages/storybook/src/UnorderedList.docs.md
+++ b/packages/storybook/src/UnorderedList.docs.md
@@ -34,15 +34,15 @@ De UnorderedList component biedt een consistente, toegankelijke manier om lijste
 
 | Token                                       | Beschrijving                               |
 | ------------------------------------------- | ------------------------------------------ |
-| `--dsn-unordered-list-font-family`          | Lettertypefamilie                          |
-| `--dsn-unordered-list-font-weight`          | Font weight                                |
 | `--dsn-unordered-list-color`                | Tekstkleur                                 |
+| `--dsn-unordered-list-font-family`          | Lettertypefamilie                          |
 | `--dsn-unordered-list-font-size`            | Font size (md)                             |
-| `--dsn-unordered-list-line-height`          | Line height                                |
-| `--dsn-unordered-list-padding-inline-start` | Linker inspringing voor de lijst           |
-| `--dsn-unordered-list-margin-block-end`     | Bottom margin van de lijst                 |
+| `--dsn-unordered-list-font-weight`          | Font weight                                |
 | `--dsn-unordered-list-gap`                  | Ruimte tussen list items                   |
+| `--dsn-unordered-list-line-height`          | Line height                                |
+| `--dsn-unordered-list-margin-block-end`     | Bottom margin van de lijst                 |
 | `--dsn-unordered-list-marker-color`         | Kleur van de bullet markers (accent kleur) |
+| `--dsn-unordered-list-padding-inline-start` | Linker inspringing voor de lijst           |
 
 ## Accessibility
 


### PR DESCRIPTION
## Summary

- Bijgewerkt alle 21 `.docs.md` tokentabellen in Storybook zodat de volgorde overeenkomt met de token JSON bronbestanden (vastgesteld in issue #56 / PR #62)
- Volgorde per conventie: basis-properties alfabetisch → states in vaste volgorde (active → checked → disabled → focus → hover → invalid → placeholder → read-only) → varianten alfabetisch → sub-componenten als laatste
- Betreft: Alert, Button, ButtonLink, Checkbox, FormFieldDescription, FormFieldErrorMessage, FormFieldLabel, FormFieldStatus, Heading, Link, Note, OptionLabel, OrderedList, Paragraph, Radio, SearchInput, Select, StatusBadge, TextArea, TextInput, UnorderedList

Sluit #63.

## Test plan

- [x] CI groen (lint, build, type-check, test, storybook-tests, chromatic)
- [x] Storybook Design Tokens tabellen zijn puur documentatie — geen functionele wijzigingen

🤖 Generated with [Claude Code](https://claude.com/claude-code)