### PR TITLE
fix(BreadcrumbNavigation): verwijder min-block-size van breadcrumb items

### DIFF
--- a/packages/components-html/src/breadcrumb-navigation/breadcrumb-navigation.css
+++ b/packages/components-html/src/breadcrumb-navigation/breadcrumb-navigation.css
@@ -60,7 +60,6 @@
 .dsn-breadcrumb-navigation__item {
   display: flex;
   align-items: center;
-  min-block-size: var(--dsn-breadcrumb-navigation-item-min-block-size);
   padding-block: var(--dsn-breadcrumb-navigation-item-padding-block);
   padding-inline: var(--dsn-breadcrumb-navigation-item-padding-inline);
   gap: var(--dsn-breadcrumb-navigation-column-gap);


### PR DESCRIPTION
## Summary
- Verwijder `min-block-size` van `.dsn-breadcrumb-navigation__item`

🤖 Generated with [Claude Code](https://claude.com/claude-code)