### PR TITLE
chore(docs): bijwerken naar versie 4.9.0 — sessie 10

### DIFF
--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-**Last Updated:** February 14, 2026
+**Last Updated:** March 5, 2026
 
 This document describes the architecture of the Design System Starter Kit, including the token system, configuration model, and repository structure.
 
@@ -70,20 +70,23 @@ design-system-starter-kit/
 │   │           │   └── information-dense/
 │   │           │       └── typography.json    # Fixed font-sizes
 │   │           └── components/
+│   │               ├── alert.json
 │   │               ├── button.json
 │   │               ├── checkbox.json
 │   │               ├── checkbox-group.json
 │   │               ├── checkbox-option.json
-│   │               ├── email-input.json
-│   │               ├── form-control.json
+│   │               ├── date-input.json
+│   │               ├── date-input-group.json
 │   │               ├── form-field.json
 │   │               ├── form-field-description.json
 │   │               ├── form-field-error-message.json
 │   │               ├── form-field-label.json
+│   │               ├── form-field-label-suffix.json
 │   │               ├── form-field-status.json
 │   │               ├── heading.json
 │   │               ├── link.json
-│   │               ├── number-input.json
+│   │               ├── note.json
+│   │               ├── option-label.json
 │   │               ├── ordered-list.json
 │   │               ├── paragraph.json
 │   │               ├── password-input.json
@@ -91,7 +94,8 @@ design-system-starter-kit/
 │   │               ├── radio-group.json
 │   │               ├── radio-option.json
 │   │               ├── search-input.json
-│   │               ├── telephone-input.json
+│   │               ├── select.json
+│   │               ├── status-badge.json
 │   │               ├── text-area.json
 │   │               ├── text-input.json
 │   │               ├── time-input.json

--- a/docs/02-design-tokens-reference.md
+++ b/docs/02-design-tokens-reference.md
@@ -1,6 +1,6 @@
 # Design Tokens Reference
 
-**Last Updated:** February 14, 2026
+**Last Updated:** March 5, 2026
 
 Complete reference for all design tokens in the Design System Starter Kit.
 
@@ -310,11 +310,11 @@ Focus indicators use a dual-outline technique: a primary `outline` for the main 
 
 ## Token Statistics
 
-**Total Tokens (as of v4.0.0):**
+**Total Tokens (as of v4.9.0):**
 
 - Semantic tokens: ~400 per configuration
-- Component tokens: ~650 (Button, Heading, Icon, Link, OrderedList, Paragraph, UnorderedList + 19 form components)
-- **Total: ~1050+ tokens per full configuration**
+- Component tokens: ~700 (30 component JSON files — 9 content + 3 display/feedback + 25 form, incl. variant kleur-tokens Alert/Note/StatusBadge)
+- **Total: ~1100+ tokens per full configuration**
 - **Total configurations: 8** (2 themes × 2 modes × 2 project types)
 
 ---

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1,6 +1,6 @@
 # Components
 
-**Last Updated:** March 3, 2026
+**Last Updated:** March 5, 2026
 
 Complete component specifications and guidelines for the Design System Starter Kit.
 
@@ -181,9 +181,9 @@ Components are designed to compose together:
 
 **Component Tokens:** 90+ tokens in `tokens/components/button.json`
 
-**Variants (10 total):**
+**Variants (9 total):**
 
-- Base: `strong`, `default`, `subtle`, `link`
+- Base: `strong`, `default`, `subtle`
 - Negative: `strong-negative`, `default-negative`, `subtle-negative`
 - Positive: `strong-positive`, `default-positive`, `subtle-positive`
 
@@ -311,6 +311,92 @@ Components are designed to compose together:
 - `marker-color` — accent color for number markers
 
 **Tests:** React (8 tests), Web Component (11 tests)
