### PR TITLE
feat(Card): voeg row-gap toe aan CardBody voor consistente kinderafstand

### DIFF
--- a/packages/components-html/src/card/card.css
+++ b/packages/components-html/src/card/card.css
@@ -55,8 +55,17 @@
 /* Card body — groeit zodat footer altijd onderaan blijft */
 .dsn-card__body {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--dsn-card-body-row-gap);
   padding-block: var(--dsn-card-body-padding-block);
   padding-inline: var(--dsn-card-body-padding-inline);
+}
+
+/* Inline-elementen in de body (badges, tags) nemen hun eigen breedte — niet full-width */
+.dsn-card__body > .dsn-status-badge,
+.dsn-card__body > .dsn-dot-badge {
+  align-self: flex-start;
 }
 
 /* Card footer — uitgelijnde onderkant */
@@ -108,7 +117,7 @@
   color: var(--dsn-card-heading-color);
   text-wrap: balance;
   margin-block-start: 0;
-  margin-block-end: var(--dsn-card-heading-margin-block-end);
+  margin-block-end: 0;
 }
 
 /* Link in de heading — erft kleur en maakt de card klikbaar via stretched link */

--- a/packages/design-tokens/src/tokens/components/card.json
+++ b/packages/design-tokens/src/tokens/components/card.json
@@ -46,6 +46,11 @@
           "value": "{dsn.space.inline.xl}",
           "type": "spacing",
           "comment": "Horizontale padding van de card body (16px)"
+        },
+        "row-gap": {
+          "value": "{dsn.space.block.lg}",
+          "type": "spacing",
+          "comment": "Verticale ruimte tussen directe kinderen van de card body (12px)"
         }
       },
       "footer": {
@@ -97,11 +102,6 @@
           "value": "{dsn.text.line-height.lg}",
           "type": "lineHeight",
           "comment": "Regelafstand van de card heading"
-        },
-        "margin-block-end": {
-          "value": "{dsn.space.block.lg}",
-          "type": "spacing",
-          "comment": "Afstand onder de card heading (12px)"
         }
       },
       "group": {


### PR DESCRIPTION
## Summary

- Nieuw token `dsn.card.body.row-gap` (`{dsn.space.block.lg}` = 12px) toegevoegd voor de verticale ruimte tussen kinderen in de card body
- `.dsn-card__body` is nu een flex-column container — de gap vervangt de `margin-block-end` op `CardHeading` (token verwijderd)
- Scoped regel toegevoegd: `.dsn-status-badge` en `.dsn-dot-badge` krijgen `align-self: flex-start` in de card-context zodat ze niet full-width uitrekken

## Test plan

- [ ] `MetStatusBadge` story: StatusBadge heeft eigen breedte, heading en paragraaf zijn full-width
- [ ] `Default` story: correcte gap tussen heading en paragraaf
- [ ] `CardGroup` story: alle cards tonen consistente spacing
- [ ] 1125 tests groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)