### PR TITLE
feat(Container): voeg Container layout component toe (#74)

### DIFF
--- a/packages/components-html/package.json
+++ b/packages/components-html/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./dist/components.css",
     "./button": "./src/button/button.css",
+    "./container": "./src/container/container.css",
     "./icon": "./src/icon/icon.css",
     "./paragraph": "./src/paragraph/paragraph.css",
     "./heading": "./src/heading/heading.css",

--- a/packages/components-html/src/container/container.css
+++ b/packages/components-html/src/container/container.css
@@ -1,0 +1,42 @@
+/**
+ * Container Component
+ * Visuele groepering van gerelateerde content met achtergrond, border en optionele schaduw.
+ *
+ * Usage:
+ * <!-- Standaard -->
+ * <div class="dsn-container">
+ *   <p class="dsn-paragraph">Inhoud</p>
+ * </div>
+ *
+ * <!-- Elevated (kaart-achtig, met schaduw) -->
+ * <div class="dsn-container dsn-container--elevated">
+ *   <p class="dsn-paragraph">Inhoud</p>
+ * </div>
+ *
+ * <!-- Semantisch element -->
+ * <section class="dsn-container">
+ *   <h2 class="dsn-heading dsn-heading--2">Sectietitel</h2>
+ *   <p class="dsn-paragraph">Inhoud</p>
+ * </section>
+ */
+
+/* ===========================
+   Base
+   =========================== */
+.dsn-container {
+  background-color: var(--dsn-container-background-color);
+  border: var(--dsn-container-border-width) solid
+    var(--dsn-container-border-color);
+  border-radius: var(--dsn-container-border-radius);
+  box-shadow: var(--dsn-container-box-shadow);
+  color: var(--dsn-container-color);
+  padding-block: var(--dsn-container-padding-block);
+  padding-inline: var(--dsn-container-padding-inline);
+}
+
+/* ===========================
+   Elevated modifier — kaart-achtige schaduw
+   =========================== */
+.dsn-container--elevated {
+  box-shadow: var(--dsn-container-elevated-box-shadow);
+}

--- a/packages/components-react/src/Container/Container.css
+++ b/packages/components-react/src/Container/Container.css
@@ -1,0 +1,6 @@
+/**
+ * Container component styles for React
+ * Re-exports the base Container styles from components-html
+ */
+
+@import '../../../components-html/src/container/container.css';

--- a/packages/components-react/src/Container/Container.tsx
+++ b/packages/components-react/src/Container/Container.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import './Container.css';
+
+export type ContainerAs = 'div' | 'section' | 'article' | 'aside';
+
+export interface ContainerProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * HTML-element — ontkoppelt semantiek van visuele stijl
+   * @default 'div'
+   */
+  as?: ContainerAs;
+
+  /**
+   * Voegt een lichte schaduw toe voor een zwevend, kaart-achtig effect
+   * @default false
+   */
+  elevated?: boolean;
+
+  children?: React.ReactNode;
+}
+
+/**
+ * Container component
+ * Visuele groepering van gerelateerde content met achtergrond, border en optionele schaduw.
+ *
+ * @example
+ * ```tsx
+ * // Standaard
+ * <Container>
+ *   <Paragraph>Inhoud</Paragraph>
+ * </Container>
+ *
+ * // Elevated (kaart-achtig)
+ * <Container elevated>
+ *   <Paragraph>Inhoud</Paragraph>
+ * </Container>
+ *
+ * // Semantisch element
+ * <Container as="section">
+ *   <Heading level={2}>Sectietitel</Heading>
+ *   <Paragraph>Inhoud</Paragraph>
+ * </Container>
+ * ```
+ */
+export const Container = React.forwardRef<HTMLElement, ContainerProps>(
+  (
+    { as: As = 'div', className, elevated = false, children, ...props },
+    ref
+  ) => {
+    const classes = classNames(
+      'dsn-container',
+      elevated && 'dsn-container--elevated',
+      className
+    );
+
+    return (
+      <As ref={ref as React.Ref<HTMLDivElement>} className={classes} {...props}>
+        {children}
+      </As>
+    );
+  }
+);
+
+Container.displayName = 'Container';

--- a/packages/components-react/src/Container/index.ts
+++ b/packages/components-react/src/Container/index.ts
@@ -1,0 +1,2 @@
+export { Container } from './Container';
+export type { ContainerProps, ContainerAs } from './Container';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 // Layout Components
+export * from './Container';
 export * from './Grid';
 export * from './Stack';
 

