### PR TITLE
feat(DotBadge): voeg DotBadge component toe (issue #39)

### DIFF
--- a/packages/components-html/src/dot-badge/dot-badge.css
+++ b/packages/components-html/src/dot-badge/dot-badge.css
@@ -1,0 +1,93 @@
+/**
+ * DotBadge Component
+ * Kleine gekleurde stip die bij een Button of Link wordt geplaatst om
+ * zonder label of getal de aandacht te trekken bij een statuswijziging.
+ *
+ * Altijd aria-hidden="true" — context via dsn-visually-hidden in de parent.
+ * Parent-wrapper heeft position: relative nodig.
+ *
+ * Usage:
+ * <!-- Basis dot (negative, meest gebruikt) -->
+ * <span class="dsn-dot-badge dsn-dot-badge--negative" aria-hidden="true"></span>
+ *
+ * <!-- Met pulse-effect voor urgente statuswijzigingen -->
+ * <span class="dsn-dot-badge dsn-dot-badge--negative dsn-dot-badge--pulse" aria-hidden="true"></span>
+ *
+ * <!-- Positive variant -->
+ * <span class="dsn-dot-badge dsn-dot-badge--positive" aria-hidden="true"></span>
+ *
+ * <!-- Info variant -->
+ * <span class="dsn-dot-badge dsn-dot-badge--info" aria-hidden="true"></span>
+ *
+ * <!-- Warning variant -->
+ * <span class="dsn-dot-badge dsn-dot-badge--warning" aria-hidden="true"></span>
+ *
+ * <!-- Neutral variant -->
+ * <span class="dsn-dot-badge dsn-dot-badge--neutral" aria-hidden="true"></span>
+ */
+
+.dsn-dot-badge {
+  display: block;
+  position: absolute;
+  inline-size: var(--dsn-dot-badge-size);
+  block-size: var(--dsn-dot-badge-size);
+  border-radius: 50%;
+  background-color: var(--dsn-dot-badge-color);
+  inset-block-start: var(--dsn-dot-badge-inset-block-start);
+  inset-inline-end: var(--dsn-dot-badge-inset-inline-end);
+}
+
+/* Variant kleuren */
+.dsn-dot-badge--negative {
+  --dsn-dot-badge-color: var(--dsn-color-negative-color-default);
+}
+
+.dsn-dot-badge--positive {
+  --dsn-dot-badge-color: var(--dsn-color-positive-color-default);
+}
+
+.dsn-dot-badge--warning {
+  --dsn-dot-badge-color: var(--dsn-color-warning-color-default);
+}
+
+.dsn-dot-badge--info {
+  --dsn-dot-badge-color: var(--dsn-color-info-color-default);
+}
+
+.dsn-dot-badge--neutral {
+  --dsn-dot-badge-color: var(--dsn-color-neutral-color-default);
+}
+
+/* Pulse-effect via ::before pseudo-element — geen extra DOM-nodes nodig */
+.dsn-dot-badge--pulse::before {
+  content: '';
+  display: block;
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background-color: var(--dsn-dot-badge-color);
+  animation: dsn-dot-badge-pulse var(--dsn-dot-badge-pulse-duration)
+    var(--dsn-dot-badge-pulse-easing) infinite;
+}
+
+@keyframes dsn-dot-badge-pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+  70% {
+    transform: scale(2.5);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(2.5);
+    opacity: 0;
+  }
+}
+
+/* Animatie respecteert prefers-reduced-motion — dot blijft zichtbaar */
+@media (prefers-reduced-motion: reduce) {
+  .dsn-dot-badge--pulse::before {
+    animation: none;
+  }
+}

--- a/packages/components-react/src/DotBadge/DotBadge.css
+++ b/packages/components-react/src/DotBadge/DotBadge.css
@@ -1,0 +1,1 @@
+@import '@dsn/components-html/dot-badge/dot-badge.css';

