### PR TITLE
feat(Image): afbeeldingscomponent met lazy loading, prioriteit en vaste beeldverhoudingen

### DIFF
--- a/packages/components-html/src/image/image.css
+++ b/packages/components-html/src/image/image.css
@@ -1,0 +1,117 @@
+/**
+ * Image Component
+ * Performante, toegankelijke wrapper rond het native <img> element.
+ * Ondersteunt vaste beeldverhoudingen, lazy loading en optioneel bijschrift.
+ *
+ * Usage:
+ * <!-- Basis -->
+ * <figure class="dsn-image">
+ *   <img
+ *     class="dsn-image__img"
+ *     src="afbeelding.jpg"
+ *     alt="Beschrijving van de afbeelding"
+ *     width="800"
+ *     height="600"
+ *     loading="lazy"
+ *     decoding="async"
+ *   />
+ * </figure>
+ *
+ * <!-- Met vaste beeldverhouding -->
+ * <figure class="dsn-image dsn-image--ratio-16-9">
+ *   <img
+ *     class="dsn-image__img"
+ *     src="hero.jpg"
+ *     alt="Beschrijving"
+ *     width="1600"
+ *     height="900"
+ *     loading="lazy"
+ *     decoding="async"
+ *   />
+ * </figure>
+ *
+ * <!-- Met bijschrift -->
+ * <figure class="dsn-image">
+ *   <img
+ *     class="dsn-image__img"
+ *     src="foto.jpg"
+ *     alt="Beschrijving van de foto"
+ *     width="800"
+ *     height="600"
+ *     loading="lazy"
+ *     decoding="async"
+ *   />
+ *   <figcaption class="dsn-image__caption">Bijschrift bij de afbeelding</figcaption>
+ * </figure>
+ *
+ * <!-- Decoratief (aria-hidden op figure) -->
+ * <figure class="dsn-image" aria-hidden="true">
+ *   <img
+ *     class="dsn-image__img"
+ *     src="decoratief.jpg"
+ *     alt=""
+ *     width="800"
+ *     height="600"
+ *     loading="lazy"
+ *     decoding="async"
+ *   />
+ * </figure>
+ */
+
+/* ===========================
+   Root container
+   =========================== */
+.dsn-image {
+  display: block;
+  margin: 0;
+}
+
+/* ===========================
+   Image element
+   =========================== */
+.dsn-image__img {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  border-radius: var(--dsn-image-border-radius);
+}
+
+/* ===========================
+   Aspect ratio modifiers
+   Aspect-ratio forceert de weergaveverhouding;
+   object-fit: cover snijdt de rest bij.
+   =========================== */
+.dsn-image--ratio-16-9 .dsn-image__img {
+  aspect-ratio: 16 / 9;
+  height: 100%;
+}
+
+.dsn-image--ratio-4-3 .dsn-image__img {
+  aspect-ratio: 4 / 3;
+  height: 100%;
+}
+
+.dsn-image--ratio-1-1 .dsn-image__img {
+  aspect-ratio: 1 / 1;
+  height: 100%;
+}
+
+/* ===========================
+   Object-fit: contain modifier
+   Toont de volledige afbeelding zonder bijsnijden.
+   =========================== */
+.dsn-image--object-fit-contain .dsn-image__img {
+  object-fit: contain;
+}
+
+/* ===========================
+   Caption
+   =========================== */
+.dsn-image__caption {
+  display: block;
+  margin-block-start: var(--dsn-image-caption-margin-block-start);
+  color: var(--dsn-image-caption-color);
+  font-size: var(--dsn-image-caption-font-size);
+  line-height: var(--dsn-image-caption-line-height);
+}

--- a/packages/components-react/src/Image/Image.css
+++ b/packages/components-react/src/Image/Image.css
@@ -1,0 +1,6 @@
+/**
+ * Image component styles for React
+ * Re-exports the base Image styles from components-html
+ */
+
+@import '../../../components-html/src/image/image.css';

