### PR TITLE
feat(ActionGroup): voeg ActionGroup component toe (issue #40)

### DIFF
--- a/packages/components-html/src/action-group/action-group.css
+++ b/packages/components-html/src/action-group/action-group.css
@@ -1,0 +1,54 @@
+/**
+ * ActionGroup Component
+ * Groups related actions (Buttons and Links) and manages their layout.
+ *
+ * Usage:
+ * <!-- Horizontal (default) — wraps automatically when viewport is too narrow -->
+ * <div class="dsn-action-group">
+ *   <button class="dsn-button dsn-button--strong dsn-button--size-default">
+ *     <span class="dsn-button__label">Opslaan</span>
+ *   </button>
+ *   <button class="dsn-button dsn-button--subtle dsn-button--size-default">
+ *     <span class="dsn-button__label">Annuleren</span>
+ *   </button>
+ * </div>
+ *
+ * <!-- Horizontal with Link as soft exit -->
+ * <div class="dsn-action-group">
+ *   <button class="dsn-button dsn-button--strong dsn-button--size-default">
+ *     <span class="dsn-button__label">Volgende stap</span>
+ *   </button>
+ *   <a class="dsn-link" href="/">Terug naar overzicht</a>
+ * </div>
+ *
+ * <!-- Vertical -->
+ * <div class="dsn-action-group dsn-action-group--vertical">
+ *   <button class="dsn-button dsn-button--strong dsn-button--size-default">
+ *     <span class="dsn-button__label">Primaire actie</span>
+ *   </button>
+ *   <button class="dsn-button dsn-button--subtle dsn-button--size-default">
+ *     <span class="dsn-button__label">Secundaire actie</span>
+ *   </button>
+ * </div>
+ */
+
+/* ===========================
+   Base layout — horizontal (default)
+   =========================== */
+.dsn-action-group {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: var(--dsn-action-group-column-gap);
+  row-gap: var(--dsn-action-group-row-gap);
+}
+
+/* ===========================
+   Vertical modifier
+   =========================== */
+.dsn-action-group--vertical {
+  flex-direction: column;
+  flex-wrap: nowrap;
+  align-items: flex-start;
+}

--- a/packages/components-react/src/ActionGroup/ActionGroup.css
+++ b/packages/components-react/src/ActionGroup/ActionGroup.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/action-group/action-group.css';

--- a/packages/components-react/src/ActionGroup/ActionGroup.test.tsx
+++ b/packages/components-react/src/ActionGroup/ActionGroup.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ActionGroup } from './ActionGroup';
+
+describe('ActionGroup', () => {
+  // ===========================
+  // Rendering
+  // ===========================
+
+  it('renders children', () => {
+    render(
+      <ActionGroup>
+        <button>Opslaan</button>
+        <button>Annuleren</button>
+      </ActionGroup>
+    );
+    expect(screen.getByText('Opslaan')).toBeInTheDocument();
+    expect(screen.getByText('Annuleren')).toBeInTheDocument();
+  });
+
+  it('renders as a <div> element', () => {
+    const { container } = render(
+      <ActionGroup>
+        <button>Actie</button>
+      </ActionGroup>
+    );
+    expect(container.firstChild?.nodeName).toBe('DIV');
+  });
+
+  it('renders with a single child', () => {
+    render(
+      <ActionGroup>
+        <button>Enige actie</button>
+      </ActionGroup>
+    );
+    expect(screen.getByText('Enige actie')).toBeInTheDocument();
+  });
+
+  // ===========================
+  // Classes
+  // ===========================
+
+  it('always has base dsn-action-group class', () => {
+    const { container } = render(
+      <ActionGroup>
+        <button>Actie</button>
+      </ActionGroup>
+    );
+    expect(container.firstChild).toHaveClass('dsn-action-group');
+  });
+
+  it('does not have vertical modifier by default', () => {
+    const { container } = render(
+      <ActionGroup>
+        <button>Actie</button>
+      </ActionGroup>
+    );
+    expect(container.firstChild).not.toHaveClass('dsn-action-group--vertical');
+  });
+
+  it('does not have vertical modifier when direction is horizontal', () => {
+    const { container } = render(
+      <ActionGroup direction="horizontal">
+        <button>Actie</button>
+      </ActionGroup>
+    );
+    expect(container.firstChild).not.toHaveClass('dsn-action-group--vertical');
+  });
+
+  it('has vertical modifier when direction is vertical', () => {
+    const { container } = render(
+      <ActionGroup direction="vertical">
+        <button>Actie</button>
+      </ActionGroup>
+    );
+    expect(container.firstChild).toHaveClass('dsn-action-group');
+    expect(container.firstChild).toHaveClass('dsn-action-group--vertical');
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <ActionGroup className="custom-group">
+        <button>Actie</button>
+      </ActionGroup>
+    );
+    expect(container.firstChild).toHaveClass('dsn-action-group');
+    expect(container.firstChild).toHaveClass('custom-group');
+  });
+
+  // ===========================
+  // Ref + HTML attributes
+  // ===========================
+
+  it('forwards ref to the div element', () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(
+      <ActionGroup ref={ref}>
+        <button>Actie</button>
+      </ActionGroup>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.tagName).toBe('DIV');
+  });
+
+  it('spreads additional HTML attributes', () => {
+    render(
+      <ActionGroup id="action-group-1" data-testid="my-group">
+        <button>Actie</button>
+      </ActionGroup>
+    );
+    const el = screen.getByTestId('my-group');
+    expect(el).toHaveAttribute('id', 'action-group-1');
+  });
+});

