### PR TITLE
fix(wireframe): Comic Sans als primair font, Comic Neue als fallback

### DIFF
--- a/docs/02-design-tokens-reference.md
+++ b/docs/02-design-tokens-reference.md
@@ -47,7 +47,7 @@ Complete reference for all design tokens in the Design System Starter Kit.
   "dsn": {
     "text": {
       "font-family": {
-        "default": "'Comic Sans MS', 'Comic Sans', cursive",
+        "default": "'Comic Sans MS', 'Comic Sans', 'Comic Neue', cursive",
         "monospace": "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, Consolas, monospace"
       }
     }

--- a/packages/design-tokens/src/tokens/themes/wireframe/base.json
+++ b/packages/design-tokens/src/tokens/themes/wireframe/base.json
@@ -3,8 +3,8 @@
     "text": {
       "font-family": {
         "default": {
-          "value": "'Comic Neue', 'Comic Sans MS', 'Comic Sans', cursive",
-          "comment": "Comic Neue (Google Fonts) with Comic Sans MS fallback for wireframe"
+          "value": "'Comic Sans MS', 'Comic Sans', 'Comic Neue', cursive",
+          "comment": "Comic Sans MS as primary font with Comic Neue fallback for wireframe"
         },
         "monospace": {
           "value": "ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace",
@@ -54,8 +54,8 @@
     },
     "heading": {
       "font-family": {
-        "value": "'Comic Neue', 'Comic Sans MS', 'Comic Sans', cursive",
-        "comment": "Comic Neue (Google Fonts) with Comic Sans MS fallback for headings"
+        "value": "'Comic Sans MS', 'Comic Sans', 'Comic Neue', cursive",
+        "comment": "Comic Sans MS as primary font with Comic Neue fallback for headings"
       },
       "font-weight": {
         "value": "600",


### PR DESCRIPTION
## Summary
- Keert de font stack in het Wireframe thema om: Comic Sans MS is nu primair, Comic Neue is de fallback
- Van toepassing op zowel `text.font-family.default` als `heading.font-family`
- Docs bijgewerkt (`02-design-tokens-reference.md`)

## Reden
Comic Sans is niet beschikbaar op Android — daarom was Comic Neue eerder als eerste gezet. De gewenste situatie is echter omgekeerd: Comic Sans als standaard (op desktops), Comic Neue als fallback voor omgevingen zonder Comic Sans.

## Test plan
- [x] Storybook openen met Wireframe thema → font is Comic Sans (op desktop)
- [x] Controleer op een Android device → font is Comic Neue

🤖 Generated with [Claude Code](https://claude.com/claude-code)