--- a/packages/design-tokens/src/tokens/components/container.json
+++ b/packages/design-tokens/src/tokens/components/container.json
@@ -1,0 +1,47 @@
+{
+  "dsn": {
+    "container": {
+      "background-color": {
+        "value": "{dsn.color.neutral.bg-elevated}",
+        "type": "color",
+        "comment": "Achtergrondkleur — bg-elevated voor visuele scheiding van de pagina"
+      },
+      "border-color": {
+        "value": "{dsn.color.neutral.border-subtle}",
+        "type": "color",
+        "comment": "Subtiele border — minder prominent dan border-default"
+      },
+      "border-radius": {
+        "value": "{dsn.border.radius.md}",
+        "type": "dimension"
+      },
+      "border-width": {
+        "value": "{dsn.border.width.thin}",
+        "type": "dimension"
+      },
+      "box-shadow": {
+        "value": "none",
+        "comment": "Standaard geen schaduw — gebruik elevated variant voor een zwevend effect"
+      },
+      "color": {
+        "value": "{dsn.color.neutral.color-document}",
+        "type": "color",
+        "comment": "Tekstkleur — altijd de volledige document-kleur voor leesbaarheid"
+      },
+      "padding-block": {
+        "value": "{dsn.space.block.3xl}",
+        "type": "dimension"
+      },
+      "padding-inline": {
+        "value": "{dsn.space.inline.3xl}",
+        "type": "dimension"
+      },
+      "elevated": {
+        "box-shadow": {
+          "value": "{dsn.box-shadow.sm}",
+          "comment": "Lichte schaduw voor kaart-achtige containers (cards, panels)"
+        }
+      }
+    }
+  }
+}

--- a/packages/design-tokens/src/tokens/themes/wireframe/base.json
+++ b/packages/design-tokens/src/tokens/themes/wireframe/base.json
@@ -516,6 +516,20 @@
         "value": "74em",
         "comment": "Extra large breakpoint - ~1184px. Reference only; use hardcoded values in CSS @media rules."
       }
+    },
+    "box-shadow": {
+      "sm": {
+        "value": "none",
+        "comment": "Small elevation — flat in wireframe theme"
+      },
+      "md": {
+        "value": "none",
+        "comment": "Medium elevation — flat in wireframe theme"
+      },
+      "lg": {
+        "value": "none",
+        "comment": "Large elevation — flat in wireframe theme"
+      }
     }
   }
 }

--- a/packages/storybook/src/Container.docs.md
+++ b/packages/storybook/src/Container.docs.md
@@ -1,0 +1,59 @@
+# Container
+
+Visuele groepering van gerelateerde content met achtergrond, border en optionele schaduw.
+
+## Doel
+
+Container biedt een afgebakend kader voor content die visueel bij elkaar hoort. Het component combineert een `bg-elevated` achtergrond, een subtiele border en een optionele `box-shadow` tot een herkenbaar geheel. Container is puur visueel — het heeft geen eigen semantische rol en laat de keuze van het HTML-element aan de gebruiker over via de `as` prop.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Gerelateerde componenten visueel groeperen (formuliersecties, kaarten, panelen).
+- Een duidelijke grens nodig is tussen content en pagina-achtergrond.
+- Je een kaart-achtig element wilt met een lichte schaduw (`elevated`).
+- Layout componenten (Stack, Grid) een visueel kader geven in een pagina of demo.
+
+## Don't use when
+
+- Je alleen witruimte nodig hebt tussen secties — gebruik Stack of Grid met de juiste spacing tokens.
+- Het element navigatie, een formulier of andere semantisch geladen structuur is — geef dan de juiste HTML-semantiek aan de parent zelf mee.
+- Je een kleurrijke statusachtergrond wilt — gebruik Alert of Note.
+
+## Best practices
+
+### `as` prop
+
+| Waarde            | Wanneer                                                   |
+| ----------------- | --------------------------------------------------------- |
+| `'div'` (default) | Generieke groepering zonder extra semantische betekenis   |
+| `'section'`       | Benoemde inhoudssectie met een heading als label          |
+| `'article'`       | Zelfstandig herbruikbaar stuk content (kaart, nieuwsitem) |
+| `'aside'`         | Tangentieel aanvullende content naast de hoofdinhoud      |
+
+### Elevated
+
+Gebruik `elevated` alleen als de Container visueel boven de pagina zweeft — zoals een dropdown-panel, een card in een raster of een demo-wrapper in Storybook. Gebruik het niet voor alle containers, want schaduw werkt op contrast: hoe minder schaduwen, hoe meer impact.
+
+### Nesting
+
+Container kan andere layout-componenten bevatten (Stack, Grid). Container regelt de buitenkant (achtergrond, border, padding), Stack of Grid regelen de binnenste spacing.
+
+## Design tokens
+
+| Token                                 | Beschrijving                               |
+| ------------------------------------- | ------------------------------------------ |
+| `--dsn-container-background-color`    | Achtergrond — `neutral.bg-elevated`        |
+| `--dsn-container-border-color`        | Borderkleur — `neutral.border-subtle`      |
+| `--dsn-container-border-radius`       | Afronding — `border.radius.md` (8px)       |
+| `--dsn-container-border-width`        | Breedte — `border.width.thin` (1px)        |
+| `--dsn-container-box-shadow`          | Standaard geen schaduw (`none`)            |
+| `--dsn-container-color`               | Tekstkleur — `neutral.color-document`      |
+| `--dsn-container-padding-block`       | Verticale padding — `space.block.3xl`      |
+| `--dsn-container-padding-inline`      | Horizontale padding — `space.inline.3xl`   |
+| `--dsn-container-elevated-box-shadow` | Schaduw elevated variant — `box-shadow.sm` |
+
+## Accessibility
+
+Container voegt geen ARIA-rollen of labels toe. Gebruik de `as` prop voor semantisch correcte HTML. Bij `as="section"` of `as="aside"` met een heading: voeg zelf `aria-labelledby` toe aan de Container en koppel het aan het `id` van de heading.