--- a/packages/components-react/src/ActionGroup/ActionGroup.tsx
+++ b/packages/components-react/src/ActionGroup/ActionGroup.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import './ActionGroup.css';
+
+export interface ActionGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Richting van de groep — horizontale rij met wrapping of verticale kolom
+   * @default 'horizontal'
+   */
+  direction?: 'horizontal' | 'vertical';
+
+  /**
+   * `Button`- en/of `Link`-componenten
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * ActionGroup component
+ * Groepeert gerelateerde acties en verzorgt de lay-out van Buttons en Links.
+ * Horizontale richting (default) wraps automatisch bij te weinig ruimte.
+ *
+ * @example
+ * ```tsx
+ * // Horizontaal (default)
+ * <ActionGroup>
+ *   <Button variant="strong">Opslaan</Button>
+ *   <Button variant="subtle">Annuleren</Button>
+ * </ActionGroup>
+ *
+ * // Horizontaal met Link
+ * <ActionGroup>
+ *   <Button variant="strong">Volgende stap</Button>
+ *   <Link href="/">Terug naar overzicht</Link>
+ * </ActionGroup>
+ *
+ * // Verticaal
+ * <ActionGroup direction="vertical">
+ *   <Button variant="strong">Primaire actie</Button>
+ *   <Button variant="subtle">Secundaire actie</Button>
+ * </ActionGroup>
+ * ```
+ */
+export const ActionGroup = React.forwardRef<HTMLDivElement, ActionGroupProps>(
+  ({ className, direction = 'horizontal', children, ...props }, ref) => {
+    const classes = classNames(
+      'dsn-action-group',
+      direction === 'vertical' && 'dsn-action-group--vertical',
+      className
+    );
+
+    return (
+      <div ref={ref} className={classes} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+ActionGroup.displayName = 'ActionGroup';

--- a/packages/components-react/src/ActionGroup/index.ts
+++ b/packages/components-react/src/ActionGroup/index.ts
@@ -1,0 +1,2 @@
+export { ActionGroup } from './ActionGroup';
+export type { ActionGroupProps } from './ActionGroup';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 // Layout Components
+export * from './ActionGroup';
 export * from './Body';
 export * from './Container';
 export * from './Grid';

--- a/packages/design-tokens/src/tokens/components/action-group.json
+++ b/packages/design-tokens/src/tokens/components/action-group.json
@@ -1,0 +1,16 @@
+{
+  "dsn": {
+    "action-group": {
+      "column-gap": {
+        "value": "{dsn.space.inline.lg}",
+        "type": "dimension",
+        "comment": "Horizontal gap between actions in horizontal direction"
+      },
+      "row-gap": {
+        "value": "{dsn.space.row.sm}",
+        "type": "dimension",
+        "comment": "Vertical gap between wrapped rows in horizontal direction"
+      }
+    }
+  }
+}

--- a/packages/storybook/src/ActionGroup.docs.md
+++ b/packages/storybook/src/ActionGroup.docs.md
@@ -1,0 +1,53 @@
+# ActionGroup
+
+Groepeert gerelateerde acties en verzorgt de lay-out van Buttons en Links.
+
+## Doel
+
+ActionGroup is een lay-outprimitief voor het groeperen van één of meer gerelateerde acties. De groep regelt de onderlinge spacing en richting — horizontaal met automatisch wrappen (default) of verticaal als kolom. De ActionGroup bevat directe children: `Button`- en/of `Link`-componenten.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Primaire en secundaire actie naast elkaar in een formulier (bijv. "Opslaan" + "Annuleren").
+- Navigatieacties onderaan een wizardstap.
+- Combinatie van een button en een link als zachte uitweg (GOV.UK patroon).
+- Meerdere gerelateerde acties die automatisch moeten wrappen bij smalle viewports.
+
+## Don't use when
+
+- Acties geen directe relatie met elkaar hebben — gebruik dan losse Buttons.
+- Navigatie-items in een menu of navbar — gebruik andere navigatiepatronen.
+- Er slechts één actie is die niet in een groepscontext staat — een losse Button volstaat.
+
+## Best practices
+
+### Volgorde van acties
+
+- Plaats de primaire actie altijd als eerste child — dit bepaalt zowel de visuele volgorde als de lees- en tabvolgorde.
+- De secundaire actie (bijv. "Annuleren") volgt na de primaire actie.
+
+### Richting
+
+- Gebruik `direction="horizontal"` (default) voor de meeste use cases — de items wrappen automatisch bij te weinig ruimte.
+- Gebruik `direction="vertical"` wanneer de acties beter als kolom gepresenteerd worden (bijv. mobiele formulieren of stacked layouts).
+
+### Button als uitweg met Link
+
+- Combineer een `Button` met een `Link` voor het GOV.UK-patroon: de primaire actie is de button, de `Link` biedt een zachte uitweg (bijv. "Terug naar overzicht").
+- De `Link` wordt automatisch verticaal gecentreerd naast de button via `align-items: center`.
+
+## Design tokens
+
+| Token                           | Beschrijving                                                   |
+| ------------------------------- | -------------------------------------------------------------- |
+| `--dsn-action-group-column-gap` | Horizontale ruimte tussen acties in horizontale richting       |
+| `--dsn-action-group-row-gap`    | Verticale ruimte tussen gewrapte rijen in horizontale richting |
+
+## Accessibility
+
+- ActionGroup heeft geen eigen ARIA-rol — de groepering is puur lay-out, geen semantische eenheid.
+- De volgorde van children bepaalt de lees- en tabvolgorde — primaire actie altijd als eerste child.
+- Icon-only Buttons in een ActionGroup hebben hun label verborgen via `dsn-button__label` + `dsn-button--icon-only` — de ActionGroup zelf hoeft hier niets voor te doen.
+- Gebruik nooit `role="group"` of `aria-label` op de ActionGroup — dit voegt geen waarde toe voor screenreaders.

--- a/packages/storybook/src/ActionGroup.docs.mdx
+++ b/packages/storybook/src/ActionGroup.docs.mdx
@@ -1,0 +1,32 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as ActionGroupStories from './ActionGroup.stories';
+import docs from './ActionGroup.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={ActionGroupStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={ActionGroupStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={ActionGroupStories.Default}
+  html={`<div class="dsn-action-group">
+  <button class="dsn-button dsn-button--strong dsn-button--size-default">
+    <span class="dsn-button__label">Opslaan</span>
+  </button>
+  <button class="dsn-button dsn-button--subtle dsn-button--size-default">
+    <span class="dsn-button__label">Annuleren</span>
+  </button>
+</div>`}
+/>
+
+<Controls of={ActionGroupStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/ActionGroup.stories.tsx
+++ b/packages/storybook/src/ActionGroup.stories.tsx
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ActionGroup, Button, Link } from '@dsn/components-react';
+import DocsPage from './ActionGroup.docs.mdx';
+import { rtlDecorator } from './story-helpers';
+
+const meta: Meta<typeof ActionGroup> = {
+  title: 'Components/ActionGroup',
+  component: ActionGroup,
+  parameters: {
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const modifier =
+          args.direction === 'vertical' ? ' dsn-action-group--vertical' : '';
+        return `<div class="dsn-action-group${modifier}">
+  <button class="dsn-button dsn-button--strong dsn-button--size-default">
+    <span class="dsn-button__label">Opslaan</span>
+  </button>
+  <button class="dsn-button dsn-button--subtle dsn-button--size-default">
+    <span class="dsn-button__label">Annuleren</span>
+  </button>
+</div>`;
+      },
+    },
+  },
+  argTypes: {
+    direction: {
+      control: { type: 'radio' },
+      options: ['horizontal', 'vertical'],
+    },
+    children: { control: false },
+  },
+  args: {
+    direction: 'horizontal',
+    children: (
+      <>
+        <Button variant="strong">Opslaan</Button>
+        <Button variant="subtle">Annuleren</Button>
+      </>
+    ),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActionGroup>;
+
+export const Default: Story = {};
+
+export const WithLink: Story = {
+  name: 'With Link',
+  args: {
+    children: (
+      <>
+        <Button variant="strong">Volgende stap</Button>
+        <Link href="/">Terug naar overzicht</Link>
+      </>
+    ),
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    direction: 'vertical',
+  },
+};
+
+export const Wrapping: Story = {
+  name: 'Wrapping',
+  render: () => (
+    <div style={{ maxWidth: '280px' }}>
+      <ActionGroup>
+        <Button variant="strong">Opslaan</Button>
+        <Button variant="subtle">Opslaan als concept</Button>
+        <Button variant="subtle">Annuleren</Button>
+      </ActionGroup>
+    </div>
+  ),
+};
+
+export const SingleAction: Story = {
+  name: 'Single action',
+  args: {
+    children: <Button variant="strong">Verstuur aanvraag</Button>,
+  },
+};
+
+export const ShortText: Story = {
+  name: 'Short text',
+  args: {
+    children: (
+      <>
+        <Button variant="strong">Ok</Button>
+        <Button variant="subtle">Nee</Button>
+      </>
+    ),
+  },
+};
+
+export const LongText: Story = {
+  name: 'Long text',
+  args: {
+    children: (
+      <>
+        <Button variant="strong">
+          Bevestig en verstuur de volledige aanvraag
+        </Button>
+        <Button variant="subtle">
+          Annuleer en ga terug naar het overzicht
+        </Button>
+      </>
+    ),
+  },
+};
+
+export const RTL: Story = {
+  name: 'RTL',
+  decorators: [rtlDecorator],
+  render: () => (
+    <div dir="rtl">
+      <ActionGroup>
+        <Button variant="strong">حفظ</Button>
+        <Button variant="subtle">إلغاء</Button>
+      </ActionGroup>
+    </div>
+  ),
+};

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -63,8 +63,9 @@ function App() {
 
 **43 componenten totaal** — alle beschikbaar als HTML/CSS én React.
 
-### Layout Components (4)
+### Layout Components (5)
 
+- **ActionGroup** — Groepeert gerelateerde acties (Buttons en Links) horizontaal of verticaal met automatisch wrappen
 - **Body** — Document-level cascade basisstijlen (typografie, kleur, achtergrond) — zet `dsn-body` op `<body>`
 - **Container** — Centrerende wrapper met max-width en padding-inline voor pagina-layout
 - **Grid** — 12-koloms CSS Grid container met gutter, margin en optionele max-width (`contained`)
@@ -150,4 +151,4 @@ MIT License — zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.7.0 | **Laatste update:** 19 maart 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.10.0 | **Laatste update:** 20 maart 2026 | **Auteur:** Jeffrey Lauwers


### PR DESCRIPTION
## Summary

- Nieuw `ActionGroup` lay-outprimitief voor het groeperen van Buttons en Links
- Horizontale richting (default) met automatisch wrappen bij smalle viewports
- Verticale richting via `dsn-action-group--vertical` modifier / `direction="vertical"` prop
- Componenttokens: `--dsn-action-group-column-gap` (12px) en `--dsn-action-group-row-gap` (4px)

## Bestanden

- `packages/components-html/src/action-group/action-group.css` — HTML/CSS implementatie
- `packages/components-react/src/ActionGroup/` — React wrapper + tests (10 tests)
- `packages/design-tokens/src/tokens/components/action-group.json` — componenttokens
- `packages/storybook/src/ActionGroup.*` — 3 Storybook-bestanden (stories, docs.mdx, docs.md)

## Closes

Closes #40

## Test plan

- [ ] `pnpm test` — 1043 tests groen (10 nieuwe tests voor ActionGroup)
- [ ] `pnpm --filter storybook exec tsc --noEmit` — 0 TypeScript-fouten
- [ ] `pnpm lint` — 0 lint-fouten
- [ ] Storybook stories: Default, WithLink, Vertical, Wrapping, SingleAction, ShortText, LongText, RTL
- [ ] Wrapping werkt correct in smalle container (280px demo in Wrapping story)
- [ ] Verticale richting heeft `align-items: flex-start` — buttons nemen niet volledige breedte in

🤖 Generated with [Claude Code](https://claude.com/claude-code)