### PR TITLE
fix(ModalDialog): heading font-size verkleinen van xl naar lg

### DIFF
--- a/packages/design-tokens/src/tokens/components/modal-dialog.json
+++ b/packages/design-tokens/src/tokens/components/modal-dialog.json
@@ -48,12 +48,12 @@
           "comment": "Kleur van de dialoogvenster-heading"
         },
         "font-size": {
-          "value": "{dsn.text.font-size.xl}",
+          "value": "{dsn.text.font-size.lg}",
           "type": "fontSize",
           "comment": "Tekstgrootte van de dialoogvenster-heading"
         },
         "line-height": {
-          "value": "{dsn.text.line-height.xl}",
+          "value": "{dsn.text.line-height.lg}",
           "type": "lineHeight",
           "comment": "Regelafstand van de dialoogvenster-heading"
         }


### PR DESCRIPTION
## Summary

- `dsn.modal-dialog.heading.font-size` token gewijzigd van `{dsn.text.font-size.xl}` naar `{dsn.text.font-size.lg}`
- `dsn.modal-dialog.heading.line-height` token gewijzigd van `{dsn.text.line-height.xl}` naar `{dsn.text.line-height.lg}`

## Test plan

- [ ] Visueel controleren in Storybook: ModalDialog heading toont font-size `lg` in plaats van `xl`
- [ ] Chromatic visuele regressietest goedkeuren

🤖 Generated with [Claude Code](https://claude.com/claude-code)