### PR TITLE
feat(Backdrop): voeg Backdrop component toe (issue #113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pnpm --filter @dsn/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (1125 tests across 54 test suites)
+# Run tests (1133 tests across 55 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -187,11 +187,12 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Paragraph**     | Yes      | Yes   | Yes           |
 | **UnorderedList** | Yes      | Yes   | Yes           |
 
-**Display & Feedback Components (7)**
+**Display & Feedback Components (8)**
 
 | Component       | HTML/CSS | React | Web Component |
 | --------------- | -------- | ----- | ------------- |
 | **Alert**       | Yes      | Yes   | —             |
+| **Backdrop**    | Yes      | Yes   | —             |
 | **Card**        | Yes      | Yes   | —             |
 | **Details**     | Yes      | Yes   | —             |
 | **DotBadge**    | Yes      | Yes   | —             |
@@ -372,7 +373,7 @@ Comprehensive documentation is available in the `/docs` folder:
 
 - **Pre-commit hooks** via Husky + lint-staged (ESLint + Prettier)
 - **Type checking** across all packages (`pnpm type-check`)
-- **1125 tests** covering React components, Web Components, and utilities
+- **1133 tests** covering React components, Web Components, and utilities
 - **CI/CD** via GitHub Actions (lint, type-check, test, build)
 
 ## Tech Stack

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -761,7 +761,58 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 
 ## Display & Feedback Components
 
-**Status:** Complete (HTML/CSS, React) — 7 components total
+**Status:** Complete (HTML/CSS, React) — 8 components total
+
+### Backdrop
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-{html|react}/src/backdrop/` / `packages/components-react/src/Backdrop/`
+
+**Tokens:** `tokens/components/backdrop.json` + `tokens/themes/start/colors-light.json` / `colors-dark.json`
+
+**Features:**
+
+- `position: fixed; inset: 0` — bedekt het volledige viewport
+- Semi-transparante overlay via `color-mix(in srgb, var(--dsn-backdrop-background-color) var(--dsn-backdrop-opacity), transparent)` — kleur en transparantie via losse tokens
+- `backdrop-filter: blur()` — valt gracefully weg bij browsers zonder support (~6%); fallback via `dsn-backdrop--no-blur` modifier of `blur={false}` prop
+- Altijd `aria-hidden="true"` — puur decoratief, geen ARIA-rol
+- `background-color` per thema apart gedefinieerd zodat overlay altijd donker is, ongeacht light/dark mode (patroon identiek aan box-shadow kleurtokens)
+- `blur` prop (boolean, default `true`) — togglet `dsn-backdrop--no-blur` modifier
+
+**CSS klassen:**
+
+| Klasse                  | Element | Beschrijving                                                           |
+| ----------------------- | ------- | ---------------------------------------------------------------------- |
+| `dsn-backdrop`          | `<div>` | Vaste overlay over het volledige viewport; semi-transparante blur-laag |
+| `dsn-backdrop--no-blur` | `<div>` | Modifier — schakelt backdrop-filter uit (fallback)                     |
+
+**Props (React):**
+
+| Prop   | Type                        | Default | Beschrijving                                                     |
+| ------ | --------------------------- | ------- | ---------------------------------------------------------------- |
+| `blur` | `boolean`                   | `true`  | Schakelt blur-filter in/uit via `dsn-backdrop--no-blur` modifier |
+| `ref`  | `React.Ref<HTMLDivElement>` | —       | Doorgegeven via `React.forwardRef`                               |
+
+**Gebruik:**
+
+```html
+<!-- HTML/CSS — basis -->
+<div class="dsn-backdrop" aria-hidden="true"></div>
+
+<!-- HTML/CSS — zonder blur (fallback) -->
+<div class="dsn-backdrop dsn-backdrop--no-blur" aria-hidden="true"></div>
+```
+
+```tsx
+// React — conditioneel renderen vanuit parent
+{
+  isOpen && <Backdrop />;
+}
+{
+  isOpen && <Backdrop blur={false} />;
+}
+```
 
 ### Card
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Design System Documentation
 
-**Version:** 5.13.0
-**Last Updated:** March 23, 2026
+**Version:** 5.14.0
+**Last Updated:** March 25, 2026
 
 Complete documentation voor het Design System Starter Kit.
 
@@ -91,8 +91,8 @@ Complete documentation voor het Design System Starter Kit.
 
 - **Tokens per configuration:** ~1100 (400 semantic + 700 component)
 - **Configurations:** 8 (2 themes × 2 modes × 2 project types)
-- **Components:** 44 (4 layout + 9 content + 7 display/feedback + 25 form; HTML/CSS + React)
-- **Tests:** 1125 across 54 test suites
+- **Components:** 45 (4 layout + 9 content + 8 display/feedback + 25 form; HTML/CSS + React)
+- **Tests:** 1133 across 55 test suites
 - **Storybook stories:** 130+
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 5.14.0 (March 25, 2026)
+
+### Backdrop component (issue #113)
+
+#### Added
+
+- **Backdrop** component — vaste, volledig-scherm overlay die de achtergrondinhoud verhult achter een Modal Dialog of Drawer (PR #114)
+- `<div class="dsn-backdrop" aria-hidden="true">` — altijd decoratief, geen ARIA-rol
+- `dsn-backdrop--no-blur` modifier — schakelt `backdrop-filter: blur()` uit voor omgevingen zonder support
+- Component tokens: `--dsn-backdrop-background-color`, `--dsn-backdrop-opacity` (50%), `--dsn-backdrop-blur` (4px), `--dsn-backdrop-z-index` (400)
+- Kleurtoken `backdrop.background-color` in zowel `colors-light.json` als `colors-dark.json` — altijd donker ongeacht light/dark mode (zelfde patroon als box-shadow kleurtokens)
+- Semi-transparantie via `color-mix(in srgb, ...)` met expliciete fallback voor browsers zonder support
+- React `blur` prop (boolean, default `true`) — togglet `dsn-backdrop--no-blur` modifier
+- 8 React tests
+
+---
+
 ## Version 5.13.2 (March 23, 2026)
 
 ### Storybook story-structuur — consistentie (PR #111)

--- a/packages/components-html/src/backdrop/backdrop.css
+++ b/packages/components-html/src/backdrop/backdrop.css
@@ -1,0 +1,29 @@
+/**
+ * Backdrop Component
+ * Vaste, volledig-scherm overlay die de achtergrondinhoud visueel verhult
+ * wanneer een modaal UI-element open is (Modal Dialog, Drawer).
+ *
+ * Altijd aria-hidden="true" — puur decoratief, geen interactieve rol.
+ * Conditioneel renderen vanuit de parent.
+ *
+ * Usage:
+ * <div class="dsn-backdrop" aria-hidden="true"></div>
+ */
+
+.dsn-backdrop {
+  position: fixed;
+  inset: 0;
+  /* Fallback voor omgevingen zonder color-mix() support (~6%) */
+  background-color: var(--dsn-backdrop-background-color);
+  background-color: color-mix(
+    in srgb,
+    var(--dsn-backdrop-background-color) var(--dsn-backdrop-opacity),
+    transparent
+  );
+  backdrop-filter: blur(var(--dsn-backdrop-blur));
+  z-index: var(--dsn-backdrop-z-index);
+}
+
+.dsn-backdrop--no-blur {
+  backdrop-filter: none;
+}

--- a/packages/components-react/src/Backdrop/Backdrop.css
+++ b/packages/components-react/src/Backdrop/Backdrop.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/backdrop/backdrop.css';

--- a/packages/components-react/src/Backdrop/Backdrop.test.tsx
+++ b/packages/components-react/src/Backdrop/Backdrop.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Backdrop } from './Backdrop';
+
+describe('Backdrop', () => {
+  it('renders as a <div> element', () => {
+    const { container } = render(<Backdrop />);
+    expect(container.firstChild?.nodeName).toBe('DIV');
+  });
+
+  it('always has base dsn-backdrop class', () => {
+    const { container } = render(<Backdrop />);
+    expect(container.firstChild).toHaveClass('dsn-backdrop');
+  });
+
+  it('always has aria-hidden="true"', () => {
+    const { container } = render(<Backdrop />);
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('does not apply no-blur class when blur is true (default)', () => {
+    const { container } = render(<Backdrop />);
+    expect(container.firstChild).not.toHaveClass('dsn-backdrop--no-blur');
+  });
+
+  it('applies no-blur class when blur is false', () => {
+    const { container } = render(<Backdrop blur={false} />);
+    expect(container.firstChild).toHaveClass('dsn-backdrop--no-blur');
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<Backdrop className="custom" />);
+    expect(container.firstChild).toHaveClass('dsn-backdrop');
+    expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('forwards ref', () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(<Backdrop ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('spreads additional HTML attributes', () => {
+    const { container } = render(<Backdrop data-testid="backdrop" />);
+    expect(container.firstChild).toHaveAttribute('data-testid', 'backdrop');
+  });
+});

--- a/packages/components-react/src/Backdrop/Backdrop.tsx
+++ b/packages/components-react/src/Backdrop/Backdrop.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import './Backdrop.css';
+
+export interface BackdropProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Schakelt het blur-filter in of uit.
+   * Gebruik `false` als fallback voor omgevingen zonder backdrop-filter support.
+   * @default true
+   */
+  blur?: boolean;
+}
+
+/**
+ * Backdrop component
+ * Vaste, volledig-scherm overlay die de achtergrondinhoud visueel verhult
+ * wanneer een modaal UI-element open is (Modal Dialog, Drawer).
+ *
+ * Altijd aria-hidden="true" — puur decoratief, geen interactieve rol.
+ * Conditioneel renderen vanuit de parent.
+ *
+ * @example
+ * ```tsx
+ * {isOpen && <Backdrop />}
+ * {isOpen && <Backdrop blur={false} />}
+ * ```
+ */
+export const Backdrop = React.forwardRef<HTMLDivElement, BackdropProps>(
+  ({ className, blur = true, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={classNames(
+          'dsn-backdrop',
+          !blur && 'dsn-backdrop--no-blur',
+          className
+        )}
+        aria-hidden="true"
+        {...props}
+      />
+    );
+  }
+);
+
+Backdrop.displayName = 'Backdrop';

--- a/packages/components-react/src/Backdrop/index.ts
+++ b/packages/components-react/src/Backdrop/index.ts
@@ -1,0 +1,2 @@
+export { Backdrop } from './Backdrop';
+export type { BackdropProps } from './Backdrop';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -48,6 +48,7 @@ export * from './RadioOption';
 export * from './OptionLabel';
 
 // Display & Feedback Components
+export * from './Backdrop';
 export * from './DotBadge';
 export * from './StatusBadge';
 export * from './Alert';

--- a/packages/design-tokens/src/tokens/components/backdrop.json
+++ b/packages/design-tokens/src/tokens/components/backdrop.json
@@ -1,0 +1,21 @@
+{
+  "dsn": {
+    "backdrop": {
+      "opacity": {
+        "value": "50%",
+        "type": "opacity",
+        "comment": "Bepaalt hoe doorzichtig de overlay is — gebruikt in color-mix()"
+      },
+      "blur": {
+        "value": "4px",
+        "type": "dimension",
+        "comment": "backdrop-filter: blur() op de overlay — valt gracefully weg zonder support"
+      },
+      "z-index": {
+        "value": "400",
+        "type": "number",
+        "comment": "Moet lager zijn dan Modal/Drawer z-index — afstemmen zodra die componenten gedefinieerd worden"
+      }
+    }
+  }
+}

--- a/packages/design-tokens/src/tokens/themes/start/colors-dark.json
+++ b/packages/design-tokens/src/tokens/themes/start/colors-dark.json
@@ -1745,6 +1745,13 @@
           "comment": "Focus outline color for use on light/tinted backgrounds in dark mode - opposite of outline-color"
         }
       }
+    },
+    "backdrop": {
+      "background-color": {
+        "value": "{dsn.color.neutral.bg-document}",
+        "type": "color",
+        "comment": "Achtergrondkleur van de backdrop — altijd donker, ongeacht dark mode. Gebruikt neutral.bg-document (#111111) zodat de overlay donker blijft in dark mode."
+      }
     }
   }
 }

--- a/packages/design-tokens/src/tokens/themes/start/colors-light.json
+++ b/packages/design-tokens/src/tokens/themes/start/colors-light.json
@@ -1745,6 +1745,13 @@
           "comment": "Focus outline color for use on tinted/dark backgrounds - opposite of outline-color"
         }
       }
+    },
+    "backdrop": {
+      "background-color": {
+        "value": "{dsn.color.neutral-inverse.bg-document}",
+        "type": "color",
+        "comment": "Achtergrondkleur van de backdrop — altijd donker, ongeacht light mode. Gebruikt neutral-inverse.bg-document (#242424) zodat de overlay donker blijft in light mode."
+      }
     }
   }
 }

--- a/packages/storybook/src/Backdrop.docs.md
+++ b/packages/storybook/src/Backdrop.docs.md
@@ -1,0 +1,80 @@
+# Backdrop
+
+Vaste, volledig-scherm overlay die de achtergrondinhoud visueel verhult wanneer een modaal UI-element open is.
+
+## Doel
+
+Backdrop is een puur decoratief component. Het dempt de pagina-achtergrond visueel wanneer een Modal Dialog of Drawer open is, zodat de gebruiker zijn focus houdt bij het bovenliggende UI-element. De overlay combineert een semi-transparante donkere laag met een optioneel blur-filter dat de onderliggende interface vervaagt.
+
+Het component heeft bewust geen eigen interactie of toegankelijkheidsmechanisme — het is altijd `aria-hidden="true"` en wordt volledig beheerd door de parent (Modal, Drawer).
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Als visuele achtergrond achter een Modal Dialog om de pagina op de achtergrond te dempen.
+- Als visuele achtergrond achter een Drawer (zijpaneel) om context te bieden dat de interface vergrendeld is.
+- Als onderdeel van elk modaal patroon waarbij de gebruiker zijn focus bij het bovenliggende UI-element moet houden.
+- Als zelfstandig element dat door de parent conditioneel gerenderd wordt.
+
+## Don't use when
+
+- Als visuele scheider of achtergrond zonder dat er een modaal element boven staat.
+- Als interactief element — gebruik daarvoor een button of overlay met een `onClick` handler op de parent.
+- Voor paginaovergangen of laadschermen — gebruik daarvoor een specifiek loading-patroon.
+
+## Best practices
+
+### Conditioneel renderen
+
+Render de Backdrop conditioneel vanuit de parent op basis van de open-staat van het modale element:
+
+```html
+<!-- Render alleen wanneer de modal open is -->
+<div class="dsn-backdrop" aria-hidden="true"></div>
+<dialog class="dsn-modal" open>
+  <!-- modal-inhoud -->
+</dialog>
+```
+
+```tsx
+// React
+{
+  isOpen && <Backdrop />;
+}
+{
+  isOpen && <Backdrop blur={false} />;
+}
+```
+
+### Klik-gedrag
+
+De Backdrop zelf heeft geen `onClick` handler. Sluitgedrag bij klikken buiten een modaal element wordt afgehandeld door de parent (Modal/Drawer), die een transparante kliklaag of de backdrop zelf als trigger kan gebruiken.
+
+### Blur-effect
+
+Het blur-effect gebruikt `backdrop-filter: blur()` en valt gracefully weg in omgevingen zonder support (~6% van browsers). De overlay blijft volledig functioneel als semi-transparante laag zonder blur.
+
+### Z-index afstemming
+
+De `z-index` van Backdrop (`400`) is lager dan die van Modal Dialog en Drawer. Stem de waarden af wanneer die componenten gedefinieerd worden.
+
+### Animatie (toekomstige iteratie)
+
+Conditioneel renderen biedt geen ruimte voor fade-in/out. Als animatie later gewenst is, kan een `visible` prop toegevoegd worden die een CSS-transitie aanstuurt via een `dsn-backdrop--visible` modifier.
+
+## Design tokens
+
+| Token                             | Beschrijving                                                                                       |
+| --------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `--dsn-backdrop-background-color` | Basiskleur van de overlay — altijd donker, ongeacht light/dark mode (per thema apart gedefinieerd) |
+| `--dsn-backdrop-opacity`          | Transparantie van de overlay — gebruikt in `color-mix()` (standaard: `50%`)                        |
+| `--dsn-backdrop-blur`             | Intensiteit van het blur-filter (standaard: `4px`)                                                 |
+| `--dsn-backdrop-z-index`          | Stapelvolgorde — moet lager zijn dan Modal/Drawer z-index (standaard: `400`)                       |
+
+## Accessibility
+
+- Backdrop heeft altijd `aria-hidden="true"` — schermlezers nemen dit element niet waar.
+- Geen `role` attribuut nodig — het component is puur decoratief.
+- Geen toetsenbordinteractie — het component vangt geen focus en heeft geen klikgedrag.
+- Focus management en het blokkeren van toetsenbordnavigatie naar de achtergrond is de verantwoordelijkheid van de parent (Modal/Drawer via `inert` of focus trap).

--- a/packages/storybook/src/Backdrop.docs.mdx
+++ b/packages/storybook/src/Backdrop.docs.mdx
@@ -1,0 +1,25 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as BackdropStories from './Backdrop.stories';
+import docs from './Backdrop.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={BackdropStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={BackdropStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={BackdropStories.Default}
+  html={`<div class="dsn-backdrop" aria-hidden="true"></div>`}
+/>
+
+<Controls of={BackdropStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/Backdrop.stories.tsx
+++ b/packages/storybook/src/Backdrop.stories.tsx
@@ -1,0 +1,182 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Backdrop } from '@dsn/components-react';
+import DocsPage from './Backdrop.docs.mdx';
+
+const meta: Meta<typeof Backdrop> = {
+  title: 'Components/Backdrop',
+  component: Backdrop,
+  parameters: {
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const noBlur = args.blur === false ? ' dsn-backdrop--no-blur' : '';
+        return `<div class="dsn-backdrop${noBlur}" aria-hidden="true"></div>`;
+      },
+    },
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    blur: { control: 'boolean' },
+  },
+  args: {
+    blur: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Backdrop>;
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          position: 'relative',
+          height: '300px',
+          background: 'var(--dsn-color-neutral-bg-subtle)',
+          transform: 'translateZ(0)',
+        }}
+      >
+        <div
+          style={{
+            padding: '1.5rem',
+            fontFamily: 'sans-serif',
+            color: 'var(--dsn-color-neutral-color-document)',
+          }}
+        >
+          <h2 style={{ margin: '0 0 0.5rem' }}>Pagina-inhoud</h2>
+          <p style={{ margin: 0 }}>
+            Deze inhoud staat achter de backdrop overlay.
+          </p>
+        </div>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+// =============================================================================
+// VARIANTEN
+// =============================================================================
+
+export const WithoutBlur: Story = {
+  name: 'Without blur',
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          position: 'relative',
+          height: '300px',
+          background: 'var(--dsn-color-neutral-bg-subtle)',
+          transform: 'translateZ(0)',
+        }}
+      >
+        <div
+          style={{
+            padding: '1.5rem',
+            fontFamily: 'sans-serif',
+            color: 'var(--dsn-color-neutral-color-document)',
+          }}
+        >
+          <h2 style={{ margin: '0 0 0.5rem' }}>Pagina-inhoud</h2>
+          <p style={{ margin: 0 }}>
+            Backdrop zonder blur — fallback voor omgevingen zonder
+            backdrop-filter support.
+          </p>
+        </div>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    blur: false,
+  },
+};
+
+// =============================================================================
+// OVERZICHTSSTORIES
+// =============================================================================
+
+export const AllStates: Story = {
+  name: 'All states',
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gap: '1.5rem',
+        padding: '1rem',
+      }}
+    >
+      {/* Met blur */}
+      <div>
+        <p
+          style={{
+            margin: '0 0 0.5rem',
+            fontSize: '0.875rem',
+            fontWeight: 600,
+            color: 'var(--dsn-color-neutral-color-default)',
+          }}
+        >
+          Met blur
+        </p>
+        <div
+          style={{
+            position: 'relative',
+            height: '180px',
+            background: 'var(--dsn-color-neutral-bg-subtle)',
+            borderRadius: '4px',
+            transform: 'translateZ(0)',
+          }}
+        >
+          <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
+            <strong>Pagina-inhoud</strong>
+            <p style={{ margin: '0.25rem 0 0' }}>
+              Achtergrondtekst die vervaagt.
+            </p>
+          </div>
+          <div className="dsn-backdrop" aria-hidden="true" />
+        </div>
+      </div>
+
+      {/* Zonder blur */}
+      <div>
+        <p
+          style={{
+            margin: '0 0 0.5rem',
+            fontSize: '0.875rem',
+            fontWeight: 600,
+            color: 'var(--dsn-color-neutral-color-default)',
+          }}
+        >
+          Zonder blur (fallback)
+        </p>
+        <div
+          style={{
+            position: 'relative',
+            height: '180px',
+            background: 'var(--dsn-color-neutral-bg-subtle)',
+            borderRadius: '4px',
+            transform: 'translateZ(0)',
+          }}
+        >
+          <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
+            <strong>Pagina-inhoud</strong>
+            <p style={{ margin: '0.25rem 0 0' }}>
+              Achtergrondtekst zonder blur.
+            </p>
+          </div>
+          <div
+            className="dsn-backdrop dsn-backdrop--no-blur"
+            aria-hidden="true"
+          />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -61,7 +61,7 @@ function App() {
 
 ## Componenten overzicht
 
-**44 componenten totaal** — alle beschikbaar als HTML/CSS én React.
+**45 componenten totaal** — alle beschikbaar als HTML/CSS én React.
 
 ### Layout Components (5)
 
@@ -82,8 +82,9 @@ function App() {
 - **Link** — Hyperlinks met icon ondersteuning en externe link handling
 - **Lists** — OrderedList en UnorderedList
 
-### Display & Feedback Components (8)
+### Display & Feedback Components (9)
 
+- **Backdrop** — Vaste, volledig-scherm overlay die de achtergrondinhoud verhult achter een Modal Dialog of Drawer — puur decoratief (`aria-hidden="true"`)
 - **DotBadge** — Kleine gekleurde stip bij een Button of Link die zonder label de aandacht trekt bij een statuswijziging (met optioneel pulse-effect)
 - **StatusBadge** — Compact label dat een status communiceert met een signaalkleur (neutral, info, positive, negative, warning)
 - **Alert** — Belangrijk bericht dat de gebruiker informeert over de huidige activiteit (info, positive, negative, warning)
@@ -154,4 +155,4 @@ MIT License — zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.13.0 | **Laatste update:** 23 maart 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.14.0 | **Laatste update:** 25 maart 2026 | **Auteur:** Jeffrey Lauwers


### PR DESCRIPTION
## Summary

- **Backdrop** component toegevoegd — vaste overlay voor Modal Dialog en Drawer
- Design tokens (`backdrop.json`) + thema-kleuren in `colors-light.json` / `colors-dark.json`
- HTML/CSS implementatie met `color-mix()` voor semi-transparantie + `backdrop-filter: blur()`
- React component met `blur` prop (boolean, default `true`), `forwardRef`, altijd `aria-hidden="true"`
- Storybook: `Default`, `WithoutBlur` en `AllStates` stories + volledige docs-pagina
- Documentatie gesynchroniseerd (README, docs/03-components.md, changelog v5.14.0)

## Test plan

- [x] `pnpm test` — 1133 tests groen (55 test suites)
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 nieuwe TypeScript-fouten
- [x] `pnpm lint` — 0 errors
- [x] Storybook visueel geverifieerd: Default story, Without blur story, All states story, Docs-pagina

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)