+
+### LinkButton Component
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-{html|react}/src/LinkButton/`
+
+**Component Tokens:** Erft van `tokens/components/link.json` — geen eigen token namespace
+
+**Features:**
+
+- Semantisch `<button>`, visueel als een `Link` — voor JS-acties met lage attentiewaarde
+- CSS: `dsn-link dsn-link-button` — erft alle Link-stijlen
+- `disabled`: native `<button disabled>` + CSS selector `.dsn-link.dsn-link-button:disabled`
+- `font: inherit` bewust weggelaten uit `dsn-link-button` — `dsn-link` regelt dit al; herhalen overschrijft `font-size` van size-klassen
+- Zie ook: [De drie-weg keuze (Architecture)](./01-architecture.md)
+
+**Drie-weg keuze:**
+
+| Situatie                                | Component                                  |
+| --------------------------------------- | ------------------------------------------ |
+| Navigeert naar URL, hoge attentiewaarde | `ButtonLink` — `<a>` visueel als Button    |
+| Navigeert naar URL, lage attentiewaarde | `Link` — `<a>` visueel als Link            |
+| JS-actie, lage attentiewaarde           | `LinkButton` — `<button>` visueel als Link |
+| JS-actie, hoge attentiewaarde           | `Button` — `<button>` visueel als Button   |
+
+**HTML/CSS:**
+
+```html
+<button type="button" class="dsn-link dsn-link-button">Label</button>
+<button type="button" class="dsn-link dsn-link-button" disabled>
+  Uitgeschakeld
+</button>
+```
+
+**React:**
+
+```tsx
+<LinkButton onClick={handleAction}>Actie uitvoeren</LinkButton>
+<LinkButton disabled>Uitgeschakeld</LinkButton>
+```
+
+**Tests:** React (11 tests)
+
+### ButtonLink Component
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-{html|react}/src/ButtonLink/`
+
+**Component Tokens:** Erft van `tokens/components/button.json` — geen eigen token namespace
+
+**Features:**
+
+- Semantisch `<a>`, visueel als een `Button` — voor navigatieacties met hoge attentiewaarde
+- CSS: `dsn-button dsn-button--{variant} dsn-button--size-{size} dsn-button-link`
+- `disabled`: `aria-disabled="true"` + `tabIndex={-1}` + `pointer-events: none` (`:disabled` pseudo-class werkt niet op `<a>`)
+- `external`: auto `target="_blank"` + `rel="noopener noreferrer"` + zichtbare "(opent nieuw tabblad)" tekst
+- `children` altijd gewrapt in `<span class="dsn-button__label">` — zelfde patroon als Button
+
+**HTML/CSS:**
+
+```html
+<a href="/pagina" class="dsn-button dsn-button--strong dsn-button-link">
+  <span class="dsn-button__label">Navigeer naar pagina</span>
+</a>
+
+<!-- Disabled -->
+<a
+  class="dsn-button dsn-button--strong dsn-button-link"
+  aria-disabled="true"
+  tabindex="-1"
+>
+  <span class="dsn-button__label">Niet beschikbaar</span>
+</a>
+```
+
+**React:**
+
+```tsx
+<ButtonLink href="/pagina" variant="strong">Navigeer naar pagina</ButtonLink>
+<ButtonLink href="https://example.com" external>Externe link</ButtonLink>
+<ButtonLink href="/pagina" disabled>Niet beschikbaar</ButtonLink>
+```
+
+**Tests:** React (20 tests)
 
 ---
 
@@ -756,15 +842,15 @@ defineButton('my-custom-button');
 
 ## Component Statistics
 
-**Total Components:** 35
+**Total Components:** 37
 
 **Implementations:**
 
-- **HTML/CSS:** 35 components
-- **React:** 35 components (824 tests total)
+- **HTML/CSS:** 37 components
+- **React:** 37 components (880 tests total)
 - **Web Component:** 7 components (Button, Heading, Icon, Link, OrderedList, Paragraph, UnorderedList)
 
-**Test Coverage:** 824 tests across 41 test suites
+**Test Coverage:** 880 tests across 43 test suites
 
 ---
 

--- a/docs/04-development-workflow.md
+++ b/docs/04-development-workflow.md
@@ -1,6 +1,6 @@
 # Development Workflow
 
-**Last Updated:** February 14, 2026
+**Last Updated:** March 5, 2026
 
 Guidelines and workflows for developing and contributing to the Design System Starter Kit.
 
