### PR TITLE
chore(storybook): ButtonLink en LinkButton stories in lijn brengen met Button en Link

### DIFF
--- a/packages/components-html/src/button-link/button-link.css
+++ b/packages/components-html/src/button-link/button-link.css
@@ -15,7 +15,9 @@
    pointer-events: none blokkeert ook hover/active (Button's :not(:disabled) matcht
    altijd op <a>, dus we kunnen niet op die guards vertrouwen). */
 .dsn-button-link[aria-disabled='true'] {
-  opacity: 0.5;
+  background-color: var(--dsn-button-disabled-background-color);
+  color: var(--dsn-button-disabled-color);
+  border-color: var(--dsn-button-disabled-border-color);
   cursor: not-allowed;
   pointer-events: none;
 }

--- a/packages/storybook/src/ButtonLink.stories.tsx
+++ b/packages/storybook/src/ButtonLink.stories.tsx
@@ -175,6 +175,10 @@ export const Default: Story = {};
 // VARIANTEN
 // =============================================================================
 
+export const Strong: Story = {
+  args: { variant: 'strong' },
+};
+
 export const DefaultVariant: Story = {
   name: 'Default variant',
   args: { variant: 'default' },
@@ -182,6 +186,14 @@ export const DefaultVariant: Story = {
 
 export const Subtle: Story = {
   args: { variant: 'subtle' },
+};
+
+export const Small: Story = {
+  args: { size: 'small' },
+};
+
+export const Large: Story = {
+  args: { size: 'large' },
 };
 
 export const Disabled: Story = {
@@ -192,23 +204,197 @@ export const External: Story = {
   args: { href: 'https://example.com', external: true },
 };
 
+export const FullWidth: Story = {
+  args: { fullWidth: true },
+};
+
+export const NegativeSentiment: Story = {
+  name: 'Negative sentiment',
+  args: { variant: 'strong-negative' },
+};
+
+export const PositiveSentiment: Story = {
+  name: 'Positive sentiment',
+  args: { variant: 'strong-positive' },
+};
+
 export const WithIconStart: Story = {
   name: 'With icon start',
-  args: { iconStart: <Icon name="arrow-left" aria-hidden /> },
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '0.5rem',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      <ButtonLink
+        href="/"
+        variant="strong"
+        iconStart={<Icon name="check" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+      <ButtonLink
+        href="/"
+        variant="default"
+        iconStart={<Icon name="edit" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+      <ButtonLink
+        href="/"
+        variant="subtle"
+        iconStart={<Icon name="download" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+      <ButtonLink
+        href="/"
+        variant="strong-negative"
+        iconStart={<Icon name="trash" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+    </div>
+  ),
 };
 
 export const WithIconEnd: Story = {
   name: 'With icon end',
-  args: { iconEnd: <Icon name="arrow-right" aria-hidden /> },
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '0.5rem',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      <ButtonLink
+        href="/"
+        variant="strong"
+        iconEnd={<Icon name="arrow-right" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+      <ButtonLink
+        href="/"
+        variant="default"
+        iconEnd={<Icon name="arrow-right" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+      <ButtonLink
+        href="/"
+        variant="subtle"
+        iconEnd={<Icon name="chevron-down" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+    </div>
+  ),
+};
+
+export const WithIconStartAndEnd: Story = {
+  name: 'With icon start and end',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '0.5rem',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      <ButtonLink
+        href="/"
+        variant="strong"
+        iconStart={<Icon name="check" aria-hidden />}
+        iconEnd={<Icon name="arrow-right" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+      <ButtonLink
+        href="/"
+        variant="default"
+        iconStart={<Icon name="edit" aria-hidden />}
+        iconEnd={<Icon name="chevron-down" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+    </div>
+  ),
+};
+
+export const IconSizes: Story = {
+  name: 'Icon sizes per button size',
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+      <ButtonLink
+        href="/"
+        size="small"
+        iconStart={<Icon name="check" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+      <ButtonLink
+        href="/"
+        size="default"
+        iconStart={<Icon name="check" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+      <ButtonLink
+        href="/"
+        size="large"
+        iconStart={<Icon name="check" aria-hidden />}
+      >
+        {TEKST}
+      </ButtonLink>
+    </div>
+  ),
 };
 
 export const IconOnly: Story = {
   name: 'Icon only',
-  args: {
-    iconOnly: true,
-    iconStart: <Icon name="download" aria-hidden />,
-    children: 'Download',
-  },
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+      <ButtonLink
+        href="/"
+        variant="strong"
+        iconOnly
+        iconStart={<Icon name="plus" aria-hidden />}
+      >
+        Toevoegen
+      </ButtonLink>
+      <ButtonLink
+        href="/"
+        variant="default"
+        iconOnly
+        iconStart={<Icon name="settings" aria-hidden />}
+      >
+        Instellingen
+      </ButtonLink>
+      <ButtonLink
+        href="/"
+        variant="subtle"
+        iconOnly
+        iconStart={<Icon name="x" aria-hidden />}
+      >
+        Sluiten
+      </ButtonLink>
+      <ButtonLink
+        href="/"
+        variant="strong-negative"
+        iconOnly
+        iconStart={<Icon name="trash" aria-hidden />}
+      >
+        Verwijderen
+      </ButtonLink>
+    </div>
+  ),
 };
 
 // =============================================================================
@@ -227,12 +413,12 @@ export const AllVariants: Story = {
           flexWrap: 'wrap',
         }}
       >
-        <ButtonLink href="/">{TEKST} (strong)</ButtonLink>
+        <ButtonLink href="/">{TEKST}</ButtonLink>
         <ButtonLink href="/" variant="default">
-          {TEKST} (default)
+          {TEKST}
         </ButtonLink>
         <ButtonLink href="/" variant="subtle">
-          {TEKST} (subtle)
+          {TEKST}
         </ButtonLink>
       </div>
       <div
@@ -244,13 +430,13 @@ export const AllVariants: Story = {
         }}
       >
         <ButtonLink href="/" variant="strong-negative">
-          {TEKST} (strong-negative)
+          {TEKST}
         </ButtonLink>
         <ButtonLink href="/" variant="default-negative">
-          {TEKST} (default-negative)
+          {TEKST}
         </ButtonLink>
         <ButtonLink href="/" variant="subtle-negative">
-          {TEKST} (subtle-negative)
+          {TEKST}
         </ButtonLink>
       </div>
       <div
@@ -262,46 +448,52 @@ export const AllVariants: Story = {
         }}
       >
         <ButtonLink href="/" variant="strong-positive">
-          {TEKST} (strong-positive)
+          {TEKST}
         </ButtonLink>
         <ButtonLink href="/" variant="default-positive">
-          {TEKST} (default-positive)
+          {TEKST}
         </ButtonLink>
         <ButtonLink href="/" variant="subtle-positive">
-          {TEKST} (subtle-positive)
+          {TEKST}
         </ButtonLink>
       </div>
-      <div
-        style={{
-          display: 'flex',
-          gap: '0.5rem',
-          alignItems: 'center',
-          flexWrap: 'wrap',
-        }}
-      >
-        <ButtonLink href="/" size="small">
-          {TEKST} (small)
-        </ButtonLink>
-        <ButtonLink href="/">{TEKST} (default)</ButtonLink>
-        <ButtonLink href="/" size="large">
-          {TEKST} (large)
-        </ButtonLink>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          gap: '0.5rem',
-          alignItems: 'center',
-          flexWrap: 'wrap',
-        }}
-      >
-        <ButtonLink href="/" disabled>
-          {TEKST} (disabled)
-        </ButtonLink>
-        <ButtonLink href="https://example.com" external>
-          {TEKST} (external)
-        </ButtonLink>
-      </div>
+    </div>
+  ),
+};
+
+export const AllSizes: Story = {
+  name: 'All sizes',
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+      <ButtonLink href="/" size="small">
+        {TEKST}
+      </ButtonLink>
+      <ButtonLink href="/">{TEKST}</ButtonLink>
+      <ButtonLink href="/" size="large">
+        {TEKST}
+      </ButtonLink>
+    </div>
+  ),
+};
+
+export const AllStates: Story = {
+  name: 'All states',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '0.5rem',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      <ButtonLink href="/">{TEKST}</ButtonLink>
+      <ButtonLink href="/" disabled>
+        {TEKST}
+      </ButtonLink>
+      <ButtonLink href="https://example.com" external>
+        {TEKST}
+      </ButtonLink>
     </div>
   ),
 };