--- a/packages/storybook/src/Container.docs.mdx
+++ b/packages/storybook/src/Container.docs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as ContainerStories from './Container.stories';
+import docs from './Container.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={ContainerStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={ContainerStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={ContainerStories.Default}
+  html={`<div class="dsn-container">
+  <p class="dsn-paragraph">Inhoud van de container.</p>
+</div>`}
+/>
+
+<Controls of={ContainerStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/Container.stories.tsx
+++ b/packages/storybook/src/Container.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Container, Stack, Paragraph, Heading } from '@dsn/components-react';
+import DocsPage from './Container.docs.mdx';
+
+/** Placeholder box voor visuele demonstratie van layout binnen een Container */
+const Box = ({ label }: { label?: string }) => (
+  <div
+    style={{
+      padding: '0.75rem 1rem',
+      background: 'var(--dsn-color-neutral-bg-default)',
+      border: '1px solid var(--dsn-color-neutral-border-subtle)',
+      borderRadius: '4px',
+      fontSize: '0.875rem',
+      color: 'var(--dsn-color-neutral-color-document)',
+    }}
+  >
+    {label ?? 'Inhoud'}
+  </div>
+);
+
+const meta: Meta<typeof Container> = {
+  title: 'Layout Components/Container',
+  component: Container,
+  parameters: {
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const cls = [
+          'dsn-container',
+          args.elevated && 'dsn-container--elevated',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const as = args.as ?? 'div';
+        return `<${as} class="${cls}">\n  <p class="dsn-paragraph">Inhoud</p>\n</${as}>`;
+      },
+    },
+  },
+  argTypes: {
+    as: {
+      control: 'select',
+      options: ['div', 'section', 'article', 'aside'],
+    },
+    elevated: {
+      control: 'boolean',
+    },
+    children: { control: false },
+  },
+  args: {
+    as: 'div',
+    elevated: false,
+    children: <Paragraph>Inhoud van de container.</Paragraph>,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Container>;
+
+export const Default: Story = {};
+
+export const Elevated: Story = {
+  args: {
+    elevated: true,
+  },
+};
+
+export const ElevatedWithContent: Story = {
+  name: 'Elevated met content',
+  render: () => (
+    <Container elevated>
+      <Stack space="md">
+        <Heading level={2} appearance="heading-3">
+          Kaart
+        </Heading>
+        <Paragraph>
+          Een elevated Container krijgt een lichte schaduw via{' '}
+          <code>--dsn-box-shadow-sm</code>. Geschikt voor kaarten, panelen en
+          demo-wrappers.
+        </Paragraph>
+        <Box />
+      </Stack>
+    </Container>
+  ),
+};
+
+export const AllStates: Story = {
+  name: 'All states',
+  render: () => (
+    <Stack space="xl">
+      <div>
+        <div
+          style={{
+            fontSize: '0.75rem',
+            fontFamily: 'monospace',
+            color: 'var(--dsn-color-neutral-color-default)',
+            marginBlockEnd: '0.5rem',
+          }}
+        >
+          Default
+        </div>
+        <Container>
+          <Paragraph>Standaard container — border, geen schaduw.</Paragraph>
+        </Container>
+      </div>
+      <div>
+        <div
+          style={{
+            fontSize: '0.75rem',
+            fontFamily: 'monospace',
+            color: 'var(--dsn-color-neutral-color-default)',
+            marginBlockEnd: '0.5rem',
+          }}
+        >
+          Elevated
+        </div>
+        <Container elevated>
+          <Paragraph>Elevated container — border + box-shadow.sm.</Paragraph>
+        </Container>
+      </div>
+    </Stack>
+  ),
+};

--- a/packages/storybook/src/Grid.stories.tsx
+++ b/packages/storybook/src/Grid.stories.tsx
@@ -1,24 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Grid, GridItem } from '@dsn/components-react';
+import { Grid, GridItem, Container } from '@dsn/components-react';
 import DocsPage from './Grid.docs.mdx';