@@ -36,7 +36,7 @@ pnpm --filter @dsn/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (628 tests across 35 test suites)
+# Run tests (880 tests across 43 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -459,7 +459,7 @@ import '@dsn/core/css'; // Includes reset + utilities
 
 ### Test Coverage
 
-- **Total tests:** 628 across 35 test suites
+- **Total tests:** 880 across 43 test suites
 - **Frameworks:** Vitest + React Testing Library
 - **Coverage areas:** React components, Web Components, utilities
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Design System Documentation
 
-**Version:** 4.7.0
-**Last Updated:** March 3, 2026
+**Version:** 4.9.0
+**Last Updated:** March 5, 2026
 
 Complete documentation voor het Design System Starter Kit.
 
@@ -81,10 +81,10 @@ Complete documentation voor het Design System Starter Kit.
 
 ## 📊 System Statistics
 
-- **Tokens per configuration:** ~1050 (400 semantic + 650 component)
+- **Tokens per configuration:** ~1100 (400 semantic + 700 component)
 - **Configurations:** 8 (2 themes × 2 modes × 2 project types)
-- **Components:** 35 implemented (7 content + 3 display/feedback + 25 form; HTML/CSS + React)
-- **Tests:** 824 across 41 test suites
+- **Components:** 37 implemented (9 content + 3 display/feedback + 25 form; HTML/CSS + React)
+- **Tests:** 880 across 43 test suites
 - **Storybook stories:** 130+
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,89 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 4.9.0 (March 5, 2026)
+
+### Component-level tokens: kleur-tokens Alert en Note gepubliceerd (PR #68, issue #67)
+
+- **Alert:** 16 nieuwe component-level kleur-tokens toegevoegd aan `alert.json` — 4 varianten (info, negative, positive, warning) × 4 eigenschappen (background-color, border-color, color, icon-color)
+- **Note:** 20 nieuwe component-level kleur-tokens toegevoegd aan `note.json` — 5 varianten (info, negative, neutral, positive, warning) × 4 eigenschappen (background-color, border-inline-start-color, color, icon-color)
+- `alert.css` en `note.css`: intermediate lokale CSS properties verwijzen nu naar de gepubliceerde JSON token variabelen in plaats van rechtstreeks naar semantische tokens
+- `Alert.docs.md` en `Note.docs.md`: twee tabellen (layout + kleur) samengevoegd tot één uniforme tokentabel conform StatusBadge patroon; disclaimer "lokale CSS custom properties" verwijderd
+- Variant kleur-tokens zijn nu overschrijfbaar per thema via CSS custom properties
+
+---
+
+## Version 4.8.0 (March 4, 2026)
+
+### Component-level tokens: Button, FormFieldStatus, Alert, Note, StatusBadge (PR #66, issue #65)
+
+**Toegevoegde tokens Button**
+
+- `dsn.button.border-radius` → `{dsn.border.radius.md}`
+- `dsn.button.border-width` → `{dsn.border.width.thin}`
+- `dsn.button.font-family` → `{dsn.text.font-family.default}`
+- `dsn.button.font-weight` → `{dsn.text.font-weight.bold}`
+- `dsn.button.line-height` → `{dsn.text.line-height.md}`
+- `dsn.button.min-block-size` → `{dsn.pointer-target.min-block-size}`
+- `dsn.button.min-inline-size` → `{dsn.pointer-target.min-inline-size}`
+- `dsn.button.size.small.min-block-size` → `2.5rem` (kleinere touch target voor small variant)
+- `button.css`: 7 semantische tokens + 1 hardcoded waarde vervangen door component-level tokens
+
+**Toegevoegde tokens FormFieldStatus**
+
+- `dsn.form-field-status.gap` → `{dsn.space.text.sm}`
+- `dsn.form-field-status.icon-size` → `{dsn.icon.size.md}`
+- `dsn.form-field-status.positive-color` → `{dsn.color.positive.color-default}`
+- `dsn.form-field-status.warning-color` → `{dsn.color.warning.color-default}`
+
+**Toegevoegde icon-size tokens (Alert, Note, StatusBadge)**
+
+- `dsn.alert.icon-size` → `{dsn.icon.size.xl}` (ook breedte eerste grid-kolom)
+- `dsn.note.icon-size` → `{dsn.icon.size.xl}` (ook breedte eerste grid-kolom)
+- `dsn.status-badge.icon-size` → `{dsn.icon.size.sm}`
+
+**Docs**
+
+- `Button.docs.md`: 7 verouderde semantische token-rijen vervangen door 8 component-level token-rijen
+- `Button.docs.md`: 9 verouderde `--dsn-button-link-*` tokens verwijderd (link-variant bestaat niet meer; vervangen door LinkButton component)
+- `FormFieldStatus.docs.md`, `Alert.docs.md`, `Note.docs.md`, `StatusBadge.docs.md`: tokentabellen bijgewerkt
+
+---
+
+**Session 8 werk (PR's #43–#64)**
+
+### LinkButton en ButtonLink componenten (PR #43, issue #41 / PR #44, issue #42)
+
+**LinkButton**
+
+- **LinkButton component** — semantisch `<button>`, visueel als een Link — voor JS-acties met lage attentiewaarde
+- CSS: erft `dsn-link` en `dsn-link-button` klassen
+- `disabled`: native `<button disabled>` + CSS `.dsn-link.dsn-link-button:disabled`
+- `font: inherit` bewust weggelaten uit `dsn-link-button` — `dsn-link` zet dit al; herhalen overschrijft `font-size` van size-klassen
+- Storybook: Default, Disabled, All states, alle size-varianten, Long text, RTL
+
+**ButtonLink**
+
+- **ButtonLink component** — semantisch `<a>`, visueel als een Button — voor navigatieacties met hoge attentiewaarde
+- CSS: `dsn-button dsn-button--{variant} dsn-button--size-{size} dsn-button-link`
+- `disabled`: `aria-disabled="true"` + `tabIndex={-1}` + `pointer-events: none` (`:disabled` pseudo-class werkt niet op `<a>`)
+- `external`: auto `target="_blank"` + `rel="noopener noreferrer"` + zichtbare "(opent nieuw tabblad)" tekst
+- `children` altijd gewrapt in `<span class="dsn-button__label">` — zelfde patroon als Button
+- Storybook: Default, alle varianten, Disabled, External, Long text, RTL
+
+### Storybook TypeScript fixes (PR's #51, #52, #53)
+
+- `#51` — Ambient module declaration toegevoegd voor `*.mdx` imports (TypeScript kende het type niet)
+- `#52` — Subpath export geconfigureerd voor `icon-registry.generated` in `components-react`
+- `#53` — `TS7053` opgelost voor `globalThis` string-index in `preview.ts`
+
+### Token key ordering (PR #57, issue #56 / PR #64, issue #63)
+
+- `#56` — Consistente sleutelvolgorde doorgevoerd in alle token JSON bestanden: depth-first, alphabetisch, states → variants → sub-componenten
+- `#63` — Follow-up: tokenvolgorde ook doorgevoerd in alle `.docs.md` tabellen in Storybook
+
+---
+
 ## Version 4.7.0 (March 3, 2026)
 
 ### Note component + Alert/Note polish


### PR DESCRIPTION
## Summary

Documentatie bijgewerkt naar de actuele staat na sessies 8 en 9.

- `changelog.md`: versies 4.8.0 (session 8) en 4.9.0 (session 9) toegevoegd
- `README.md`: versie 4.7.0 → 4.9.0, componentcount 35 → 37, tests 824/41 → 880/43
- `01-architecture.md`: component JSON bestandslijst bijgewerkt (30 actuele bestanden)
- `02-design-tokens-reference.md`: token stats bijgewerkt naar v4.9.0
- `03-components.md`: LinkButton + ButtonLink toegevoegd, Button "link" variant verwijderd, stats bijgewerkt
- `04-development-workflow.md`: testcount bijgewerkt

## Test plan

- [x] `pnpm build` slaagt (docs zijn markdown — geen buildstap vereist)
- [x] Geen wijzigingen aan broncode

🤖 Generated with [Claude Code](https://claude.com/claude-code)