--- a/packages/storybook/src/LinkButton.stories.tsx
+++ b/packages/storybook/src/LinkButton.stories.tsx
@@ -151,6 +151,14 @@ export const Default: Story = {};
 // VARIANTEN
 // =============================================================================
 
+export const Small: Story = {
+  args: { size: 'small' },
+};
+
+export const Large: Story = {
+  args: { size: 'large' },
+};
+
 export const Disabled: Story = {
   args: { disabled: true },
 };
@@ -169,42 +177,23 @@ export const WithIconEnd: Story = {
 // OVERZICHTSSTORIES
 // =============================================================================
 
+export const AllSizes: Story = {
+  name: 'All sizes',
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <LinkButton size="small">{TEKST}</LinkButton>
+      <LinkButton size="default">{TEKST}</LinkButton>
+      <LinkButton size="large">{TEKST}</LinkButton>
+    </div>
+  ),
+};
+
 export const AllStates: Story = {
   name: 'All states',
   render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <div>
-        <h3 style={{ marginBlockEnd: '0.5rem' }}>States</h3>
-        <div
-          style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
-        >
-          <LinkButton>{TEKST}</LinkButton>
-          <LinkButton disabled>{TEKST} (disabled)</LinkButton>
-        </div>
-      </div>
-      <div>
-        <h3 style={{ marginBlockEnd: '0.5rem' }}>Met iconen</h3>
-        <div
-          style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
-        >
-          <LinkButton iconStart={<Icon name="arrow-left" aria-hidden />}>
-            {TEKST}
-          </LinkButton>
-          <LinkButton iconEnd={<Icon name="arrow-right" aria-hidden />}>
-            {TEKST}
-          </LinkButton>
-        </div>
-      </div>
-      <div>
-        <h3 style={{ marginBlockEnd: '0.5rem' }}>Alle maten</h3>
-        <div
-          style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
-        >
-          <LinkButton size="small">{TEKST} (small)</LinkButton>
-          <LinkButton size="default">{TEKST} (default)</LinkButton>
-          <LinkButton size="large">{TEKST} (large)</LinkButton>
-        </div>
-      </div>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <LinkButton>{TEKST}</LinkButton>
+      <LinkButton disabled>{TEKST} (disabled)</LinkButton>
     </div>
   ),
 };


