### PR TITLE
feat(Details): uitvouwbare inhoudsaanwijzer

### DIFF
--- a/packages/components-html/src/details/details.css
+++ b/packages/components-html/src/details/details.css
@@ -1,0 +1,115 @@
+/**
+ * Details Component
+ * Expandable disclosure widget based on the native <details>/<summary> element.
+ *
+ * Usage:
+ * <!-- Default (closed) -->
+ * <details class="dsn-details">
+ *   <summary class="dsn-details__summary">
+ *     <svg class="dsn-icon dsn-details__icon" aria-hidden="true"><!-- chevron-down --></svg>
+ *     <span class="dsn-details__summary-label">Label</span>
+ *   </summary>
+ *   <div class="dsn-details__content">
+ *     <p class="dsn-paragraph">Aanvullende informatie.</p>
+ *   </div>
+ * </details>
+ *
+ * <!-- Default open -->
+ * <details class="dsn-details" open>
+ *   <summary class="dsn-details__summary">
+ *     <svg class="dsn-icon dsn-details__icon" aria-hidden="true"><!-- chevron-down --></svg>
+ *     <span class="dsn-details__summary-label">Label</span>
+ *   </summary>
+ *   <div class="dsn-details__content">
+ *     <p class="dsn-paragraph">Inhoud is standaard zichtbaar.</p>
+ *   </div>
+ * </details>
+ */
+
+/* ===========================
+   Base layout
+   =========================== */
+.dsn-details {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--dsn-details-row-gap);
+}
+
+/* ===========================
+   Summary (toggle trigger)
+   =========================== */
+.dsn-details__summary {
+  display: flex;
+  align-items: center;
+  gap: var(--dsn-details-summary-gap);
+  list-style: none;
+  cursor: pointer;
+}
+
+/* Hide native browser disclosure marker (WebKit) */
+.dsn-details__summary::-webkit-details-marker {
+  display: none;
+}
+
+/* ===========================
+   Summary label
+   =========================== */
+.dsn-details__summary-label {
+  color: var(--dsn-details-summary-color);
+  text-decoration-line: var(--dsn-details-summary-text-decoration-line);
+  text-underline-offset: var(--dsn-details-summary-text-underline-offset);
+  text-decoration-thickness: var(
+    --dsn-details-summary-text-decoration-thickness
+  );
+}
+
+/* ===========================
+   Summary hover state
+   =========================== */
+.dsn-details__summary:hover .dsn-details__summary-label {
+  color: var(--dsn-details-summary-hover-color);
+  text-decoration-line: var(--dsn-details-summary-hover-text-decoration-line);
+}
+
+/* ===========================
+   Summary active state
+   =========================== */
+.dsn-details__summary:active .dsn-details__summary-label {
+  color: var(--dsn-details-summary-active-color);
+}
+
+/* ===========================
+   Summary focus state
+   =========================== */
+.dsn-details__summary:focus-visible {
+  outline: var(--dsn-focus-outline-width) solid var(--dsn-focus-outline-color);
+  outline-offset: var(--dsn-focus-outline-offset);
+  border-radius: var(--dsn-focus-border-radius);
+}
+
+/* ===========================
+   Icon — rotates 180° when open
+   =========================== */
+.dsn-details__icon {
+  flex-shrink: 0;
+  width: var(--dsn-details-icon-size);
+  height: var(--dsn-details-icon-size);
+  color: var(--dsn-details-summary-color);
+  transition: transform 0.2s ease;
+}
+
+.dsn-details[open] .dsn-details__icon {
+  transform: rotate(180deg);
+}
+
+/* ===========================
+   Content area
+   =========================== */
+.dsn-details__content {
+  background-color: var(--dsn-details-content-background-color);
+  border-inline-start: var(--dsn-details-content-border-inline-start-width)
+    solid var(--dsn-details-content-border-color);
+  padding-inline-start: var(--dsn-details-content-padding-inline-start);
+  padding-inline-end: var(--dsn-details-content-padding-inline-end);
+  padding-block: var(--dsn-details-content-padding-block);
+}

--- a/packages/components-react/src/Details/Details.css
+++ b/packages/components-react/src/Details/Details.css
@@ -1,0 +1,6 @@
+/**
+ * Details component styles for React
+ * Re-exports the base Details styles from components-html
+ */
+
+@import '../../../components-html/src/details/details.css';

