### PR TITLE
fix(Radio): inner circle zichtbaar bij checked + focus state

### DIFF
--- a/packages/components-react/src/Radio/Radio.css
+++ b/packages/components-react/src/Radio/Radio.css
@@ -131,6 +131,12 @@
   background-color: var(--dsn-radio-checked-focus-background-color);
 }
 
+.dsn-radio__input:checked:focus-visible
+  + .dsn-radio__control
+  .dsn-radio__inner-circle {
+  background-color: var(--dsn-radio-checked-focus-color);
+}
+
 /* Disabled state */
 .dsn-radio__input:disabled + .dsn-radio__control {
   border-color: var(--dsn-radio-disabled-border-color);


### PR DESCRIPTION
## Summary

- Voegt de ontbrekende CSS-regel toe voor `.dsn-radio__inner-circle` bij de `checked:focus-visible` state
- De inner circle was onzichtbaar omdat de donkere achtergrondkleur van `dsn-radio-checked-focus-background-color` hem overschreef
- Volgt het bestaande patroon van `checked:hover` en `checked:active` (en de equivalente Checkbox fix)

## Test plan

- [ ] Geselecteerde radio button via toetsenbord focussen → inner circle is zichtbaar
- [ ] `pnpm test` — 1057 tests groen
- [ ] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [ ] `pnpm lint` — schoon

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)