--- a/packages/components-react/src/DotBadge/DotBadge.test.tsx
+++ b/packages/components-react/src/DotBadge/DotBadge.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { DotBadge } from './DotBadge';
+
+describe('DotBadge', () => {
+  it('renders as a <span> element', () => {
+    const { container } = render(<DotBadge />);
+    expect(container.firstChild?.nodeName).toBe('SPAN');
+  });
+
+  it('always has base dsn-dot-badge class', () => {
+    const { container } = render(<DotBadge />);
+    expect(container.firstChild).toHaveClass('dsn-dot-badge');
+  });
+
+  it('always has aria-hidden="true"', () => {
+    const { container } = render(<DotBadge />);
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('applies negative variant class by default', () => {
+    const { container } = render(<DotBadge />);
+    expect(container.firstChild).toHaveClass('dsn-dot-badge--negative');
+  });
+
+  it.each(['positive', 'negative', 'warning', 'info', 'neutral'] as const)(
+    'applies variant modifier class for %s variant',
+    (variant) => {
+      const { container } = render(<DotBadge variant={variant} />);
+      expect(container.firstChild).toHaveClass(`dsn-dot-badge--${variant}`);
+    }
+  );
+
+  it('does not apply pulse class when pulse is false (default)', () => {
+    const { container } = render(<DotBadge />);
+    expect(container.firstChild).not.toHaveClass('dsn-dot-badge--pulse');
+  });
+
+  it('applies pulse class when pulse is true', () => {
+    const { container } = render(<DotBadge pulse />);
+    expect(container.firstChild).toHaveClass('dsn-dot-badge--pulse');
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<DotBadge className="custom" />);
+    expect(container.firstChild).toHaveClass('dsn-dot-badge');
+    expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('forwards ref', () => {
+    const ref = { current: null as HTMLSpanElement | null };
+    render(<DotBadge ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+
+  it('spreads additional HTML attributes', () => {
+    const { container } = render(<DotBadge data-testid="dot" />);
+    expect(container.firstChild).toHaveAttribute('data-testid', 'dot');
+  });
+});

--- a/packages/components-react/src/DotBadge/DotBadge.tsx
+++ b/packages/components-react/src/DotBadge/DotBadge.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import './DotBadge.css';
+
+export type DotBadgeVariant =
+  | 'negative'
+  | 'positive'
+  | 'warning'
+  | 'info'
+  | 'neutral';
+
+export interface DotBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /**
+   * Signaalkleur van de stip
+   * @default 'negative'
+   */
+  variant?: DotBadgeVariant;
+
+  /**
+   * Voegt een pulserend ring-effect toe om extra aandacht te trekken
+   * @default false
+   */
+  pulse?: boolean;
+}
+
+/**
+ * DotBadge component
+ * Kleine gekleurde stip die bij een Button of Link wordt geplaatst om
+ * zonder label of getal de aandacht te trekken bij een statuswijziging.
+ *
+ * Altijd aria-hidden="true" — context via dsn-visually-hidden in de parent.
+ * Parent-wrapper heeft position: relative nodig.
+ *
+ * @example
+ * ```tsx
+ * // Basis gebruik — negatieve dot bij een icon-only Button
+ * <div style={{ position: 'relative', display: 'inline-flex' }}>
+ *   <Button variant="subtle" iconOnly iconStart={<Icon name="inbox" aria-hidden />}>
+ *     Inbox
+ *     <span className="dsn-visually-hidden">, 3 ongelezen berichten</span>
+ *   </Button>
+ *   <DotBadge variant="negative" />
+ * </div>
+ *
+ * // Met pulse-effect voor urgente statuswijzigingen
+ * <DotBadge variant="negative" pulse />
+ * ```
+ */
+export const DotBadge = React.forwardRef<HTMLSpanElement, DotBadgeProps>(
+  ({ className, variant = 'negative', pulse = false, ...props }, ref) => {
+    const classes = classNames(
+      'dsn-dot-badge',
+      `dsn-dot-badge--${variant}`,
+      pulse && 'dsn-dot-badge--pulse',
+      className
+    );
+
+    return <span ref={ref} className={classes} aria-hidden="true" {...props} />;
+  }
+);
+
+DotBadge.displayName = 'DotBadge';

--- a/packages/components-react/src/DotBadge/index.ts
+++ b/packages/components-react/src/DotBadge/index.ts
@@ -1,0 +1,1 @@
+export * from './DotBadge';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -48,6 +48,7 @@ export * from './RadioOption';
 export * from './OptionLabel';
 
 // Display & Feedback Components
+export * from './DotBadge';
 export * from './StatusBadge';
 export * from './Alert';
 export * from './Note';

--- a/packages/design-tokens/src/tokens/components/dot-badge.json
+++ b/packages/design-tokens/src/tokens/components/dot-badge.json
@@ -1,0 +1,30 @@
+{
+  "dsn": {
+    "dot-badge": {
+      "size": {
+        "value": "0.5rem",
+        "type": "dimension",
+        "comment": "Diameter van de dot (8px)"
+      },
+      "inset-block-start": {
+        "value": "-0.25rem",
+        "type": "dimension",
+        "comment": "Verticale offset — dot steekt boven de rechterbovenhoek van de parent uit"
+      },
+      "inset-inline-end": {
+        "value": "-0.25rem",
+        "type": "dimension",
+        "comment": "Horizontale offset — dot steekt rechts buiten de parent uit"
+      },
+      "pulse-duration": {
+        "value": "{dsn.transition.duration.slower}",
+        "type": "duration",
+        "comment": "Duur van de pulse-animatie"
+      },
+      "pulse-easing": {
+        "value": "{dsn.transition.easing.default}",
+        "comment": "Easing van de pulse-animatie"
+      }
+    }
+  }
+}

--- a/packages/storybook/src/DotBadge.docs.md
+++ b/packages/storybook/src/DotBadge.docs.md
@@ -1,0 +1,99 @@
+# DotBadge
+
+Kleine gekleurde stip die bij een Button of Link wordt geplaatst om zonder label of getal de aandacht te trekken bij een statuswijziging.
+
+## Doel
+
+DotBadge is een puur visueel indicator-component. Het trekt de aandacht op een discrete statuswijziging — zoals ongelezen berichten bij een inbox-icoon of nieuwe updates achter een navigatielink — zonder dat er een getal of label voor nodig is. Via de `pulse`-modifier kan de stip pulseren voor extra urgentie.
+
+De component heeft bewust geen eigen toegankelijkheidsmechanisme. De verantwoordelijkheid voor toegankelijke context ligt bij de implementerende code via `dsn-visually-hidden`.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Een gebruiker subtiel moet worden gewezen op een statuswijziging zonder dat een getal of label nodig is.
+- Ongelezen berichten of notificaties bij een inbox- of bell-icoon.
+- Nieuwe updates achter een navigatielink.
+- Urgente, tijdkritische statuswijzigingen waarbij de `pulse`-modifier extra aandacht trekt.
+
+## Don't use when
+
+- Je een getal wilt tonen (bijv. "3 ongelezen") — gebruik dan een **StatusBadge** of een badge met getal.
+- Je een statustoestand wilt communiceren met een label — gebruik **StatusBadge**.
+- De dot op zichzelf staat zonder parent Button of Link — de dot heeft altijd context nodig.
+
+## Best practices
+
+### Variantkeuze
+
+- **Negative** — standaard, voor foutmeldingen en ongelezen berichten.
+- **Positive** — voor succesvolle statuswijzigingen.
+- **Warning** — voor waarschuwingen die aandacht vragen.
+- **Info** — voor informatieve updates.
+- **Neutral** — voor neutrale statuswijzigingen.
+
+### Parent-wrapper
+
+DotBadge is `position: absolute`. De parent-wrapper heeft altijd `position: relative` nodig. Gebruik `display: inline-flex` om de wrapper zo klein mogelijk te houden rond de parent Button of Link:
+
+```html
+<div style="position: relative; display: inline-flex;">
+  <!-- Button of Link -->
+  <span class="dsn-dot-badge dsn-dot-badge--negative" aria-hidden="true"></span>
+</div>
+```
+
+### Toegankelijkheid
+
+DotBadge heeft altijd `aria-hidden="true"` — screenreaders negeren de dot volledig. Voeg altijd een `dsn-visually-hidden` span toe in de parent Button of Link om de context te beschrijven:
+
+```html
+<!-- Icon-only button met inbox-dot -->
+<div style="position: relative; display: inline-flex;">
+  <button
+    class="dsn-button dsn-button--subtle dsn-button--size-default dsn-button--icon-only"
+  >
+    <svg class="dsn-icon" aria-hidden="true"><!-- mail --></svg>
+    <span class="dsn-button__label">
+      Inbox
+      <span class="dsn-visually-hidden">, 3 ongelezen berichten</span>
+    </span>
+  </button>
+  <span class="dsn-dot-badge dsn-dot-badge--negative" aria-hidden="true"></span>
+</div>
+```
+
+### Pulse-effect
+
+Gebruik de `pulse`-modifier alleen voor urgente, tijdkritische statuswijzigingen. De animatie respecteert `prefers-reduced-motion: reduce` — bij verminderde bewegingsvoorkeur vervalt de animatie maar blijft de dot zichtbaar.
+
+```html
+<span
+  class="dsn-dot-badge dsn-dot-badge--negative dsn-dot-badge--pulse"
+  aria-hidden="true"
+></span>
+```
+
+### Dynamische updates
+
+Bij dynamisch bijwerken van de dot (bijv. nieuwe berichten binnenkomen): voeg `aria-live="polite"` toe op een hoger niveau zodat screenreaders de wijziging aankondigen via de toegankelijke tekst in de Button of Link.
+
+## Design tokens
+
+| Token                               | Beschrijving                                      |
+| ----------------------------------- | ------------------------------------------------- |
+| `--dsn-dot-badge-size`              | Diameter van de dot (8px)                         |
+| `--dsn-dot-badge-color`             | Achtergrondkleur — wordt per variant ingesteld    |
+| `--dsn-dot-badge-inset-block-start` | Verticale offset t.o.v. rechterbovenhoek parent   |
+| `--dsn-dot-badge-inset-inline-end`  | Horizontale offset t.o.v. rechterbovenhoek parent |
+| `--dsn-dot-badge-pulse-duration`    | Duur van de pulse-animatie                        |
+| `--dsn-dot-badge-pulse-easing`      | Easing van de pulse-animatie                      |
+
+## Accessibility
+
+- DotBadge heeft altijd `aria-hidden="true"` — geen semantische betekenis op zichzelf.
+- Context via `dsn-visually-hidden` span in de parent Button of Link — **verplicht**.
+- Gebruik nooit `aria-label` op DotBadge zelf.
+- Bij dynamisch bijwerken: voeg `aria-live="polite"` toe op een hoger niveau.
+- Pulse-animatie respecteert `prefers-reduced-motion: reduce` — animatie vervalt, dot blijft zichtbaar.

--- a/packages/storybook/src/DotBadge.docs.mdx
+++ b/packages/storybook/src/DotBadge.docs.mdx
@@ -1,0 +1,25 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as DotBadgeStories from './DotBadge.stories';
+import docs from './DotBadge.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={DotBadgeStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={DotBadgeStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={DotBadgeStories.Default}
+  html={`<span class="dsn-dot-badge dsn-dot-badge--negative" aria-hidden="true"></span>`}
+/>
+
+<Controls of={DotBadgeStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/DotBadge.stories.tsx
+++ b/packages/storybook/src/DotBadge.stories.tsx
@@ -1,0 +1,229 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button, DotBadge, Icon, Link } from '@dsn/components-react';
+import DocsPage from './DotBadge.docs.mdx';
+
+const meta: Meta<typeof DotBadge> = {
+  title: 'Components/DotBadge',
+  component: DotBadge,
+  parameters: {
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const variant = args.variant ?? 'negative';
+        const pulse = args.pulse ? ' dsn-dot-badge--pulse' : '';
+        return `<span class="dsn-dot-badge dsn-dot-badge--${variant}${pulse}" aria-hidden="true"></span>`;
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['negative', 'positive', 'warning', 'info', 'neutral'],
+    },
+    pulse: { control: 'boolean' },
+  },
+  args: {
+    variant: 'negative',
+    pulse: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DotBadge>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          position: 'relative',
+          display: 'inline-block',
+          padding: '0.5rem',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const AllVariants: Story = {
+  name: 'All variants',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '2rem',
+        padding: '0.5rem',
+        alignItems: 'center',
+      }}
+    >
+      {(['negative', 'positive', 'warning', 'info', 'neutral'] as const).map(
+        (variant) => (
+          <div
+            key={variant}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: '0.5rem',
+            }}
+          >
+            <div
+              style={{
+                position: 'relative',
+                display: 'inline-block',
+                padding: '0.5rem',
+              }}
+            >
+              <DotBadge variant={variant} />
+            </div>
+            <span
+              style={{
+                fontSize: '0.75rem',
+                color: 'var(--dsn-color-neutral-color-default)',
+              }}
+            >
+              {variant}
+            </span>
+          </div>
+        )
+      )}
+    </div>
+  ),
+};
+
+export const WithPulse: Story = {
+  name: 'With pulse',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '2rem',
+        padding: '0.75rem',
+        alignItems: 'center',
+      }}
+    >
+      {(['negative', 'positive', 'warning', 'info', 'neutral'] as const).map(
+        (variant) => (
+          <div
+            key={variant}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: '0.5rem',
+            }}
+          >
+            <div
+              style={{
+                position: 'relative',
+                display: 'inline-block',
+                padding: '0.75rem',
+              }}
+            >
+              <DotBadge variant={variant} pulse />
+            </div>
+            <span
+              style={{
+                fontSize: '0.75rem',
+                color: 'var(--dsn-color-neutral-color-default)',
+              }}
+            >
+              {variant}
+            </span>
+          </div>
+        )
+      )}
+    </div>
+  ),
+};
+
+export const WithButton: Story = {
+  name: 'With Button',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '2rem',
+        flexWrap: 'wrap',
+        alignItems: 'flex-start',
+      }}
+    >
+      {/* Icon-only button met dot */}
+      <div style={{ position: 'relative', display: 'inline-flex' }}>
+        <Button
+          variant="subtle"
+          iconOnly
+          iconStart={<Icon name="mail" aria-hidden />}
+        >
+          Inbox
+          <span className="dsn-visually-hidden">, 3 ongelezen berichten</span>
+        </Button>
+        <DotBadge variant="negative" />
+      </div>
+
+      {/* Icon-only button met pulserende dot */}
+      <div style={{ position: 'relative', display: 'inline-flex' }}>
+        <Button
+          variant="subtle"
+          iconOnly
+          iconStart={<Icon name="bell" aria-hidden />}
+        >
+          Meldingen
+          <span className="dsn-visually-hidden">, nieuwe meldingen</span>
+        </Button>
+        <DotBadge variant="negative" pulse />
+      </div>
+
+      {/* Icon-only button met positieve dot */}
+      <div style={{ position: 'relative', display: 'inline-flex' }}>
+        <Button
+          variant="subtle"
+          iconOnly
+          iconStart={<Icon name="circle-check" aria-hidden />}
+        >
+          Status
+          <span className="dsn-visually-hidden">, status bijgewerkt</span>
+        </Button>
+        <DotBadge variant="positive" />
+      </div>
+    </div>
+  ),
+};
+
+export const WithLink: Story = {
+  name: 'With Link',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '2rem',
+        flexWrap: 'wrap',
+        alignItems: 'flex-start',
+      }}
+    >
+      {/* Link met dot */}
+      <div style={{ position: 'relative', display: 'inline-flex' }}>
+        <Link href="#">
+          Meldingen
+          <span className="dsn-visually-hidden"> (ongelezen)</span>
+        </Link>
+        <DotBadge variant="negative" />
+      </div>
+
+      {/* Link met pulserende dot */}
+      <div style={{ position: 'relative', display: 'inline-flex' }}>
+        <Link href="#">
+          Updates
+          <span className="dsn-visually-hidden">
+            {' '}
+            (nieuwe updates beschikbaar)
+          </span>
+        </Link>
+        <DotBadge variant="info" pulse />
+      </div>
+    </div>
+  ),
+};

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -82,8 +82,9 @@ function App() {
 - **Link** — Hyperlinks met icon ondersteuning en externe link handling
 - **Lists** — OrderedList en UnorderedList
 
-### Display & Feedback Components (5)
+### Display & Feedback Components (6)
 
+- **DotBadge** — Kleine gekleurde stip bij een Button of Link die zonder label de aandacht trekt bij een statuswijziging (met optioneel pulse-effect)
 - **StatusBadge** — Compact label dat een status communiceert met een signaalkleur (neutral, info, positive, negative, warning)
 - **Alert** — Belangrijk bericht dat de gebruiker informeert over de huidige activiteit (info, positive, negative, warning)
 - **Note** — Visueel uitgelicht bericht voor aanvullende informatie, passief (geen live region)


### PR DESCRIPTION
## Summary

- Nieuwe `DotBadge` component: kleine gekleurde stip die bij een Button of Link de aandacht trekt bij een statuswijziging
- Vijf varianten (`negative` (default), `positive`, `warning`, `info`, `neutral`) via modifier-klassen
- Optioneel `pulse`-effect via `dsn-dot-badge--pulse` modifier — pulserend ring-animatie via `::before`, respecteert `prefers-reduced-motion`
- Absoluut gepositioneerd via logische properties (`inset-block-start`, `inset-inline-end`) voor RTL-correctheid
- Altijd `aria-hidden="true"` — context via `dsn-visually-hidden` in de parent Button of Link

## Bestanden

- `packages/design-tokens/src/tokens/components/dot-badge.json` — component tokens
- `packages/components-html/src/dot-badge/dot-badge.css` — HTML/CSS implementatie
- `packages/components-react/src/DotBadge/` — React component + CSS + tests + index
- `packages/storybook/src/DotBadge.*` — stories, docs.mdx, docs.md

## Test plan

- [x] 14 nieuwe tests groen (`DotBadge.test.tsx`), totaal 1057 tests
- [x] TypeScript schoon: `pnpm --filter storybook exec tsc --noEmit`
- [x] Lint schoon: `pnpm lint`
- [x] Stories: Default, AllVariants, WithPulse, WithButton, WithLink

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)