--- a/packages/components-react/src/Image/Image.test.tsx
+++ b/packages/components-react/src/Image/Image.test.tsx
@@ -1,0 +1,299 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Image } from './Image';
+
+describe('Image', () => {
+  // ===========================
+  // Rendering
+  // ===========================
+
+  it('renders a <figure> element as root', () => {
+    const { container } = render(
+      <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+    );
+    expect(container.firstChild?.nodeName).toBe('FIGURE');
+  });
+
+  it('renders an <img> element inside figure', () => {
+    const { container } = render(
+      <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+    );
+    expect(container.querySelector('img')).toBeInTheDocument();
+  });
+
+  it('renders with correct src, alt, width and height', () => {
+    render(
+      <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+    );
+    const img = screen.getByRole('img', { name: 'Beschrijving' });
+    expect(img).toHaveAttribute('src', '/foto.jpg');
+    expect(img).toHaveAttribute('alt', 'Beschrijving');
+    expect(img).toHaveAttribute('width', '800');
+    expect(img).toHaveAttribute('height', '600');
+  });
+
+  it('renders caption when provided', () => {
+    render(
+      <Image
+        src="/foto.jpg"
+        alt="Beschrijving"
+        width={800}
+        height={600}
+        caption="Bijschrift bij de afbeelding"
+      />
+    );
+    expect(
+      screen.getByText('Bijschrift bij de afbeelding')
+    ).toBeInTheDocument();
+  });
+
+  it('renders caption inside <figcaption>', () => {
+    const { container } = render(
+      <Image
+        src="/foto.jpg"
+        alt="Beschrijving"
+        width={800}
+        height={600}
+        caption="Bijschrift"
+      />
+    );
+    const figcaption = container.querySelector('figcaption');
+    expect(figcaption).toBeInTheDocument();
+    expect(figcaption).toHaveClass('dsn-image__caption');
+    expect(figcaption?.textContent).toBe('Bijschrift');
+  });
+
+  it('does not render figcaption when caption is not provided', () => {
+    const { container } = render(
+      <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+    );
+    expect(container.querySelector('figcaption')).not.toBeInTheDocument();
+  });
+
+  // ===========================
+  // Classes
+  // ===========================
+
+  it('always has base dsn-image class on figure', () => {
+    const { container } = render(
+      <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+    );
+    expect(container.firstChild).toHaveClass('dsn-image');
+  });
+
+  it('always has dsn-image__img class on img', () => {
+    const { container } = render(
+      <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+    );
+    expect(container.querySelector('img')).toHaveClass('dsn-image__img');
+  });
+
+  it('applies custom className to figure', () => {
+    const { container } = render(
+      <Image
+        src="/foto.jpg"
+        alt="Beschrijving"
+        width={800}
+        height={600}
+        className="custom-image"
+      />
+    );
+    expect(container.firstChild).toHaveClass('dsn-image');
+    expect(container.firstChild).toHaveClass('custom-image');
+  });
+
+  it('applies dsn-image--ratio-16-9 class for ratio="16:9"', () => {
+    const { container } = render(
+      <Image
+        src="/foto.jpg"
+        alt="Beschrijving"
+        width={1600}
+        height={900}
+        ratio="16:9"
+      />
+    );
+    expect(container.firstChild).toHaveClass('dsn-image--ratio-16-9');
+  });
+
+  it('applies dsn-image--ratio-4-3 class for ratio="4:3"', () => {
+    const { container } = render(
+      <Image
+        src="/foto.jpg"
+        alt="Beschrijving"
+        width={800}
+        height={600}
+        ratio="4:3"
+      />
+    );
+    expect(container.firstChild).toHaveClass('dsn-image--ratio-4-3');
+  });
+
+  it('applies dsn-image--ratio-1-1 class for ratio="1:1"', () => {
+    const { container } = render(
+      <Image
+        src="/foto.jpg"
+        alt="Beschrijving"
+        width={400}
+        height={400}
+        ratio="1:1"
+      />
+    );
+    expect(container.firstChild).toHaveClass('dsn-image--ratio-1-1');
+  });
+
+  it('does not apply a ratio class when ratio is not provided', () => {
+    const { container } = render(
+      <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+    );
+    expect(container.firstChild).not.toHaveClass('dsn-image--ratio-16-9');
+    expect(container.firstChild).not.toHaveClass('dsn-image--ratio-4-3');
+    expect(container.firstChild).not.toHaveClass('dsn-image--ratio-1-1');
+  });
+
+  it('applies dsn-image--object-fit-contain class for objectFit="contain"', () => {
+    const { container } = render(
+      <Image
+        src="/logo.png"
+        alt="Logo"
+        width={400}
+        height={300}
+        ratio="4:3"
+        objectFit="contain"
+      />
+    );
+    expect(container.firstChild).toHaveClass('dsn-image--object-fit-contain');
+  });
+
+  it('does not apply object-fit-contain class for default objectFit', () => {
+    const { container } = render(
+      <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+    );
+    expect(container.firstChild).not.toHaveClass(
+      'dsn-image--object-fit-contain'
+    );
+  });
+
+  // ===========================
+  // Loading attributes
+  // ===========================
+
+  it('applies loading="lazy" and decoding="async" by default', () => {
+    render(
+      <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+    );
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('loading', 'lazy');
+    expect(img).toHaveAttribute('decoding', 'async');
+  });
+
+  it('applies loading="eager" and fetchpriority="high" when priority is true', () => {
+    render(
+      <Image src="/hero.jpg" alt="Hero" width={1600} height={900} priority />
+    );
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('loading', 'eager');
+    expect(img).toHaveAttribute('fetchpriority', 'high');
+    expect(img).toHaveAttribute('decoding', 'async');
+  });
+
+  it('does not apply fetchpriority when priority is false', () => {
+    render(
+      <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+    );
+    const img = screen.getByRole('img');
+    expect(img).not.toHaveAttribute('fetchpriority');
+  });
+
+  // ===========================
+  // srcSet and sizes pass-through
+  // ===========================
+
+  it('passes srcSet to img element', () => {
+    render(
+      <Image
+        src="/foto.jpg"
+        alt="Beschrijving"
+        width={800}
+        height={600}
+        srcSet="/foto-400.jpg 400w, /foto-800.jpg 800w"
+      />
+    );
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute(
+      'srcset',
+      '/foto-400.jpg 400w, /foto-800.jpg 800w'
+    );
+  });
+
+  it('passes sizes to img element', () => {
+    render(
+      <Image
+        src="/foto.jpg"
+        alt="Beschrijving"
+        width={800}
+        height={600}
+        sizes="(max-width: 768px) 100vw, 50vw"
+      />
+    );
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('sizes', '(max-width: 768px) 100vw, 50vw');
+  });
+
+  // ===========================
+  // Accessibility — decoratieve afbeeldingen
+  // ===========================
+
+  it('adds aria-hidden="true" to figure when alt is empty string', () => {
+    const { container } = render(
+      <Image src="/decoratief.jpg" alt="" width={800} height={600} />
+    );
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('does not add aria-hidden when alt has text content', () => {
+    const { container } = render(
+      <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+    );
+    expect(container.firstChild).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('decorative image keeps alt="" on img element', () => {
+    render(<Image src="/decoratief.jpg" alt="" width={800} height={600} />);
+    const img = screen.getByRole('presentation', { hidden: true });
+    expect(img).toHaveAttribute('alt', '');
+  });
+
+  // ===========================
+  // Ref + HTML attributes
+  // ===========================
+
+  it('forwards ref to the figure element', () => {
+    const ref = { current: null as HTMLElement | null };
+    render(
+      <Image
+        ref={ref}
+        src="/foto.jpg"
+        alt="Beschrijving"
+        width={800}
+        height={600}
+      />
+    );
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.tagName).toBe('FIGURE');
+  });
+
+  it('spreads additional HTML attributes to figure', () => {
+    render(
+      <Image
+        src="/foto.jpg"
+        alt="Beschrijving"
+        width={800}
+        height={600}
+        id="image-1"
+        data-testid="my-image"
+      />
+    );
+    const el = screen.getByTestId('my-image');
+    expect(el).toHaveAttribute('id', 'image-1');
+  });
+});

--- a/packages/components-react/src/Image/Image.tsx
+++ b/packages/components-react/src/Image/Image.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import './Image.css';
+
+// fetchpriority is not yet in React 18's HTMLAttributes types (added in React 19).
+// Extend ImgHTMLAttributes locally so we can pass it through to the DOM.
+type ImgProps = React.ImgHTMLAttributes<HTMLImageElement> & {
+  fetchpriority?: 'high' | 'low' | 'auto';
+};
+
+export interface ImageProps extends React.HTMLAttributes<HTMLElement> {
+  /** Verplicht. URL van de afbeelding */
+  src: string;
+
+  /** Verplicht. Alternatieve tekst. Lege string (`""`) voor decoratieve afbeeldingen — activeert automatisch `aria-hidden="true"` op de figure */
+  alt: string;
+
+  /** Verplicht. Intrinsieke breedte in pixels (voorkomt CLS) */
+  width: number;
+
+  /** Verplicht. Intrinsieke hoogte in pixels (voorkomt CLS) */
+  height: number;
+
+  /** Forceert beeldverhouding via CSS `aspect-ratio` + `object-fit: cover` */
+  ratio?: '16:9' | '4:3' | '1:1';
+
+  /** Hoe de afbeelding het ratio-kader vult. @default 'cover' */
+  objectFit?: 'cover' | 'contain';
+
+  /**
+   * LCP-modus: `loading="eager"` + `fetchpriority="high"`.
+   * Gebruik maximaal één keer per pagina voor de primaire LCP-afbeelding.
+   * @default false
+   */
+  priority?: boolean;
+
+  /** Optioneel bijschrift, rendert als `<figcaption>` */
+  caption?: React.ReactNode;
+
+  /** Pass-through naar native `srcset` attribuut */
+  srcSet?: string;
+
+  /** Pass-through naar native `sizes` attribuut */
+  sizes?: string;
+}
+
+const ratioClassMap: Record<NonNullable<ImageProps['ratio']>, string> = {
+  '16:9': 'dsn-image--ratio-16-9',
+  '4:3': 'dsn-image--ratio-4-3',
+  '1:1': 'dsn-image--ratio-1-1',
+};
+
+/**
+ * Image component
+ * Performante, toegankelijke wrapper rond het native `<img>` element.
+ * Biedt ingebakken lazy loading, expliciete ondersteuning voor LCP/hero-afbeeldingen
+ * via een `priority` prop, en vaste beeldverhoudingen via de CSS `aspect-ratio` property.
+ *
+ * @example
+ * ```tsx
+ * // Basis
+ * <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} />
+ *
+ * // Met vaste beeldverhouding
+ * <Image src="/hero.jpg" alt="Hero" width={1600} height={900} ratio="16:9" />
+ *
+ * // LCP / hero-afbeelding — max. één keer per pagina
+ * <Image src="/hero.jpg" alt="Pagina hero" width={1600} height={900} ratio="16:9" priority />
+ *
+ * // Met bijschrift
+ * <Image src="/foto.jpg" alt="Beschrijving" width={800} height={600} caption="Bijschrift" />
+ *
+ * // Decoratief — alt="" activeert automatisch aria-hidden="true" op de figure
+ * <Image src="/decoratief.jpg" alt="" width={800} height={600} />
+ * ```
+ */
+export const Image = React.forwardRef<HTMLElement, ImageProps>(
+  (
+    {
+      className,
+      src,
+      alt,
+      width,
+      height,
+      ratio,
+      objectFit = 'cover',
+      priority = false,
+      caption,
+      srcSet,
+      sizes,
+      ...props
+    },
+    ref
+  ) => {
+    const isDecorative = alt === '';
+
+    const figureClasses = classNames(
+      'dsn-image',
+      ratio && ratioClassMap[ratio],
+      objectFit === 'contain' && 'dsn-image--object-fit-contain',
+      className
+    );
+
+    const imgProps: ImgProps = {
+      className: 'dsn-image__img',
+      src,
+      alt,
+      width,
+      height,
+      decoding: 'async',
+      ...(priority
+        ? { loading: 'eager', fetchpriority: 'high' }
+        : { loading: 'lazy' }),
+      ...(srcSet && { srcSet }),
+      ...(sizes && { sizes }),
+    };
+
+    return (
+      <figure
+        ref={ref}
+        className={figureClasses}
+        {...(isDecorative && { 'aria-hidden': true })}
+        {...props}
+      >
+        <img {...imgProps} />
+        {caption && (
+          <figcaption className="dsn-image__caption">{caption}</figcaption>
+        )}
+      </figure>
+    );
+  }
+);
+
+Image.displayName = 'Image';

--- a/packages/components-react/src/Image/index.ts
+++ b/packages/components-react/src/Image/index.ts
@@ -1,0 +1,2 @@
+export { Image } from './Image';
+export type { ImageProps } from './Image';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -66,3 +66,5 @@ export * from './FormFieldErrorMessage';
 export * from './FormFieldStatus';
 export * from './FormFieldset';
 export * from './FormFieldLegend';
+
+export * from './Image';

--- a/packages/design-tokens/src/tokens/components/image.json
+++ b/packages/design-tokens/src/tokens/components/image.json
@@ -1,0 +1,33 @@
+{
+  "dsn": {
+    "image": {
+      "border-radius": {
+        "value": "{dsn.border.radius.md}",
+        "type": "dimension",
+        "comment": "Afgeronde hoeken van de afbeelding"
+      },
+      "caption": {
+        "color": {
+          "value": "{dsn.color.neutral.color-subtle}",
+          "type": "color",
+          "comment": "Gedempte kleur voor bijschrift — bewust minder prominent dan bodytekst"
+        },
+        "font-size": {
+          "value": "{dsn.text.font-size.sm}",
+          "type": "dimension",
+          "comment": "Iets kleiner dan bodytekst om hiërarchie te markeren"
+        },
+        "line-height": {
+          "value": "{dsn.text.line-height.sm}",
+          "type": "lineHeight",
+          "comment": "Compacte regelafstand passend bij kleine tekst — consistent met font-size.sm"
+        },
+        "margin-block-start": {
+          "value": "{dsn.space.row.sm}",
+          "type": "dimension",
+          "comment": "Kleine ademruimte tussen afbeelding en bijschrift"
+        }
+      }
+    }
+  }
+}

--- a/packages/storybook/src/Image.docs.md
+++ b/packages/storybook/src/Image.docs.md
@@ -1,0 +1,77 @@
+# Image
+
+Performante, toegankelijke wrapper rond het native `<img>` element met ingebakken lazy loading en ondersteuning voor vaste beeldverhoudingen.
+
+## Doel
+
+De Image component biedt een semantisch correcte afbeeldingcontainer op basis van `<figure>` en `<img>`. Gebruik het voor contentafbeeldingen waarbij CLS-preventie, laadprioriteit of vaste beeldverhoudingen vereist zijn. Het component biedt ingebakken lazy loading, expliciete ondersteuning voor LCP/hero-afbeeldingen via een `priority` prop, en drie vaste beeldverhoudingen via de CSS `aspect-ratio` property.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Contentafbeeldingen in artikelen, cards en hero-secties.
+- Een vaste beeldverhouding vereist is (bijv. 16:9 voor video-thumbnails).
+- Een LCP-afbeelding is waarbij laadprioriteit expliciet gestuurd moet worden.
+- Een optioneel bijschrift (`<figcaption>`) bij de afbeelding gewenst is.
+
+## Don't use when
+
+- Decoratieve SVG-iconen of UI-iconen — gebruik daarvoor het **Icon** component.
+- Afbeeldingen die via CSS als achtergrond gezet worden (`background-image`).
+
+## Best practices
+
+### Alt-tekst
+
+- Schrijf beschrijvende alt-tekst die de betekenis van de afbeelding overbrengt, niet de inhoud letterlijk beschrijft.
+- Gebruik `alt=""` (lege string) voor puur decoratieve afbeeldingen — de React-component voegt dan automatisch `aria-hidden="true"` toe aan de `<figure>`.
+- Laat `alt` nooit weg — een ontbrekend `alt` attribuut is een WCAG 2.2 SC 1.1.1 overtreding.
+
+### Breedte en hoogte
+
+- Geef altijd `width` en `height` mee met de intrinsieke pixelafmetingen van de afbeelding.
+- De browser reserveert daardoor de ruimte vooraf en voorkomt layout shift (CLS).
+- De werkelijke weergavegrootte wordt bepaald door CSS — de attributen zijn alleen een hint voor de browser.
+
+### Beeldverhoudingen
+
+- Gebruik `ratio` om een vaste beeldverhouding te forceren. Dit is nuttig bij wisselende bronafbeeldingen (bijv. gebruikersuploads).
+- `object-fit: cover` (standaard) snijdt de afbeelding bij zodat deze het kader vult.
+- Gebruik `objectFit="contain"` als de volledige afbeelding zichtbaar moet blijven (bijv. voor logo's of diagrammen).
+
+### Priority (LCP)
+
+- Gebruik `priority` **maximaal één keer per pagina**, alleen voor de grootste bovenste-viewport-afbeelding (LCP).
+- `priority` stelt `loading="eager"` en `fetchpriority="high"` in, waardoor de browser de afbeelding met hoge prioriteit laadt.
+- Gebruik `priority` **nooit** voor afbeeldingen buiten de initiële viewport.
+
+### Bijschrift
+
+- Gebruik `caption` voor tekst die de afbeelding toelicht of van bron voorziet.
+- De `<figcaption>` is semantisch gelinkt aan de `<figure>` — geen extra `aria-labelledby` nodig.
+
+### srcSet en sizes
+
+- Gebruik `srcSet` en `sizes` voor responsieve afbeeldingen met meerdere formaten.
+- Het component berekent deze waarden niet intern — dit is afhankelijk van de asset pipeline van de applicatie (Next.js, Cloudinary, etc.).
+
+## Design tokens
+
+| Token                                    | Beschrijving                                         |
+| ---------------------------------------- | ---------------------------------------------------- |
+| `--dsn-image-border-radius`              | Afgeronde hoeken van de afbeelding                   |
+| `--dsn-image-caption-color`              | Gedempte kleur voor het bijschrift                   |
+| `--dsn-image-caption-font-size`          | Iets kleiner dan bodytekst om hiërarchie te markeren |
+| `--dsn-image-caption-line-height`        | Regelafstand passend bij kleine tekst                |
+| `--dsn-image-caption-margin-block-start` | Ruimte tussen afbeelding en bijschrift               |
+
+## Accessibility
+
+- `alt` is altijd verplicht aanwezig als attribuut. Een ontbrekend `alt` is een WCAG 2.2 SC 1.1.1 overtreding.
+- `alt=""` (lege string) is correct voor decoratieve afbeeldingen — de React-component voegt automatisch `aria-hidden="true"` toe aan de `<figure>`.
+- Gebruik **nooit** `role="presentation"` in combinatie met `alt=""` — dit is een HTML-validatiefout.
+- `<figure>` heeft de impliciete ARIA-rol `figure` — geen extra `role` attribuut nodig.
+- `<figcaption>` is semantisch gelinkt aan de `<figure>` — geen extra `aria-labelledby` nodig.
+- `<figure>` en `<img>` zijn niet focusbaar. Als de afbeelding klikbaar moet zijn, wrap dan met `Link` of `ButtonLink` buiten dit component.
+- `decoding="async"` wordt altijd toegepast om de hoofdthread niet te blokkeren.

--- a/packages/storybook/src/Image.docs.mdx
+++ b/packages/storybook/src/Image.docs.mdx
@@ -1,0 +1,35 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as ImageStories from './Image.stories';
+import docs from './Image.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={ImageStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={ImageStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={ImageStories.Default}
+  html={`<figure class="dsn-image">
+  <img
+    class="dsn-image__img"
+    src="afbeelding.jpg"
+    alt="Beschrijving van de afbeelding"
+    width="800"
+    height="600"
+    loading="lazy"
+    decoding="async"
+  />
+</figure>`}
+/>
+
+<Controls of={ImageStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/Image.stories.tsx
+++ b/packages/storybook/src/Image.stories.tsx
@@ -1,0 +1,196 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Image } from '@dsn/components-react';
+import DocsPage from './Image.docs.mdx';
+
+const PLACEHOLDER_SRC = 'https://picsum.photos/800/600';
+const PLACEHOLDER_WIDE = 'https://picsum.photos/1600/900';
+const PLACEHOLDER_SQUARE = 'https://picsum.photos/600/600';
+const PLACEHOLDER_CONTAIN = 'https://picsum.photos/200/150';
+
+const meta: Meta<typeof Image> = {
+  title: 'Components/Image',
+  component: Image,
+  parameters: {
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const ratioClass = args.ratio
+          ? ` dsn-image--ratio-${args.ratio.replace(':', '-')}`
+          : '';
+        const containClass =
+          args.objectFit === 'contain' ? ' dsn-image--object-fit-contain' : '';
+        const ariaHidden = args.alt === '' ? ' aria-hidden="true"' : '';
+        const loading = args.priority ? 'eager' : 'lazy';
+        const priority = args.priority ? '\n    fetchpriority="high"' : '';
+        const caption = args.caption
+          ? `\n  <figcaption class="dsn-image__caption">${args.caption}</figcaption>`
+          : '';
+        return `<figure class="dsn-image${ratioClass}${containClass}"${ariaHidden}>
+  <img
+    class="dsn-image__img"
+    src="${args.src ?? PLACEHOLDER_SRC}"
+    alt="${args.alt ?? 'Beschrijving van de afbeelding'}"
+    width="${args.width ?? 800}"
+    height="${args.height ?? 600}"
+    loading="${loading}"${priority}
+    decoding="async"
+  />${caption}
+</figure>`;
+      },
+    },
+  },
+  argTypes: {
+    src: { control: 'text' },
+    alt: { control: 'text' },
+    width: { control: 'number' },
+    height: { control: 'number' },
+    ratio: {
+      control: 'select',
+      options: [undefined, '16:9', '4:3', '1:1'],
+    },
+    objectFit: {
+      control: 'radio',
+      options: ['cover', 'contain'],
+    },
+    priority: { control: 'boolean' },
+    caption: { control: 'text' },
+    srcSet: { control: 'text' },
+    sizes: { control: 'text' },
+  },
+  args: {
+    src: PLACEHOLDER_SRC,
+    alt: 'Beschrijving van de afbeelding',
+    width: 800,
+    height: 600,
+    priority: false,
+    objectFit: 'cover',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Image>;
+
+export const Default: Story = {};
+
+export const WithRatio: Story = {
+  name: 'With ratio',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1.5rem',
+        maxWidth: '640px',
+      }}
+    >
+      <div>
+        <p
+          style={{
+            marginBottom: '0.5rem',
+            fontFamily: 'sans-serif',
+            fontSize: '0.875rem',
+            color: '#666',
+          }}
+        >
+          16:9 (video, hero)
+        </p>
+        <Image
+          src={PLACEHOLDER_WIDE}
+          alt="16:9 afbeelding"
+          width={1600}
+          height={900}
+          ratio="16:9"
+        />
+      </div>
+      <div>
+        <p
+          style={{
+            marginBottom: '0.5rem',
+            fontFamily: 'sans-serif',
+            fontSize: '0.875rem',
+            color: '#666',
+          }}
+        >
+          4:3 (klassieke foto)
+        </p>
+        <Image
+          src={PLACEHOLDER_SRC}
+          alt="4:3 afbeelding"
+          width={800}
+          height={600}
+          ratio="4:3"
+        />
+      </div>
+      <div>
+        <p
+          style={{
+            marginBottom: '0.5rem',
+            fontFamily: 'sans-serif',
+            fontSize: '0.875rem',
+            color: '#666',
+          }}
+        >
+          1:1 (vierkant, avatar)
+        </p>
+        <Image
+          src={PLACEHOLDER_SQUARE}
+          alt="1:1 afbeelding"
+          width={600}
+          height={600}
+          ratio="1:1"
+        />
+      </div>
+    </div>
+  ),
+};
+
+export const Priority: Story = {
+  name: 'Priority (LCP / hero)',
+  args: {
+    src: PLACEHOLDER_WIDE,
+    alt: 'Hero afbeelding van de pagina',
+    width: 1600,
+    height: 900,
+    ratio: '16:9',
+    priority: true,
+  },
+};
+
+export const WithCaption: Story = {
+  name: 'With caption',
+  args: {
+    caption: 'Bijschrift bij de afbeelding — extra context voor de lezer.',
+  },
+};
+
+export const Decorative: Story = {
+  name: 'Decorative (alt="")',
+  args: {
+    alt: '',
+  },
+};
+
+export const ObjectFitContain: Story = {
+  name: 'Object-fit: contain',
+  args: {
+    src: PLACEHOLDER_CONTAIN,
+    alt: 'Logo zonder bijsnijden',
+    width: 200,
+    height: 150,
+    ratio: '16:9',
+    objectFit: 'contain',
+  },
+};
+
+export const WithSrcSet: Story = {
+  name: 'With srcSet (responsief)',
+  args: {
+    src: PLACEHOLDER_SRC,
+    alt: 'Responsieve afbeelding',
+    width: 800,
+    height: 600,
+    srcSet: `${PLACEHOLDER_SRC.replace('800/600', '400/300')} 400w, ${PLACEHOLDER_SRC} 800w`,
+    sizes: '(max-width: 768px) 100vw, 50vw',
+  },
+};

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -82,7 +82,7 @@ function App() {
 - **Link** — Hyperlinks met icon ondersteuning en externe link handling
 - **Lists** — OrderedList en UnorderedList
 
-### Display & Feedback Components (6)
+### Display & Feedback Components (7)
 
 - **DotBadge** — Kleine gekleurde stip bij een Button of Link die zonder label de aandacht trekt bij een statuswijziging (met optioneel pulse-effect)
 - **StatusBadge** — Compact label dat een status communiceert met een signaalkleur (neutral, info, positive, negative, warning)
@@ -90,6 +90,7 @@ function App() {
 - **Note** — Visueel uitgelicht bericht voor aanvullende informatie, passief (geen live region)
 - **Table** — Toegankelijke datatable met caption, optionele scroll-wrapper, tfoot-ondersteuning en CSS-patroon voor sorteerknoppen
 - **Details** — Uitvouwbare inhoudsaanwijzer voor aanvullende inhoud (`<details>`/`<summary>`, CSS-only toggle)
+- **Image** — Performante, toegankelijke wrapper rond het native `<img>` element met ingebakken lazy loading, vaste beeldverhoudingen en LCP-prioriteit
 
 ### Navigation Components (1)
 
@@ -152,4 +153,4 @@ MIT License — zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.10.0 | **Laatste update:** 20 maart 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.12.0 | **Laatste update:** 21 maart 2026 | **Auteur:** Jeffrey Lauwers


### PR DESCRIPTION
Closes #96

## Summary

- Component tokens JSON (`image.json`) met `border-radius`, caption kleur/grootte/regelafstand/spacing
- HTML/CSS implementatie (`image.css`) met ratio-modifiers (`16:9`, `4:3`, `1:1`) en `object-fit-contain` modifier
- React component (`Image.tsx`) met `forwardRef`, `priority` prop (`fetchpriority="high"`), automatisch `aria-hidden="true"` bij `alt=""`
- 25 unit tests — alle groen (1082 totaal)
- Storybook: 7 stories — Default, WithRatio, Priority, WithCaption, Decorative, ObjectFitContain, WithSrcSet

## Test plan

- [x] `pnpm exec vitest run` — 53 suites, 1082 tests, 0 failures
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [x] `pnpm lint` — 0 fouten

🤖 Generated with [Claude Code](https://claude.com/claude-code)