### PR TITLE
feat(tokens): elevatie box-shadow tokens (sm, md, lg)

### DIFF
--- a/packages/design-tokens/src/tokens/themes/start/base.json
+++ b/packages/design-tokens/src/tokens/themes/start/base.json
@@ -516,6 +516,20 @@
         "value": "74em",
         "comment": "Extra large breakpoint - ~1184px. Reference only; use hardcoded values in CSS @media rules."
       }
+    },
+    "box-shadow": {
+      "sm": {
+        "value": "0 1px 2px 0 {dsn.color.shadow.direct}, 0 2px 4px 0 {dsn.color.shadow.ambient}, 0 0 0 1px {dsn.color.shadow.highlight}",
+        "comment": "Kleine elevatie — cards, chips, kleine floating elementen"
+      },
+      "md": {
+        "value": "0 2px 4px 0 {dsn.color.shadow.direct}, 0 8px 16px 0 {dsn.color.shadow.ambient}, 0 0 0 1px {dsn.color.shadow.highlight}",
+        "comment": "Middelgrote elevatie — dropdowns, date pickers, tooltips"
+      },
+      "lg": {
+        "value": "0 4px 8px 0 {dsn.color.shadow.direct}, 0 16px 32px 0 {dsn.color.shadow.ambient}, 0 0 0 1px {dsn.color.shadow.highlight}",
+        "comment": "Grote elevatie — modals, dialogen, side panels"
+      }
     }
   }
 }

--- a/packages/design-tokens/src/tokens/themes/start/colors-dark.json
+++ b/packages/design-tokens/src/tokens/themes/start/colors-dark.json
@@ -1545,6 +1545,23 @@
         "value": "transparent",
         "type": "color",
         "comment": "Fully transparent - for invisible backgrounds and borders"
+      },
+      "shadow": {
+        "direct": {
+          "value": "color-mix(in srgb, black 60%, transparent)",
+          "type": "color",
+          "comment": "Scherpe schaduwlaag — sterker dan light mode omdat donkere achtergronden meer contrast nodig hebben"
+        },
+        "ambient": {
+          "value": "color-mix(in srgb, black 40%, transparent)",
+          "type": "color",
+          "comment": "Diffuse schaduwlaag — sterker dan light mode"
+        },
+        "highlight": {
+          "value": "color-mix(in srgb, white 8%, transparent)",
+          "type": "color",
+          "comment": "Outline-laag — subtiele witte rand geeft elevated surfaces randscherpte in dark mode"
+        }
       }
     },
     "heading": {

--- a/packages/design-tokens/src/tokens/themes/start/colors-light.json
+++ b/packages/design-tokens/src/tokens/themes/start/colors-light.json
@@ -1545,6 +1545,23 @@
         "value": "transparent",
         "type": "color",
         "comment": "Fully transparent - for invisible backgrounds and borders"
+      },
+      "shadow": {
+        "direct": {
+          "value": "color-mix(in srgb, black 12%, transparent)",
+          "type": "color",
+          "comment": "Scherpe schaduwlaag — direct licht, dichtbij het object"
+        },
+        "ambient": {
+          "value": "color-mix(in srgb, black 6%, transparent)",
+          "type": "color",
+          "comment": "Diffuse schaduwlaag — omgevingslicht, verder weg"
+        },
+        "highlight": {
+          "value": "transparent",
+          "type": "color",
+          "comment": "Outline-laag — transparent in light mode (no-op)"
+        }
       }
     },
     "heading": {

--- a/packages/storybook/src/DesignTokens.mdx
+++ b/packages/storybook/src/DesignTokens.mdx
@@ -645,3 +645,33 @@ Minimum touch/click target sizes following WCAG 2.5.5 Target Size.
     { name: 'Min Inline Size', cssVar: '--dsn-pointer-target-min-inline-size', value: '3rem (48px)' },
   ]}
 />
+
+---
+
+## Box Shadows
+
+Elevation shadows communicate depth — which surface floats above another. Each shadow is composed of two drop shadow layers (direct + ambient) and a spread-only outline layer (highlight). Only the color tokens differ between light and dark mode; the shadow structure is identical.
+
+### Shadow Colors
+
+The three primitives that power all elevation shadows. In light mode `highlight` is transparent (no visual effect). In dark mode `highlight` becomes a subtle white outline to define edges where drop shadows are less visible.
+
+<TokenTable
+  previewType="color"
+  tokens={[
+    { name: 'Direct', cssVar: '--dsn-color-shadow-direct' },
+    { name: 'Ambient', cssVar: '--dsn-color-shadow-ambient' },
+    { name: 'Highlight', cssVar: '--dsn-color-shadow-highlight' },
+  ]}
+/>
+
+### Elevation Scale
+
+<TokenTable
+  previewType="shadow"
+  tokens={[
+    { name: 'sm — Cards, chips', cssVar: '--dsn-box-shadow-sm' },
+    { name: 'md — Dropdowns, tooltips', cssVar: '--dsn-box-shadow-md' },
+    { name: 'lg — Modals, dialogs', cssVar: '--dsn-box-shadow-lg' },
+  ]}
+/>