-
-/** Placeholder box voor visuele demonstratie van Grid-kolommen */
-const Box = ({ label, height }: { label?: string; height?: string }) => (
-  <div
-    style={{
-      padding: '0.75rem 1rem',
-      background: 'var(--dsn-color-neutral-bg-default)',
-      border: '1px solid var(--dsn-color-neutral-border-subtle)',
-      borderRadius: '4px',
-      fontSize: '0.875rem',
-      color: 'var(--dsn-color-neutral-color-document)',
-      fontFamily: 'monospace',
-      blockSize: height,
-    }}
-  >
-    {label ?? 'Inhoud'}
-  </div>
-);
 
 const meta: Meta<typeof Grid> = {
   title: 'Layout Components/Grid',
@@ -31,7 +13,7 @@ const meta: Meta<typeof Grid> = {
         const cls = ['dsn-grid', args.contained && 'dsn-grid--contained']
           .filter(Boolean)
           .join(' ');
-        return `<div class="${cls}">\n  <div class="dsn-col-8">Hoofdinhoud</div>\n  <div class="dsn-col-4">Sidebar</div>\n</div>`;
+        return `<div class="${cls}">\n  <div class="dsn-col-8 dsn-container">Hoofdinhoud</div>\n  <div class="dsn-col-4 dsn-container">Sidebar</div>\n</div>`;
       },
     },
   },
