### PR TITLE
chore(storybook): dsn-body toepassen op PreviewFrame visuele voorbeelden

### DIFF
--- a/packages/storybook/src/components/PreviewFrame.tsx
+++ b/packages/storybook/src/components/PreviewFrame.tsx
@@ -12,12 +12,12 @@ interface PreviewFrameProps {
 export function PreviewFrame({ children }: PreviewFrameProps) {
   return (
     <div
+      className="dsn-body"
       style={{
         border: '1px solid var(--dsn-color-neutral-border-subtle, #C4C4C4)',
         borderRadius: '4px 4px 0 0',
         borderBottom: 'none',
         padding: '32px 24px',
-        background: 'var(--dsn-color-neutral-bg-document, #FCFCFC)',
       }}
     >
       {children}


### PR DESCRIPTION
## Samenvatting

- `className="dsn-body"` toegevoegd aan de `PreviewFrame` wrapper in de Docs-pagina's
- Redundante inline `background`-style verwijderd (wordt nu gedekt door `dsn-body`)

## Probleem

Op de Docs-pagina's (bijv. Card, Details) werden typography-tokens zoals `font-size`, `font-family` en `line-height` niet correct geërvd in het visuele voorbeeldblok. Op de afzonderlijke story-pagina's werkte dit wél, omdat de decorator `dsn-body` op de `<body>` zet. In de Docs-view rendert de story inline in de Storybook-docs-pagina, waardoor Storybook's eigen CSS de typografie kon overschrijven.

## Oplossing

Door `dsn-body` op de `PreviewFrame` div te zetten, hebben alle visuele voorbeeldblokken in alle Docs-pagina's nu de juiste typography-context — identiek aan de afzonderlijke story-canvassen.

## Testplan

- [x] Card Docs — preview block toont correcte font-size voor links en tekst
- [x] Details Docs — preview block toont correcte font-size
- [x] Border, padding en border-radius van PreviewFrame blijven intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)