### PR DESCRIPTION
## Summary

- **ButtonLink stories** uitgebreid met ontbrekende stories: `Strong`, `Small`, `Large`, `FullWidth`, `NegativeSentiment`, `PositiveSentiment`, `WithIconStartAndEnd`, `IconSizes`
- **ButtonLink** `WithIconStart`, `WithIconEnd` en `IconOnly` uitgebreid naar render-functies met meerdere varianten (consistent met Button)
- **ButtonLink** `AllVariants` toont nu alleen varianten; `AllSizes` en `AllStates` zijn aparte stories
- **LinkButton stories** uitgebreid met `Small`, `Large` en `AllSizes`; `AllStates` vereenvoudigd (sizes zitten nu in eigen story)
- **fix:** ButtonLink disabled state gebruikt nu `--dsn-button-disabled-*` tokens i.p.v. `opacity: 0.5`, zodat de grijstinten overeenkomen met de Button disabled state

## Test plan

- [ ] Storybook: ButtonLink sidebar toont alle nieuwe stories
- [ ] Storybook: LinkButton sidebar toont Small, Large en All sizes
- [ ] Storybook: ButtonLink › Disabled toont grijstinten (identiek aan Button › Disabled)
- [ ] Storybook: ButtonLink › All states — disabled ziet er hetzelfde uit als Button › All states

🤖 Generated with [Claude Code](https://claude.com/claude-code)