@@ -53,10 +35,10 @@ export const Default: Story = {
   render: (args) => (
     <Grid {...args}>
       <GridItem colSpan={8}>
-        <Box label="dsn-col-8 — Hoofdinhoud" height="80px" />
+        <Container>dsn-col-8 — Hoofdinhoud</Container>
       </GridItem>
       <GridItem colSpan={4}>
-        <Box label="dsn-col-4 — Sidebar" height="80px" />
+        <Container>dsn-col-4 — Sidebar</Container>
       </GridItem>
     </Grid>
   ),
@@ -67,10 +49,10 @@ export const Contained: Story = {
   render: () => (
     <Grid contained>
       <GridItem colSpan={8}>
-        <Box label="dsn-col-8 — Hoofdinhoud" height="80px" />
+        <Container>dsn-col-8 — Hoofdinhoud</Container>
       </GridItem>
       <GridItem colSpan={4}>
-        <Box label="dsn-col-4 — Sidebar" height="80px" />
+        <Container>dsn-col-4 — Sidebar</Container>
       </GridItem>
     </Grid>
   ),
@@ -82,10 +64,7 @@ export const Responsive: Story = {
     <Grid contained>
       {(['A', 'B', 'C'] as const).map((label) => (
         <GridItem key={label} colSpan={12} colSpanMd={6} colSpanLg={4}>
-          <Box
-            label={`col-12 → col-md-6 → col-lg-4 — Item ${label}`}
-            height="80px"
-          />
+          <Container>{`col-12 → col-md-6 → col-lg-4 — Item ${label}`}</Container>
         </GridItem>
       ))}
     </Grid>
@@ -97,7 +76,7 @@ export const FullBleed: Story = {
   render: () => (
     <Grid contained>
       <GridItem colSpan={8}>
-        <Box label="Normale content (col-8)" />
+        <Container>Normale content (col-8)</Container>
       </GridItem>
       <GridItem fullBleed>
         <div
@@ -107,11 +86,13 @@ export const FullBleed: Story = {
             borderBlock: '1px solid var(--dsn-color-neutral-border-subtle)',
           }}
         >
-          <Box label="Full-bleed sectie — breekt uit tot container-randen" />
+          <Container>
+            Full-bleed sectie — breekt uit tot container-randen
+          </Container>
         </div>
       </GridItem>
       <GridItem colSpan={8}>
-        <Box label="Vervolg content (col-8)" />
+        <Container>Vervolg content (col-8)</Container>
       </GridItem>
     </Grid>
   ),
@@ -123,7 +104,7 @@ export const AllColumns: Story = {
     <Grid>
       {([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const).map((n) => (
         <GridItem key={n} colSpan={n}>
-          <Box label={`col-${n}`} />
+          <Container>{`col-${n}`}</Container>
         </GridItem>
       ))}
     </Grid>
@@ -136,13 +117,13 @@ export const InformationDense: Story = {
     <div className="dsn-density-dense">
       <Grid>
         <GridItem colSpan={4}>
-          <Box label="col-4" height="60px" />
+          <Container>col-4</Container>
         </GridItem>
         <GridItem colSpan={4}>
-          <Box label="col-4" height="60px" />
+          <Container>col-4</Container>
         </GridItem>
         <GridItem colSpan={4}>
-          <Box label="col-4" height="60px" />
+          <Container>col-4</Container>
         </GridItem>
       </Grid>
       <p

--- a/packages/storybook/src/Stack.stories.tsx
+++ b/packages/storybook/src/Stack.stories.tsx
@@ -1,22 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Stack } from '@dsn/components-react';
+import { Stack, Container } from '@dsn/components-react';
 import DocsPage from './Stack.docs.mdx';
-
-/** Placeholder box voor visuele demonstratie van Stack-spacing */
-const Box = ({ label }: { label?: string }) => (
-  <div
-    style={{
-      padding: '0.75rem 1rem',
-      background: 'var(--dsn-color-neutral-bg-default)',
-      border: '1px solid var(--dsn-color-neutral-border-subtle)',
-      borderRadius: '4px',
-      fontSize: '0.875rem',
-      color: 'var(--dsn-color-neutral-color-document)',
-    }}
-  >
-    {label ?? 'Inhoud'}
-  </div>
-);
 
 const meta: Meta<typeof Stack> = {
   title: 'Layout Components/Stack',
@@ -30,7 +14,7 @@ const meta: Meta<typeof Stack> = {
         const cls = ['dsn-stack', space !== 'md' && `dsn-stack--space-${space}`]
           .filter(Boolean)
           .join(' ');
-        return `<div class="${cls}">\n  <div>...</div>\n  <div>...</div>\n  <div>...</div>\n</div>`;
+        return `<div class="${cls}">\n  <div class="dsn-container">...</div>\n  <div class="dsn-container">...</div>\n  <div class="dsn-container">...</div>\n</div>`;
       },
     },
   },
@@ -52,9 +36,9 @@ type Story = StoryObj<typeof Stack>;
 export const Default: Story = {
   render: (args) => (
     <Stack {...args}>
-      <Box />
-      <Box />
-      <Box />
+      <Container>Inhoud</Container>
+      <Container>Inhoud</Container>
+      <Container>Inhoud</Container>
     </Stack>
   ),
 };
@@ -107,9 +91,9 @@ export const AllSpaces: Story = {
             {SPACE_LABELS[space]}
           </div>
           <Stack space={space}>
-            <Box />
-            <Box />
-            <Box />
+            <Container>Inhoud</Container>
+            <Container>Inhoud</Container>
+            <Container>Inhoud</Container>
           </Stack>
         </div>
       ))}


### PR DESCRIPTION
## Summary

- Nieuw `Container` component voor visuele groepering van gerelateerde content
- Design tokens in `container.json` met `elevated` variant via `box-shadow.sm`
- Wireframe thema aangevuld met ontbrekende `box-shadow` tokens (`sm/md/lg: none`)
- HTML/CSS: `.dsn-container` + `.dsn-container--elevated` modifier
- React: `Container` component met `as`, `elevated` props en `forwardRef`
- Storybook: Default, Elevated, ElevatedWithContent en AllStates stories
- Stack en Grid stories: placeholder `Box` component vervangen door `Container` items

> **Note:** Deze PR is gebaseerd op `feature/72-shadow-tokens` omdat `Container` gebruikmaakt van de `box-shadow.sm` token uit die branch. Na mergen van #73 kan deze PR worden gerebaset op `main`.

## Test plan

- [ ] Token build slaagt voor alle thema's (start, wireframe)
- [ ] `.dsn-container` toont achtergrond, border en padding
- [ ] `.dsn-container--elevated` toont `box-shadow.sm` schaduw
- [ ] Wireframe thema: geen schaduw (flat)
- [ ] Storybook: alle 4 stories laden correct
- [ ] Stack en Grid stories tonen Container als items (geen grijze Box meer)
- [ ] TypeScript: geen fouten (`pnpm --filter storybook exec tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)