### PR TITLE
refactor(Button): vervang opacity-disabled door semantische neutral-scale tokens

### DIFF
--- a/packages/components-html/src/button/button.css
+++ b/packages/components-html/src/button/button.css
@@ -302,7 +302,9 @@
 
 /* Disabled State */
 .dsn-button:disabled {
-  opacity: 0.5;
+  background-color: var(--dsn-button-disabled-background-color);
+  color: var(--dsn-button-disabled-color);
+  border-color: var(--dsn-button-disabled-border-color);
   cursor: not-allowed;
 }
 

--- a/packages/design-tokens/src/tokens/components/button.json
+++ b/packages/design-tokens/src/tokens/components/button.json
@@ -495,6 +495,23 @@
           }
         }
       },
+      "disabled": {
+        "background-color": {
+          "value": "{dsn.color.neutral.bg-subtle}",
+          "type": "color",
+          "comment": "Disabled button background — neutral scale, variant-independent"
+        },
+        "color": {
+          "value": "{dsn.color.neutral.color-subtle}",
+          "type": "color",
+          "comment": "Disabled button text/icon color — neutral scale, variant-independent"
+        },
+        "border-color": {
+          "value": "{dsn.color.neutral.border-subtle}",
+          "type": "color",
+          "comment": "Disabled button border color — neutral scale, variant-independent"
+        }
+      },
       "size": {
         "default": {
           "font-size": {

--- a/packages/storybook/src/Button.docs.md
+++ b/packages/storybook/src/Button.docs.md
@@ -125,6 +125,9 @@ De Button component biedt een consistente, toegankelijke manier om acties te tri
 | `--dsn-button-subtle-positive-hover-background-color`   | Achtergrondkleur subtle-positive hover          |
 | `--dsn-button-subtle-positive-hover-border-color`       | Borderkleur subtle-positive hover               |
 | `--dsn-button-subtle-positive-hover-color`              | Tekstkleur subtle-positive hover                |
+| `--dsn-button-disabled-background-color`                | Achtergrondkleur disabled state (neutral scale) |
+| `--dsn-button-disabled-color`                           | Tekstkleur disabled state (neutral scale)       |
+| `--dsn-button-disabled-border-color`                    | Borderkleur disabled state (neutral scale)      |
 | `--dsn-button-size-default-font-size`                   | Font size default variant                       |
 | `--dsn-button-size-default-gap`                         | Ruimte tussen icoon en tekst default variant    |
 | `--dsn-button-size-default-icon-only-padding`           | Padding voor icon-only default variant          |


### PR DESCRIPTION
## Summary

- Drie nieuwe `--dsn-button-disabled-*` design tokens gedefinieerd in `button.json`, verwijzend naar de neutral color scale (`neutral.bg-subtle`, `neutral.color-subtle`, `neutral.border-subtle`)
- `opacity: 0.5` aanpak verwijderd uit `.dsn-button:disabled` in `button.css`
- Disabled state geeft nu een consistente, variant-onafhankelijke grijstint voor alle varianten (strong, default, subtle en sentimentvarianten)
- Token-tabel in `Button.docs.md` bijgewerkt met de nieuwe disabled tokens

Closes #99

## Test plan

- [x] `pnpm test` — 1057 tests groen
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [x] `pnpm lint` — 0 fouten

🤖 Generated with [Claude Code](https://claude.com/claude-code)