### PR TITLE
refactor(tokens): publiceer kleur-tokens Alert en Note als component-level tokens (#67)

### DIFF
--- a/packages/components-html/src/alert/alert.css
+++ b/packages/components-html/src/alert/alert.css
@@ -52,31 +52,31 @@
    Local color tokens (info = default)
    =========================== */
 .dsn-alert {
-  --dsn-alert-icon-color: var(--dsn-color-info-color-default);
-  --dsn-alert-color: var(--dsn-color-info-color-document);
-  --dsn-alert-background-color: var(--dsn-color-info-bg-default);
-  --dsn-alert-border-color: var(--dsn-color-info-border-default);
+  --dsn-alert-icon-color: var(--dsn-alert-info-icon-color);
+  --dsn-alert-color: var(--dsn-alert-info-color);
+  --dsn-alert-background-color: var(--dsn-alert-info-background-color);
+  --dsn-alert-border-color: var(--dsn-alert-info-border-color);
 }
 
 .dsn-alert--positive {
-  --dsn-alert-icon-color: var(--dsn-color-positive-color-default);
-  --dsn-alert-color: var(--dsn-color-positive-color-document);
-  --dsn-alert-background-color: var(--dsn-color-positive-bg-default);
-  --dsn-alert-border-color: var(--dsn-color-positive-border-default);
+  --dsn-alert-icon-color: var(--dsn-alert-positive-icon-color);
+  --dsn-alert-color: var(--dsn-alert-positive-color);
+  --dsn-alert-background-color: var(--dsn-alert-positive-background-color);
+  --dsn-alert-border-color: var(--dsn-alert-positive-border-color);
 }
 
 .dsn-alert--negative {
-  --dsn-alert-icon-color: var(--dsn-color-negative-color-default);
-  --dsn-alert-color: var(--dsn-color-negative-color-document);
-  --dsn-alert-background-color: var(--dsn-color-negative-bg-default);
-  --dsn-alert-border-color: var(--dsn-color-negative-border-default);
+  --dsn-alert-icon-color: var(--dsn-alert-negative-icon-color);
+  --dsn-alert-color: var(--dsn-alert-negative-color);
+  --dsn-alert-background-color: var(--dsn-alert-negative-background-color);
+  --dsn-alert-border-color: var(--dsn-alert-negative-border-color);
 }
 
 .dsn-alert--warning {
-  --dsn-alert-icon-color: var(--dsn-color-warning-color-default);
-  --dsn-alert-color: var(--dsn-color-warning-color-document);
-  --dsn-alert-background-color: var(--dsn-color-warning-bg-default);
-  --dsn-alert-border-color: var(--dsn-color-warning-border-default);
+  --dsn-alert-icon-color: var(--dsn-alert-warning-icon-color);
+  --dsn-alert-color: var(--dsn-alert-warning-color);
+  --dsn-alert-background-color: var(--dsn-alert-warning-background-color);
+  --dsn-alert-border-color: var(--dsn-alert-warning-border-color);
 }
 
 /* ===========================

--- a/packages/components-html/src/note/note.css
+++ b/packages/components-html/src/note/note.css
@@ -57,42 +57,48 @@
    Local color tokens (neutral = default)
    =========================== */
 .dsn-note {
-  --dsn-note-icon-color: var(--dsn-color-neutral-color-default);
-  --dsn-note-color: var(--dsn-color-neutral-color-document);
-  --dsn-note-background-color: var(--dsn-color-neutral-bg-default);
-  --dsn-note-border-inline-start-color: var(--dsn-color-neutral-border-default);
+  --dsn-note-icon-color: var(--dsn-note-neutral-icon-color);
+  --dsn-note-color: var(--dsn-note-neutral-color);
+  --dsn-note-background-color: var(--dsn-note-neutral-background-color);
+  --dsn-note-border-inline-start-color: var(
+    --dsn-note-neutral-border-inline-start-color
+  );
 }
 
 .dsn-note--info {
-  --dsn-note-icon-color: var(--dsn-color-info-color-default);
-  --dsn-note-color: var(--dsn-color-info-color-document);
-  --dsn-note-background-color: var(--dsn-color-info-bg-default);
-  --dsn-note-border-inline-start-color: var(--dsn-color-info-border-default);
+  --dsn-note-icon-color: var(--dsn-note-info-icon-color);
+  --dsn-note-color: var(--dsn-note-info-color);
+  --dsn-note-background-color: var(--dsn-note-info-background-color);
+  --dsn-note-border-inline-start-color: var(
+    --dsn-note-info-border-inline-start-color
+  );
 }
 
 .dsn-note--positive {
-  --dsn-note-icon-color: var(--dsn-color-positive-color-default);
-  --dsn-note-color: var(--dsn-color-positive-color-document);
-  --dsn-note-background-color: var(--dsn-color-positive-bg-default);
+  --dsn-note-icon-color: var(--dsn-note-positive-icon-color);
+  --dsn-note-color: var(--dsn-note-positive-color);
+  --dsn-note-background-color: var(--dsn-note-positive-background-color);
   --dsn-note-border-inline-start-color: var(
-    --dsn-color-positive-border-default
+    --dsn-note-positive-border-inline-start-color
   );
 }
 
 .dsn-note--negative {
-  --dsn-note-icon-color: var(--dsn-color-negative-color-default);
-  --dsn-note-color: var(--dsn-color-negative-color-document);
-  --dsn-note-background-color: var(--dsn-color-negative-bg-default);
+  --dsn-note-icon-color: var(--dsn-note-negative-icon-color);
+  --dsn-note-color: var(--dsn-note-negative-color);
+  --dsn-note-background-color: var(--dsn-note-negative-background-color);
   --dsn-note-border-inline-start-color: var(
-    --dsn-color-negative-border-default
+    --dsn-note-negative-border-inline-start-color
   );
 }
 
 .dsn-note--warning {
-  --dsn-note-icon-color: var(--dsn-color-warning-color-default);
-  --dsn-note-color: var(--dsn-color-warning-color-document);
-  --dsn-note-background-color: var(--dsn-color-warning-bg-default);
-  --dsn-note-border-inline-start-color: var(--dsn-color-warning-border-default);
+  --dsn-note-icon-color: var(--dsn-note-warning-icon-color);
+  --dsn-note-color: var(--dsn-note-warning-color);
+  --dsn-note-background-color: var(--dsn-note-warning-background-color);
+  --dsn-note-border-inline-start-color: var(
+    --dsn-note-warning-border-inline-start-color
+  );
 }
 
 /* ===========================

--- a/packages/design-tokens/src/tokens/components/alert.json
+++ b/packages/design-tokens/src/tokens/components/alert.json
@@ -35,6 +35,94 @@
         "value": "{dsn.space.row.md}",
         "type": "dimension",
         "comment": "Gap between heading and body"
+      },
+      "info": {
+        "background-color": {
+          "value": "{dsn.color.info.bg-default}",
+          "type": "color",
+          "comment": "Background color for info variant (default)"
+        },
+        "border-color": {
+          "value": "{dsn.color.info.border-default}",
+          "type": "color",
+          "comment": "Border color for info variant (default)"
+        },
+        "color": {
+          "value": "{dsn.color.info.color-document}",
+          "type": "color",
+          "comment": "Text color for info variant (default)"
+        },
+        "icon-color": {
+          "value": "{dsn.color.info.color-default}",
+          "type": "color",
+          "comment": "Icon color for info variant (default)"
+        }
+      },
+      "negative": {
+        "background-color": {
+          "value": "{dsn.color.negative.bg-default}",
+          "type": "color",
+          "comment": "Background color for negative variant"
+        },
+        "border-color": {
+          "value": "{dsn.color.negative.border-default}",
+          "type": "color",
+          "comment": "Border color for negative variant"
+        },
+        "color": {
+          "value": "{dsn.color.negative.color-document}",
+          "type": "color",
+          "comment": "Text color for negative variant"
+        },
+        "icon-color": {
+          "value": "{dsn.color.negative.color-default}",
+          "type": "color",
+          "comment": "Icon color for negative variant"
+        }
+      },
+      "positive": {
+        "background-color": {
+          "value": "{dsn.color.positive.bg-default}",
+          "type": "color",
+          "comment": "Background color for positive variant"
+        },
+        "border-color": {
+          "value": "{dsn.color.positive.border-default}",
+          "type": "color",
+          "comment": "Border color for positive variant"
+        },
+        "color": {
+          "value": "{dsn.color.positive.color-document}",
+          "type": "color",
+          "comment": "Text color for positive variant"
+        },
+        "icon-color": {
+          "value": "{dsn.color.positive.color-default}",
+          "type": "color",
+          "comment": "Icon color for positive variant"
+        }
+      },
+      "warning": {
+        "background-color": {
+          "value": "{dsn.color.warning.bg-default}",
+          "type": "color",
+          "comment": "Background color for warning variant"
+        },
+        "border-color": {
+          "value": "{dsn.color.warning.border-default}",
+          "type": "color",
+          "comment": "Border color for warning variant"
+        },
+        "color": {
+          "value": "{dsn.color.warning.color-document}",
+          "type": "color",
+          "comment": "Text color for warning variant"
+        },
+        "icon-color": {
+          "value": "{dsn.color.warning.color-default}",
+          "type": "color",
+          "comment": "Icon color for warning variant"
+        }
       }
     }
   }

--- a/packages/design-tokens/src/tokens/components/note.json
+++ b/packages/design-tokens/src/tokens/components/note.json
@@ -35,6 +35,116 @@
         "value": "{dsn.space.row.md}",
         "type": "dimension",
         "comment": "Gap between heading and body"
+      },
+      "info": {
+        "background-color": {
+          "value": "{dsn.color.info.bg-default}",
+          "type": "color",
+          "comment": "Background color for info variant"
+        },
+        "border-inline-start-color": {
+          "value": "{dsn.color.info.border-default}",
+          "type": "color",
+          "comment": "Left border color for info variant"
+        },
+        "color": {
+          "value": "{dsn.color.info.color-document}",
+          "type": "color",
+          "comment": "Text color for info variant"
+        },
+        "icon-color": {
+          "value": "{dsn.color.info.color-default}",
+          "type": "color",
+          "comment": "Icon color for info variant"
+        }
+      },
+      "negative": {
+        "background-color": {
+          "value": "{dsn.color.negative.bg-default}",
+          "type": "color",
+          "comment": "Background color for negative variant"
+        },
+        "border-inline-start-color": {
+          "value": "{dsn.color.negative.border-default}",
+          "type": "color",
+          "comment": "Left border color for negative variant"
+        },
+        "color": {
+          "value": "{dsn.color.negative.color-document}",
+          "type": "color",
+          "comment": "Text color for negative variant"
+        },
+        "icon-color": {
+          "value": "{dsn.color.negative.color-default}",
+          "type": "color",
+          "comment": "Icon color for negative variant"
+        }
+      },
+      "neutral": {
+        "background-color": {
+          "value": "{dsn.color.neutral.bg-default}",
+          "type": "color",
+          "comment": "Background color for neutral variant (default)"
+        },
+        "border-inline-start-color": {
+          "value": "{dsn.color.neutral.border-default}",
+          "type": "color",
+          "comment": "Left border color for neutral variant (default)"
+        },
+        "color": {
+          "value": "{dsn.color.neutral.color-document}",
+          "type": "color",
+          "comment": "Text color for neutral variant (default)"
+        },
+        "icon-color": {
+          "value": "{dsn.color.neutral.color-default}",
+          "type": "color",
+          "comment": "Icon color for neutral variant (default)"
+        }
+      },
+      "positive": {
+        "background-color": {
+          "value": "{dsn.color.positive.bg-default}",
+          "type": "color",
+          "comment": "Background color for positive variant"
+        },
+        "border-inline-start-color": {
+          "value": "{dsn.color.positive.border-default}",
+          "type": "color",
+          "comment": "Left border color for positive variant"
+        },
+        "color": {
+          "value": "{dsn.color.positive.color-document}",
+          "type": "color",
+          "comment": "Text color for positive variant"
+        },
+        "icon-color": {
+          "value": "{dsn.color.positive.color-default}",
+          "type": "color",
+          "comment": "Icon color for positive variant"
+        }
+      },
+      "warning": {
+        "background-color": {
+          "value": "{dsn.color.warning.bg-default}",
+          "type": "color",
+          "comment": "Background color for warning variant"
+        },
+        "border-inline-start-color": {
+          "value": "{dsn.color.warning.border-default}",
+          "type": "color",
+          "comment": "Left border color for warning variant"
+        },
+        "color": {
+          "value": "{dsn.color.warning.color-document}",
+          "type": "color",
+          "comment": "Text color for warning variant"
+        },
+        "icon-color": {
+          "value": "{dsn.color.warning.color-default}",
+          "type": "color",
+          "comment": "Icon color for warning variant"
+        }
       }
     }
   }

--- a/packages/storybook/src/Alert.docs.md
+++ b/packages/storybook/src/Alert.docs.md
@@ -61,24 +61,31 @@ De Alert component toont een prominent bericht op de pagina — bij een succesvo
 
 ## Design tokens
 
-| Token                        | Beschrijving                                          |
-| ---------------------------- | ----------------------------------------------------- |
-| `--dsn-alert-border-radius`  | Border radius (0px by default; thema-overschrijfbaar) |
-| `--dsn-alert-border-width`   | Breedte van de border                                 |
-| `--dsn-alert-column-gap`     | Ruimte tussen icoon en tekst                          |
-| `--dsn-alert-icon-size`      | Icoongrootte (ook breedte eerste grid-kolom)          |
-| `--dsn-alert-padding-block`  | Verticale padding                                     |
-| `--dsn-alert-padding-inline` | Horizontale padding                                   |
-| `--dsn-alert-row-gap`        | Ruimte tussen heading en body content                 |
-
-De kleur-tokens zijn lokale CSS custom properties en worden niet als globale tokens gepubliceerd:
-
-| Lokale property                | Beschrijving                          |
-| ------------------------------ | ------------------------------------- |
-| `--dsn-alert-icon-color`       | Kleur van het icoon (signaalkleur)    |
-| `--dsn-alert-color`            | Tekstkleur (leesbaar, iets donkerder) |
-| `--dsn-alert-background-color` | Achtergrondkleur                      |
-| `--dsn-alert-border-color`     | Kleur van de linkerborder             |
+| Token                                   | Beschrijving                                          |
+| --------------------------------------- | ----------------------------------------------------- |
+| `--dsn-alert-border-radius`             | Border radius (0px by default; thema-overschrijfbaar) |
+| `--dsn-alert-border-width`              | Breedte van de border                                 |
+| `--dsn-alert-column-gap`                | Ruimte tussen icoon en tekst                          |
+| `--dsn-alert-icon-size`                 | Icoongrootte (ook breedte eerste grid-kolom)          |
+| `--dsn-alert-padding-block`             | Verticale padding                                     |
+| `--dsn-alert-padding-inline`            | Horizontale padding                                   |
+| `--dsn-alert-row-gap`                   | Ruimte tussen heading en body content                 |
+| `--dsn-alert-info-background-color`     | Achtergrond info variant                              |
+| `--dsn-alert-info-border-color`         | Borderkleur info variant                              |
+| `--dsn-alert-info-color`                | Tekstkleur info variant                               |
+| `--dsn-alert-info-icon-color`           | Icoonkleur info variant                               |
+| `--dsn-alert-negative-background-color` | Achtergrond negative variant                          |
+| `--dsn-alert-negative-border-color`     | Borderkleur negative variant                          |
+| `--dsn-alert-negative-color`            | Tekstkleur negative variant                           |
+| `--dsn-alert-negative-icon-color`       | Icoonkleur negative variant                           |
+| `--dsn-alert-positive-background-color` | Achtergrond positive variant                          |
+| `--dsn-alert-positive-border-color`     | Borderkleur positive variant                          |
+| `--dsn-alert-positive-color`            | Tekstkleur positive variant                           |
+| `--dsn-alert-positive-icon-color`       | Icoonkleur positive variant                           |
+| `--dsn-alert-warning-background-color`  | Achtergrond warning variant                           |
+| `--dsn-alert-warning-border-color`      | Borderkleur warning variant                           |
+| `--dsn-alert-warning-color`             | Tekstkleur warning variant                            |
+| `--dsn-alert-warning-icon-color`        | Icoonkleur warning variant                            |
 
 ## Accessibility
 

--- a/packages/storybook/src/Note.docs.md
+++ b/packages/storybook/src/Note.docs.md
@@ -62,24 +62,35 @@ Bij `as="nav"`, `as="aside"` of `as="section"` + een `heading` prop: de Note kop
 
 ## Design tokens
 
-| Token                                  | Beschrijving                                 |
-| -------------------------------------- | -------------------------------------------- |
-| `--dsn-note-border-inline-start-width` | Breedte van de linkerborder                  |
-| `--dsn-note-column-gap`                | Ruimte tussen icoon en tekst                 |
-| `--dsn-note-icon-size`                 | Icoongrootte (ook breedte eerste grid-kolom) |
-| `--dsn-note-padding-block`             | Verticale padding                            |
-| `--dsn-note-padding-inline-end`        | Horizontale padding rechts                   |
-| `--dsn-note-padding-inline-start`      | Horizontale padding links                    |
-| `--dsn-note-row-gap`                   | Ruimte tussen heading en body                |
-
-De kleur-tokens zijn lokale CSS custom properties per variant:
-
-| Lokale property                        | Beschrijving                       |
-| -------------------------------------- | ---------------------------------- |
-| `--dsn-note-icon-color`                | Kleur van het icoon (signaalkleur) |
-| `--dsn-note-color`                     | Tekstkleur                         |
-| `--dsn-note-background-color`          | Achtergrondkleur                   |
-| `--dsn-note-border-inline-start-color` | Kleur van de linkerborder          |
+| Token                                           | Beschrijving                                 |
+| ----------------------------------------------- | -------------------------------------------- |
+| `--dsn-note-border-inline-start-width`          | Breedte van de linkerborder                  |
+| `--dsn-note-column-gap`                         | Ruimte tussen icoon en tekst                 |
+| `--dsn-note-icon-size`                          | Icoongrootte (ook breedte eerste grid-kolom) |
+| `--dsn-note-padding-block`                      | Verticale padding                            |
+| `--dsn-note-padding-inline-end`                 | Horizontale padding rechts                   |
+| `--dsn-note-padding-inline-start`               | Horizontale padding links                    |
+| `--dsn-note-row-gap`                            | Ruimte tussen heading en body                |
+| `--dsn-note-info-background-color`              | Achtergrond info variant                     |
+| `--dsn-note-info-border-inline-start-color`     | Linkerborderkleur info variant               |
+| `--dsn-note-info-color`                         | Tekstkleur info variant                      |
+| `--dsn-note-info-icon-color`                    | Icoonkleur info variant                      |
+| `--dsn-note-negative-background-color`          | Achtergrond negative variant                 |
+| `--dsn-note-negative-border-inline-start-color` | Linkerborderkleur negative variant           |
+| `--dsn-note-negative-color`                     | Tekstkleur negative variant                  |
+| `--dsn-note-negative-icon-color`                | Icoonkleur negative variant                  |
+| `--dsn-note-neutral-background-color`           | Achtergrond neutral variant                  |
+| `--dsn-note-neutral-border-inline-start-color`  | Linkerborderkleur neutral variant            |
+| `--dsn-note-neutral-color`                      | Tekstkleur neutral variant                   |
+| `--dsn-note-neutral-icon-color`                 | Icoonkleur neutral variant                   |
+| `--dsn-note-positive-background-color`          | Achtergrond positive variant                 |
+| `--dsn-note-positive-border-inline-start-color` | Linkerborderkleur positive variant           |
+| `--dsn-note-positive-color`                     | Tekstkleur positive variant                  |
+| `--dsn-note-positive-icon-color`                | Icoonkleur positive variant                  |
+| `--dsn-note-warning-background-color`           | Achtergrond warning variant                  |
+| `--dsn-note-warning-border-inline-start-color`  | Linkerborderkleur warning variant            |
+| `--dsn-note-warning-color`                      | Tekstkleur warning variant                   |
+| `--dsn-note-warning-icon-color`                 | Icoonkleur warning variant                   |
 
 ## Accessibility
 


### PR DESCRIPTION
## Summary

- `alert.json`: 16 nieuwe variant kleur-tokens toegevoegd (info/negative/positive/warning × background-color/border-color/color/icon-color)
- `note.json`: 20 nieuwe variant kleur-tokens toegevoegd (info/negative/neutral/positive/warning × background-color/border-inline-start-color/color/icon-color)
- `alert.css` en `note.css`: intermediate lokale CSS properties verwijzen nu naar JSON token variabelen i.p.v. semantische tokens direct
- `Alert.docs.md` en `Note.docs.md`: twee tabellen samengevoegd tot één uniforme tabel; disclaimer "lokale CSS custom properties" verwijderd

Volgt het StatusBadge patroon: alle kleur-tokens zijn nu gepubliceerde component-level tokens die per thema overschrijfbaar zijn.

Sluit #67.

## Test plan

- [x] `pnpm build` slaagt
- [x] `pnpm test` groen (880/880)
- [x] `pnpm lint` geen errors (4 pre-existing warnings)
- [x] Gegenereerde CSS bevat `--dsn-alert-info-background-color`, `--dsn-note-neutral-icon-color` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)