--- a/packages/storybook/src/components/TokenTable.tsx
+++ b/packages/storybook/src/components/TokenTable.tsx
@@ -18,6 +18,7 @@ type PreviewType =
   | 'spacing'
   | 'typography-size'
   | 'border-radius'
+  | 'shadow'
   | 'none';
 
 interface TokenTableProps {
@@ -102,6 +103,30 @@ function BorderRadiusPreview({ cssVar }: { cssVar: string }) {
   );
 }
 
+function ShadowPreview({ cssVar }: { cssVar: string }) {
+  return (
+    <div
+      style={{
+        padding: '6px 8px',
+        background: 'var(--dsn-color-neutral-bg-document, #fcfcfc)',
+        borderRadius: 6,
+        boxShadow: `var(${cssVar})`,
+      }}
+    >
+      <span
+        style={{
+          fontSize: 11,
+          fontFamily: 'var(--dsn-text-font-family-default, sans-serif)',
+          color: 'var(--dsn-color-neutral-color-subtle, #666)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {cssVar.replace('--dsn-box-shadow-', '')}
+      </span>
+    </div>
+  );
+}
+
 function Preview({ type, cssVar }: { type: PreviewType; cssVar: string }) {
   switch (type) {
     case 'color':
@@ -112,6 +137,8 @@ function Preview({ type, cssVar }: { type: PreviewType; cssVar: string }) {
       return <TypographySizePreview cssVar={cssVar} />;
     case 'border-radius':
       return <BorderRadiusPreview cssVar={cssVar} />;
+    case 'shadow':
+      return <ShadowPreview cssVar={cssVar} />;
     case 'none':
       return null;
   }
@@ -291,7 +318,12 @@ export function TokenTable({
         {tokens.map((token) => (
           <tr key={token.cssVar}>
             {showPreview && (
-              <td style={{ ...cellStyle, width: 60 }}>
+              <td
+                style={{
+                  ...cellStyle,
+                  width: previewType === 'shadow' ? 140 : 60,
+                }}
+              >
                 <Preview type={previewType} cssVar={token.cssVar} />
               </td>
             )}


### PR DESCRIPTION
## Summary

- Voegt `dsn.color.shadow.{direct,ambient,highlight}` toe als primitieve kleurtokens in `colors-light.json` en `colors-dark.json` (start-thema)
- Voegt `dsn.box-shadow.{sm,md,lg}` toe als samengestelde shorthand tokens in `base.json`
- Voegt `## Box Shadows` sectie toe aan Foundations/Design Tokens in Storybook, inclusief een `ShadowPreview` component met live dark mode support

## Token-architectuur

Elke shadow bestaat uit 3 lagen die via CSS custom properties worden opgebouwd:

```css
--dsn-box-shadow-sm:
  0 1px 2px 0 var(--dsn-color-shadow-direct),
  0 2px 4px 0 var(--dsn-color-shadow-ambient),
  0 0 0 1px var(--dsn-color-shadow-highlight);
```

De `box-shadow` tokens zijn identiek voor light en dark mode. Alleen de kleurtokens verschillen:

| Token | Light | Dark |
|---|---|---|
| `direct` | `color-mix(in srgb, black 12%, transparent)` | `color-mix(in srgb, black 60%, transparent)` |
| `ambient` | `color-mix(in srgb, black 6%, transparent)` | `color-mix(in srgb, black 40%, transparent)` |
| `highlight` | `transparent` (no-op) | `color-mix(in srgb, white 8%, transparent)` |

## Test plan

- [x] `pnpm --filter design-tokens build` — alle 8 configuraties gebouwd zonder fouten
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 TypeScript-fouten
- [x] `pnpm lint` — 0 errors
- [x] Storybook handmatig gecontroleerd in light mode — schaduwen zichtbaar, live values correct
- [x] Storybook handmatig gecontroleerd in dark mode — kleurtokens updaten, highlight outline zichtbaar

Sluit #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)