### PR TITLE
fix(Card): TypeScript-fouten in Card.stories.tsx oplossen

### DIFF
--- a/packages/storybook/src/Card.stories.tsx
+++ b/packages/storybook/src/Card.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   Card,
@@ -21,10 +22,10 @@ import {
 } from './story-helpers';
 
 const PLACEHOLDER_16_9 = 'https://picsum.photos/seed/card1/800/450';
-const PLACEHOLDER_16_9_B = 'https://picsum.photos/seed/card2/800/450';
-const PLACEHOLDER_16_9_C = 'https://picsum.photos/seed/card3/800/450';
 
-const meta: Meta<typeof Card> = {
+type CardStoryArgs = React.ComponentProps<typeof Card> & { showImage: boolean };
+
+const meta: Meta<CardStoryArgs> = {
   title: 'Components/Card',
   component: Card,
   parameters: {
@@ -62,7 +63,7 @@ const meta: Meta<typeof Card> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof Card>;
+type Story = StoryObj<CardStoryArgs>;
 
 // =============================================================================
 // DEFAULT


### PR DESCRIPTION
## Summary

- `PLACEHOLDER_16_9_B` en `PLACEHOLDER_16_9_C` verwijderd (waren gedeclareerd maar nooit gebruikt — TS6133)
- `CardStoryArgs` type toegevoegd (`React.ComponentProps<typeof Card> & { showImage: boolean }`) zodat `showImage` als custom story-arg correct getypeerd is (TS2353, TS2339)
- `Meta` en `StoryObj` omgezet naar `CardStoryArgs` zodat TypeScript de custom arg herkent

## Test plan

- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [x] `pnpm lint` — 0 fouten

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)