--- a/packages/components-react/src/Details/Details.test.tsx
+++ b/packages/components-react/src/Details/Details.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Details } from './Details';
+
+describe('Details', () => {
+  // ===========================
+  // Rendering
+  // ===========================
+
+  it('renders summary label', () => {
+    render(<Details summary="Meer informatie">Inhoud</Details>);
+    expect(screen.getByText('Meer informatie')).toBeInTheDocument();
+  });
+
+  it('renders children content', () => {
+    render(<Details summary="Label">Aanvullende informatie</Details>);
+    expect(screen.getByText('Aanvullende informatie')).toBeInTheDocument();
+  });
+
+  it('renders as a <details> element', () => {
+    const { container } = render(<Details summary="Label">Inhoud</Details>);
+    expect(container.firstChild?.nodeName).toBe('DETAILS');
+  });
+
+  it('renders a <summary> element inside details', () => {
+    const { container } = render(<Details summary="Label">Inhoud</Details>);
+    expect(container.querySelector('summary')).toBeInTheDocument();
+  });
+
+  it('wraps children in dsn-details__content div', () => {
+    render(
+      <Details summary="Label">
+        <p>Inhoud</p>
+      </Details>
+    );
+    const content = document.querySelector('.dsn-details__content');
+    expect(content).toBeInTheDocument();
+    expect(content?.querySelector('p')).toBeInTheDocument();
+  });
+
+  // ===========================
+  // Classes
+  // ===========================
+
+  it('always has base dsn-details class', () => {
+    const { container } = render(<Details summary="Label">Inhoud</Details>);
+    expect(container.firstChild).toHaveClass('dsn-details');
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <Details summary="Label" className="custom-details">
+        Inhoud
+      </Details>
+    );
+    expect(container.firstChild).toHaveClass('dsn-details');
+    expect(container.firstChild).toHaveClass('custom-details');
+  });
+
+  it('applies dsn-details__summary class to summary element', () => {
+    const { container } = render(<Details summary="Label">Inhoud</Details>);
+    expect(container.querySelector('summary')).toHaveClass(
+      'dsn-details__summary'
+    );
+  });
+
+  it('applies dsn-details__summary-label class to label span', () => {
+    const { container } = render(<Details summary="Label">Inhoud</Details>);
+    expect(
+      container.querySelector('.dsn-details__summary-label')
+    ).toBeInTheDocument();
+  });
+
+  it('applies dsn-details__icon class to chevron icon', () => {
+    const { container } = render(<Details summary="Label">Inhoud</Details>);
+    expect(container.querySelector('.dsn-details__icon')).toBeInTheDocument();
+  });
+
+  // ===========================
+  // Open state
+  // ===========================
+
+  it('is closed by default', () => {
+    const { container } = render(<Details summary="Label">Inhoud</Details>);
+    expect(container.firstChild).not.toHaveAttribute('open');
+  });
+
+  it('opens when defaultOpen is true', () => {
+    const { container } = render(
+      <Details summary="Label" defaultOpen>
+        Inhoud
+      </Details>
+    );
+    expect(container.firstChild).toHaveAttribute('open');
+  });
+
+  // ===========================
+  // onToggle callback
+  // ===========================
+
+  it('calls onToggle when toggled', async () => {
+    const onToggle = vi.fn();
+    render(
+      <Details summary="Label" onToggle={onToggle}>
+        Inhoud
+      </Details>
+    );
+    const summary = screen.getByText('Label').closest('summary')!;
+    await userEvent.click(summary);
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onToggle with false when closed after being open', async () => {
+    const onToggle = vi.fn();
+    render(
+      <Details summary="Label" defaultOpen onToggle={onToggle}>
+        Inhoud
+      </Details>
+    );
+    const summary = screen.getByText('Label').closest('summary')!;
+    await userEvent.click(summary);
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it('does not throw when onToggle is not provided', async () => {
+    render(<Details summary="Label">Inhoud</Details>);
+    const summary = screen.getByText('Label').closest('summary')!;
+    await expect(userEvent.click(summary)).resolves.not.toThrow();
+  });
+
+  // ===========================
+  // Ref + HTML attributes
+  // ===========================
+
+  it('forwards ref to the details element', () => {
+    const ref = { current: null as HTMLDetailsElement | null };
+    render(
+      <Details ref={ref} summary="Label">
+        Inhoud
+      </Details>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.tagName).toBe('DETAILS');
+  });
+
+  it('spreads additional HTML attributes', () => {
+    render(
+      <Details summary="Label" id="details-1" data-testid="my-details">
+        Inhoud
+      </Details>
+    );
+    const el = screen.getByTestId('my-details');
+    expect(el).toHaveAttribute('id', 'details-1');
+  });
+
+  // ===========================
+  // Accessibility
+  // ===========================
+
+  it('chevron icon has aria-hidden', () => {
+    const { container } = render(<Details summary="Label">Inhoud</Details>);
+    const icon = container.querySelector('.dsn-details__icon');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('summary label text is the accessible name', () => {
+    render(<Details summary="Meer informatie">Inhoud</Details>);
+    // The summary element should be discoverable by its visible text
+    expect(
+      screen.getByText('Meer informatie').closest('summary')
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/components-react/src/Details/Details.tsx
+++ b/packages/components-react/src/Details/Details.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import { Icon } from '../Icon';
+import './Details.css';
+
+export interface DetailsProps extends Omit<
+  React.HTMLAttributes<HTMLDetailsElement>,
+  'onToggle'
+> {
+  /**
+   * Zichtbare labeltekst in de `<summary>`
+   */
+  summary: string;
+
+  /**
+   * Standaard open bij eerste render (ongecontroleerde staat)
+   * @default false
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Callback die wordt aangeroepen wanneer de open/dicht staat wijzigt
+   */
+  onToggle?: (open: boolean) => void;
+
+  /**
+   * De verborgen inhoud
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * Details component
+ * Uitvouwbare inhoudsaanwijzer voor aanvullende inhoud die niet iedereen nodig heeft.
+ * Gebaseerd op het native `<details>`/`<summary>` element — CSS-only, geen JavaScript voor de toggle.
+ *
+ * @example
+ * ```tsx
+ * // Standaard gesloten
+ * <Details summary="Meer informatie">
+ *   <Paragraph>Aanvullende informatie die beschikbaar is voor wie dit nodig heeft.</Paragraph>
+ * </Details>
+ *
+ * // Standaard open
+ * <Details summary="Meer informatie" defaultOpen>
+ *   <Paragraph>Inhoud is standaard zichtbaar.</Paragraph>
+ * </Details>
+ *
+ * // Met toggle callback
+ * <Details summary="Meer informatie" onToggle={(open) => console.log('open:', open)}>
+ *   <Paragraph>Inhoud.</Paragraph>
+ * </Details>
+ * ```
+ */
+export const Details = React.forwardRef<HTMLDetailsElement, DetailsProps>(
+  (
+    { className, summary, defaultOpen = false, onToggle, children, ...props },
+    ref
+  ) => {
+    const classes = classNames('dsn-details', className);
+
+    const handleToggle = (event: React.SyntheticEvent<HTMLDetailsElement>) => {
+      onToggle?.((event.currentTarget as HTMLDetailsElement).open);
+    };
+
+    return (
+      <details
+        ref={ref}
+        className={classes}
+        open={defaultOpen || undefined}
+        onToggle={handleToggle}
+        {...props}
+      >
+        <summary className="dsn-details__summary">
+          <Icon name="chevron-down" className="dsn-details__icon" aria-hidden />
+          <span className="dsn-details__summary-label">{summary}</span>
+        </summary>
+        <div className="dsn-details__content">{children}</div>
+      </details>
+    );
+  }
+);
+
+Details.displayName = 'Details';

--- a/packages/components-react/src/Details/index.ts
+++ b/packages/components-react/src/Details/index.ts
@@ -1,0 +1,2 @@
+export { Details } from './Details';
+export type { DetailsProps } from './Details';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -50,6 +50,7 @@ export * from './StatusBadge';
 export * from './Alert';
 export * from './Note';
 export * from './Table';
+export * from './Details';
 
 // Form Field Components
 export * from './FormField';

--- a/packages/design-tokens/src/tokens/components/details.json
+++ b/packages/design-tokens/src/tokens/components/details.json
@@ -1,0 +1,96 @@
+{
+  "dsn": {
+    "details": {
+      "row-gap": {
+        "value": "{dsn.space.row.md}",
+        "type": "dimension",
+        "comment": "Vertical gap between summary and content"
+      },
+      "summary": {
+        "color": {
+          "value": "{dsn.color.action-2.color-default}",
+          "type": "color",
+          "comment": "Summary label color (follows Link via action-2)"
+        },
+        "gap": {
+          "value": "{dsn.space.text.sm}",
+          "type": "dimension",
+          "comment": "Gap between chevron icon and label text"
+        },
+        "text-decoration-line": {
+          "value": "none",
+          "type": "other",
+          "comment": "No underline by default; appears on hover"
+        },
+        "text-underline-offset": {
+          "value": "4px",
+          "type": "dimension",
+          "comment": "Underline offset for hover state"
+        },
+        "text-decoration-thickness": {
+          "value": "auto",
+          "type": "other",
+          "comment": "Underline thickness for hover state"
+        },
+        "hover": {
+          "color": {
+            "value": "{dsn.color.action-2.color-hover}",
+            "type": "color",
+            "comment": "Summary label color on hover"
+          },
+          "text-decoration-line": {
+            "value": "underline",
+            "type": "other",
+            "comment": "Underline appears on hover"
+          }
+        },
+        "active": {
+          "color": {
+            "value": "{dsn.color.action-2.color-active}",
+            "type": "color",
+            "comment": "Summary label color on active"
+          }
+        }
+      },
+      "icon": {
+        "size": {
+          "value": "{dsn.icon.size.md}",
+          "type": "dimension",
+          "comment": "Chevron icon size"
+        }
+      },
+      "content": {
+        "background-color": {
+          "value": "transparent",
+          "type": "color",
+          "comment": "Content area background"
+        },
+        "border-color": {
+          "value": "{dsn.color.neutral.border-subtle}",
+          "type": "color",
+          "comment": "Left border color for visual grouping"
+        },
+        "border-inline-start-width": {
+          "value": "{dsn.border.width.medium}",
+          "type": "dimension",
+          "comment": "Left border width"
+        },
+        "padding-inline-start": {
+          "value": "{dsn.space.inline.xl}",
+          "type": "dimension",
+          "comment": "Left padding — aligns content with label text"
+        },
+        "padding-inline-end": {
+          "value": "{dsn.space.inline.xl}",
+          "type": "dimension",
+          "comment": "Right padding"
+        },
+        "padding-block": {
+          "value": "{dsn.space.block.xl}",
+          "type": "dimension",
+          "comment": "Top and bottom padding"
+        }
+      }
+    }
+  }
+}

--- a/packages/storybook/src/Details.docs.md
+++ b/packages/storybook/src/Details.docs.md
@@ -1,0 +1,68 @@
+# Details
+
+Uitvouwbare inhoudsaanwijzer voor aanvullende informatie die niet iedereen nodig heeft.
+
+## Doel
+
+De Details component biedt een semantisch correcte uitvouwbare sectie op basis van het native `<details>`/`<summary>` element. Gebruik het om aanvullende context, uitleg of informatie beschikbaar te maken zonder de pagina te belasten. De inhoud is verborgen totdat de gebruiker actief kiest om die te zien.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Aanvullende informatie die niet iedereen nodig heeft (uitleg, toelichting, achtergrondinformatie).
+- Inhoud die de pagina-scan voor de meeste gebruikers belemmert.
+- Inhoud die alleen relevant is voor een specifieke doelgroep.
+- FAQ-patronen waarbij meerdere Details-componenten onder elkaar staan.
+
+## Don't use when
+
+- De meerderheid van gebruikers de informatie nodig heeft — verberg geen essentiële inhoud.
+- De inhoud cruciaal is voor het voltooien van een taak — toon het altijd zichtbaar.
+- Er een urgente melding nodig is — gebruik een **Alert**.
+
+## Best practices
+
+### Summarylabel
+
+- Houd het summarylabel bondig en beschrijvend — gebruikers beslissen op basis van dit label of ze klikken.
+- Gebruik een actieve formulering die duidelijk maakt wat er achter zit (bijv. "Welke documenten heb ik nodig?" in plaats van "Meer informatie").
+
+### Meerdere Details onder elkaar
+
+- Gebruik meerdere afzonderlijke Details-componenten voor FAQ-patronen — niet genest.
+- Voeg consistente spacing toe via een Stack of een eigen wrapper.
+
+### Standaard open
+
+- Gebruik `defaultOpen` alleen als er een goede reden is om de inhoud direct zichtbaar te maken (bijv. na een fout of wanneer de context dit vereist).
+
+## Design tokens
+
+| Token                                              | Beschrijving                               |
+| -------------------------------------------------- | ------------------------------------------ |
+| `--dsn-details-row-gap`                            | Verticale ruimte tussen summary en content |
+| `--dsn-details-summary-color`                      | Kleur van het summarylabel (default)       |
+| `--dsn-details-summary-gap`                        | Ruimte tussen chevron-icoon en label       |
+| `--dsn-details-summary-text-decoration-line`       | Onderstreepstijl (standaard: none)         |
+| `--dsn-details-summary-text-underline-offset`      | Offset van de onderstreping                |
+| `--dsn-details-summary-text-decoration-thickness`  | Dikte van de onderstreping                 |
+| `--dsn-details-summary-hover-color`                | Kleur van het label bij hover              |
+| `--dsn-details-summary-hover-text-decoration-line` | Onderstreepstijl bij hover (underline)     |
+| `--dsn-details-summary-active-color`               | Kleur van het label bij active             |
+| `--dsn-details-icon-size`                          | Grootte van het chevron-icoon              |
+| `--dsn-details-content-background-color`           | Achtergrond van de content-area            |
+| `--dsn-details-content-border-color`               | Kleur van de linkerborder                  |
+| `--dsn-details-content-border-inline-start-width`  | Breedte van de linkerborder                |
+| `--dsn-details-content-padding-inline-start`       | Linkerpadding van de content-area          |
+| `--dsn-details-content-padding-inline-end`         | Rechterpadding van de content-area         |
+| `--dsn-details-content-padding-block`              | Verticale padding van de content-area      |
+
+## Accessibility
+
+- Het native `<details>`/`<summary>` element heeft een impliciete ARIA-rol `group` — geen extra `role` attribuut nodig.
+- De `<summary>` is volledig toetsenbordtoegankelijk: Tab om te focussen, Spatiebalk of Enter om te togglen.
+- Het chevron-icoon heeft `aria-hidden="true"` — de zichtbare tekst in de summarylabel is de toegankelijke naam.
+- Gebruik **nooit** `aria-label` op de `<summary>` — de zichtbare tekst is de toegankelijke naam.
+- De native browser-aanwijzer is verborgen via `list-style: none` en `summary::-webkit-details-marker { display: none }`.
+- Het chevron-icoon roteert 180° via CSS bij de open staat — geen JavaScript nodig.

--- a/packages/storybook/src/Details.docs.mdx
+++ b/packages/storybook/src/Details.docs.mdx
@@ -1,0 +1,33 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as DetailsStories from './Details.stories';
+import docs from './Details.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={DetailsStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={DetailsStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={DetailsStories.Default}
+  html={`<details class="dsn-details">
+  <summary class="dsn-details__summary">
+    <svg class="dsn-icon dsn-details__icon" aria-hidden="true"><!-- chevron-down --></svg>
+    <span class="dsn-details__summary-label">Label</span>
+  </summary>
+  <div class="dsn-details__content">
+    <p class="dsn-paragraph">Tekst</p>
+  </div>
+</details>`}
+/>
+
+<Controls of={DetailsStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/Details.stories.tsx
+++ b/packages/storybook/src/Details.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Details, Paragraph, UnorderedList } from '@dsn/components-react';
+import DocsPage from './Details.docs.mdx';
+import {
+  TEKST,
+  VEEL_TEKST,
+  TEKST_AR,
+  VEEL_TEKST_AR,
+  rtlDecorator,
+} from './story-helpers';
+
+const meta: Meta<typeof Details> = {
+  title: 'Components/Details',
+  component: Details,
+  parameters: {
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const summaryLabel = args.summary ?? 'Label';
+        const open = args.defaultOpen ? ' open' : '';
+        return `<details class="dsn-details"${open}>
+  <summary class="dsn-details__summary">
+    <svg class="dsn-icon dsn-details__icon" aria-hidden="true"><!-- chevron-down --></svg>
+    <span class="dsn-details__summary-label">${summaryLabel}</span>
+  </summary>
+  <div class="dsn-details__content">
+    <p class="dsn-paragraph">${TEKST}</p>
+  </div>
+</details>`;
+      },
+    },
+  },
+  argTypes: {
+    summary: { control: 'text' },
+    defaultOpen: { control: 'boolean' },
+    onToggle: { control: false },
+    children: { control: false },
+  },
+  args: {
+    summary: 'Label',
+    defaultOpen: false,
+    children: <Paragraph>{TEKST}</Paragraph>,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Details>;
+
+export const Default: Story = {};
+
+export const Open: Story = {
+  name: 'Open (defaultOpen)',
+  args: {
+    defaultOpen: true,
+  },
+};
+
+export const WithList: Story = {
+  name: 'With list',
+  render: () => (
+    <Details summary="Welke documenten heb ik nodig?">
+      <UnorderedList>
+        <li>Geldig identiteitsbewijs</li>
+        <li>Bankafschrift van de afgelopen 3 maanden</li>
+        <li>Bewijs van inschrijving</li>
+      </UnorderedList>
+    </Details>
+  ),
+};
+
+export const WithLongContent: Story = {
+  name: 'With long content',
+  render: () => (
+    <Details summary="Uitgebreide toelichting" defaultOpen>
+      <Paragraph>{VEEL_TEKST}</Paragraph>
+    </Details>
+  ),
+};
+
+export const Multiple: Story = {
+  name: 'Multiple',
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <Details summary="Wat is de levertijd?">
+        <Paragraph>Standaard levertijd is 3 tot 5 werkdagen.</Paragraph>
+      </Details>
+      <Details summary="Kan ik mijn bestelling annuleren?">
+        <Paragraph>
+          Ja, u kunt uw bestelling annuleren zolang deze nog niet verzonden is.
+        </Paragraph>
+      </Details>
+      <Details summary="Hoe neem ik contact op?">
+        <Paragraph>
+          Neem contact op via het contactformulier op onze website.
+        </Paragraph>
+      </Details>
+    </div>
+  ),
+};
+
+export const RTL: Story = {
+  name: 'RTL',
+  decorators: [rtlDecorator],
+  render: () => (
+    <div dir="rtl" lang="ar">
+      <Details summary={TEKST_AR}>
+        <Paragraph>{TEKST_AR}</Paragraph>
+      </Details>
+    </div>
+  ),
+};
+
+export const RTLLongText: Story = {
+  name: 'RTL long text',
+  decorators: [rtlDecorator],
+  render: () => (
+    <div dir="rtl" lang="ar">
+      <Details summary={TEKST_AR} defaultOpen>
+        <Paragraph>{VEEL_TEKST_AR}</Paragraph>
+      </Details>
+    </div>
+  ),
+};

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -61,7 +61,7 @@ function App() {
 
 ## Componenten overzicht
 
-**41 componenten totaal** — alle beschikbaar als HTML/CSS én React.
+**42 componenten totaal** — alle beschikbaar als HTML/CSS én React.
 
 ### Layout Components (3)
 
@@ -80,12 +80,13 @@ function App() {
 - **Link** — Hyperlinks met icon ondersteuning en externe link handling
 - **Lists** — OrderedList en UnorderedList
 
-### Display & Feedback Components (4)
+### Display & Feedback Components (5)
 
 - **StatusBadge** — Compact label dat een status communiceert met een signaalkleur (neutral, info, positive, negative, warning)
 - **Alert** — Belangrijk bericht dat de gebruiker informeert over de huidige activiteit (info, positive, negative, warning)
 - **Note** — Visueel uitgelicht bericht voor aanvullende informatie, passief (geen live region)
 - **Table** — Toegankelijke datatable met caption, optionele scroll-wrapper, tfoot-ondersteuning en CSS-patroon voor sorteerknoppen
+- **Details** — Uitvouwbare inhoudsaanwijzer voor aanvullende inhoud (`<details>`/`<summary>`, CSS-only toggle)
 
 ### Form Components (25)
 
@@ -144,4 +145,4 @@ MIT License — zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.4.0 | **Laatste update:** 7 maart 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.6.0 | **Laatste update:** 12 maart 2026 | **Auteur:** Jeffrey Lauwers


### PR DESCRIPTION
## Summary

- Voegt `Details` component toe gebaseerd op native `<details>`/`<summary>` — CSS-only toggle, geen JavaScript
- Component tokens via `action-2` kleurreeks (summary gedraagt zich visueel als een Link)
- Chevron-icoon roteert 180° via `details[open]` CSS selector
- 19 tests: rendering, klassen, open state, `onToggle` callback, accessibility, ref forwarding

## Bestanden

- `packages/design-tokens/src/tokens/components/details.json` — component tokens
- `packages/components-html/src/details/details.css` — CSS implementatie
- `packages/components-react/src/Details/` — React component + test + index
- `packages/storybook/src/Details.*` — stories + docs (mdx + md)
- `packages/components-react/src/index.ts` — export toegevoegd
- `packages/storybook/src/Introduction.mdx` — 42 componenten, v5.6.0

## Test plan

- [x] 1002 tests groen (`pnpm test`)
- [x] TypeScript schoon (`pnpm --filter storybook exec tsc --noEmit`)
- [x] Lint schoon (`pnpm lint`, alleen pre-bestaande warnings)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)