### PR TITLE
fix(tokens): hardcoded kleur- en schaduwfallbacks in table.css vervangen

### DIFF
--- a/packages/components-html/src/table/table.css
+++ b/packages/components-html/src/table/table.css
@@ -10,18 +10,19 @@
  *
  * ⚠️ Vereist dat --dsn-table-wrapper-background-color overeenkomt met de omringende
  * pagina-achtergrond. Overschrijf dit token als de tabel op een gekleurde achtergrond staat.
- * De schaduwkleur is niet getoken (shadow.direct bestaat niet in alle thema's);
- * overschrijf --dsn-table-wrapper-scroll-shadow-color als je een andere schaduwkleur wilt.
+ * Overschrijf --dsn-table-wrapper-scroll-shadow-color als je een andere schaduwkleur wilt.
  */
 
 .dsn-table-wrapper {
-  /* Lokale variabelen zodat de waarden maar één keer herhaald hoeven te worden.
-   * Fallbacks zorgen ervoor dat de schaduwen werken ook zonder gebouwde design tokens. */
+  /* Lokale variabelen zodat de waarden maar één keer herhaald hoeven te worden. */
   --_bg: var(
     --dsn-table-wrapper-background-color,
-    var(--dsn-color-neutral-bg-document, #fcfcfc)
+    var(--dsn-color-neutral-bg-document)
   );
-  --_shadow: var(--dsn-table-wrapper-scroll-shadow-color, rgba(0, 0, 0, 0.15));
+  --_shadow: var(
+    --dsn-table-wrapper-scroll-shadow-color,
+    var(--dsn-color-shadow-scroll)
+  );
 
   overflow-x: auto;
   background-color: var(--_bg);


### PR DESCRIPTION
## Summary

- Verwijdert hardcoded `#fcfcfc` fallback — `--_bg` gebruikt nu `var(--dsn-color-neutral-bg-document)` zonder hardcoded waarde
- Vervangt `rgba(0, 0, 0, 0.15)` door `var(--dsn-color-shadow-scroll)` — dark mode krijgt nu automatisch `rgba(255, 255, 255, 0.12)` (lichte schaduw op donkere achtergrond)
- Bijgewerkte comment: vermelding "is niet getoken" verwijderd

**Opmerking:** `dsn.color.shadow.scroll` bestond al in beide thema's — alleen de CSS-referentie in `table.css` ontbrak.

Closes #86

## Test plan

- [x] `pnpm test` — 1008 tests groen
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [x] `pnpm lint` — 0 fouten
- [x] Scrollable table story visueel geverifieerd in Storybook preview
- [x] Visuele regressie via Chromatic (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)