### PR TITLE
feat(Heading): voeg text-wrap: balance toe

### DIFF
--- a/packages/components-html/src/heading/heading.css
+++ b/packages/components-html/src/heading/heading.css
@@ -11,6 +11,7 @@
 
 .dsn-heading {
   margin-block-start: 0;
+  text-wrap: balance;
 }
 
 /* Heading 1 Appearance */

--- a/packages/storybook/src/Heading.docs.md
+++ b/packages/storybook/src/Heading.docs.md
@@ -27,6 +27,7 @@ De Heading component biedt een consistente, toegankelijke manier om koppen weer 
 - **Respecteer de heading hiërarchie.** Spring geen levels over (bijv. niet direct van h2 naar h5). Dit helpt screenreaders de documentstructuur te begrijpen.
 - **Gebruik `appearance` voor visuele flexibiliteit.** Als je een h3 visueel kleiner wilt maken, gebruik dan `<Heading level={3} appearance="heading-5">` in plaats van `level={5}` te gebruiken.
 - **Houd headings kort en beschrijvend.** Goede headings zijn 1-6 woorden en beschrijven duidelijk wat volgt.
+- **Gebalanceerde regelafbrekingen.** Alle headings gebruiken `text-wrap: balance` zodat tekst gelijkmatig over regels verdeeld wordt en weeswoorden worden vermeden.
 - **Combineer met paragraphs.** Gebruik headings om secties te markeren en paragraphs voor de lopende tekst binnen die secties.
 - **Test met screenreaders.** Verifieer dat de heading structuur logisch is wanneer je door de headings navigeert (NVDA, JAWS, VoiceOver).
 


### PR DESCRIPTION
## Summary

- `text-wrap: balance` toegevoegd aan `.dsn-heading` in de CSS
- Docs bijgewerkt met toelichting over gebalanceerde regelafbrekingen

## Test plan

- [x] Alle 1057 tests groen
- [x] TypeScript schoon (0 fouten)
- [x] Lint schoon (0 fouten)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)