### PR TITLE
fix(tokens): focus outline in reset.css ontkoppelen van hardcoded waarden

### DIFF
--- a/packages/core/src/styles/reset.css
+++ b/packages/core/src/styles/reset.css
@@ -78,8 +78,9 @@ button {
 
 /* Improve focus visibility */
 :focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: 2px;
+  outline: var(--dsn-focus-outline-width) var(--dsn-focus-outline-style)
+    var(--dsn-focus-outline-color);
+  outline-offset: var(--dsn-focus-outline-offset);
 }
 
 /* Remove focus outline for mouse users */


### PR DESCRIPTION
## Summary

- Vervangt hardcoded `2px solid currentColor` / `outline-offset: 2px` in `reset.css` door de design token variabelen `--dsn-focus-outline-width`, `--dsn-focus-outline-style`, `--dsn-focus-outline-color` en `--dsn-focus-outline-offset`
- Tokens definiëren `dashed`, `0px offset` en de correcte token-kleur — de reset volgt nu dezelfde bron van waarheid als de componenten zelf

**Opmerking:** Probleem 2 uit het issue (dark mode focus-tokens ontbreken) was al opgelost — `colors-dark.json` bevat al een expliciete `focus`-sectie met eigen dark mode waarden (`#f4f4f4` outline, inverse `#0b0c0c`).

Closes #87

## Test plan

- [x] `pnpm test` — 1008 tests groen
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [x] `pnpm lint` — 0 fouten
- [x] Visuele regressie via Chromatic (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)