### PR TITLE
feat(Drawer): zijpaneel dat vanuit links of rechts inschuift

### DIFF
--- a/.claude/commands/new-component-issue.md
+++ b/.claude/commands/new-component-issue.md
@@ -183,6 +183,7 @@ Het [ComponentName] component wordt gebruikt voor:
 
 - [ ] `[ComponentName]` component met [props opsomming]
 - [ ] `React.forwardRef<HTML[Element]Element>`
+- [ ] `index.ts` barrel file aangemaakt in de componentdirectory (exporteert component + prop types)
 - [ ] Export toegevoegd aan `packages/components-react/src/index.ts`
 
 ### Storybook

--- a/packages/components-html/src/drawer/drawer.css
+++ b/packages/components-html/src/drawer/drawer.css
@@ -1,0 +1,257 @@
+/* ===== Drawer ===== */
+
+/*
+ * dsn-drawer — Zijpaneel dat vanuit links of rechts de viewport inschuift
+ *
+ * Gebaseerd op het native <dialog> element.
+ * Modaal (modal prop): openen via .showModal() — natieve focus-trap + ::backdrop.
+ * Non-modaal:          openen via .show()      — achtergrond blijft interactief.
+ *
+ * HTML-structuur:
+ *
+ * <dialog class="dsn-drawer dsn-drawer--side-right" aria-labelledby="drawer-title">
+ *   <div class="dsn-drawer__header">
+ *     <h2 class="dsn-drawer-heading" id="drawer-title">Titel</h2>
+ *     <button type="button" class="dsn-button dsn-button--subtle dsn-button--size-small dsn-button--icon-only">
+ *       <svg class="dsn-icon" aria-hidden="true"><!-- x --></svg>
+ *       <span class="dsn-button__label">Sluiten</span>
+ *     </button>
+ *   </div>
+ *   <div class="dsn-drawer__body">
+ *     <!-- inhoud -->
+ *   </div>
+ *   <div class="dsn-drawer__footer">
+ *     <div class="dsn-action-group">
+ *       <!-- knoppen -->
+ *     </div>
+ *   </div>
+ * </dialog>
+ */
+
+.dsn-drawer {
+  /* Reset native <dialog> styling */
+  border: none;
+  box-shadow: var(--dsn-drawer-box-shadow);
+  background: var(--dsn-drawer-background);
+  padding: 0;
+
+  /* Grootte */
+  inline-size: min(
+    var(--dsn-drawer-max-width),
+    calc(100svw - var(--dsn-drawer-min-gap))
+  );
+  block-size: 100svh;
+  max-block-size: 100svh;
+
+  /* Positionering — override UA's auto-centrering voor zowel modal als non-modal */
+  position: fixed;
+  inset-block: 0;
+  margin-block: 0;
+
+  /* Altijd flex-direction column, ook tijdens sluitanimatie */
+  flex-direction: column;
+
+  /* Animatietransitie (ook voor sluitanimatie) */
+  opacity: 1;
+  transform: translateX(0);
+  transition:
+    opacity var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default),
+    transform var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default),
+    display var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default) allow-discrete,
+    overlay var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default) allow-discrete;
+}
+
+/*
+ * Flexbox layout alleen bij open staat.
+ * Gebruik [open] zodat de UA-stylesheet's display:none van kracht blijft
+ * wanneer de drawer gesloten is — anders overschrijft display:flex de UA.
+ */
+.dsn-drawer[open] {
+  display: flex;
+}
+
+/* Animatie uitschakelen bij prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  .dsn-drawer {
+    transition: none;
+  }
+}
+
+/* ===== Side: Right (standaard) ===== */
+
+.dsn-drawer--side-right {
+  right: 0;
+  left: auto;
+
+  /* Alleen de rand aan de kant van de pagina (links) */
+  border-inline-start: var(--dsn-drawer-border-width) solid
+    var(--dsn-drawer-border-color);
+}
+
+/* Openingsanimatie rechts: start buiten beeld rechts */
+@starting-style {
+  .dsn-drawer--side-right[open] {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+}
+
+/* Native backdrop (alleen bij .showModal()) */
+.dsn-drawer--side-right::backdrop {
+  background: var(--dsn-backdrop-background, rgba(0, 0, 0, 0.5));
+  backdrop-filter: var(--dsn-backdrop-blur, blur(2px));
+  opacity: 1;
+  transition:
+    opacity var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default),
+    display var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default) allow-discrete,
+    overlay var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default) allow-discrete;
+}
+
+@starting-style {
+  .dsn-drawer--side-right[open]::backdrop {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dsn-drawer--side-right::backdrop {
+    transition: none;
+  }
+}
+
+/* ===== Side: Left ===== */
+
+.dsn-drawer--side-left {
+  left: 0;
+  right: auto;
+
+  /* Alleen de rand aan de kant van de pagina (rechts) */
+  border-inline-end: var(--dsn-drawer-border-width) solid
+    var(--dsn-drawer-border-color);
+}
+
+/* Openingsanimatie links: start buiten beeld links */
+@starting-style {
+  .dsn-drawer--side-left[open] {
+    opacity: 0;
+    transform: translateX(-100%);
+  }
+}
+
+/* Native backdrop (alleen bij .showModal()) */
+.dsn-drawer--side-left::backdrop {
+  background: var(--dsn-backdrop-background, rgba(0, 0, 0, 0.5));
+  backdrop-filter: var(--dsn-backdrop-blur, blur(2px));
+  opacity: 1;
+  transition:
+    opacity var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default),
+    display var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default) allow-discrete,
+    overlay var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default) allow-discrete;
+}
+
+@starting-style {
+  .dsn-drawer--side-left[open]::backdrop {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dsn-drawer--side-left::backdrop {
+    transition: none;
+  }
+}
+
+/* ===== Header ===== */
+
+.dsn-drawer__header {
+  display: flex;
+  align-items: center;
+  gap: var(--dsn-space-inline-xl);
+  flex-shrink: 0;
+
+  padding-block-start: var(--dsn-drawer-header-padding-block-start);
+  padding-block-end: var(--dsn-drawer-header-padding-block-end);
+  padding-inline: var(--dsn-drawer-header-padding-inline);
+
+  /* Scheidingslijn onder de header */
+  border-block-end: var(--dsn-drawer-border-width) solid
+    var(--dsn-drawer-border-color);
+}
+
+/* ===== Heading ===== */
+
+.dsn-drawer-heading {
+  flex: 1;
+  margin: 0;
+
+  font-family: var(--dsn-drawer-heading-font-family);
+  font-weight: var(--dsn-drawer-heading-font-weight);
+  font-size: var(--dsn-drawer-heading-font-size);
+  line-height: var(--dsn-drawer-heading-line-height);
+  color: var(--dsn-drawer-heading-color);
+}
+
+/* ===== Body met scroll-affordance ===== */
+/*
+ * Scroll-affordance schaduw (Lea Verou techniek — verticale variant):
+ * - Dekkende overlagen (background-attachment: local) scrollen mee met de content
+ *   en verbergen de schaduwen wanneer je aan het begin of einde bent.
+ * - Schaduw-overlagen (background-attachment: scroll) blijven gefixeerd.
+ * - Resultaat: schaduw is zichtbaar zodra er content is om naartoe te scrollen.
+ *
+ * ⚠️ Vereist dat de achtergrondkleur overeenkomt met de drawer-achtergrond.
+ */
+
+.dsn-drawer__body {
+  --_bg: var(--dsn-drawer-background);
+  --_shadow: var(--dsn-color-shadow-scroll, rgba(0, 0, 0, 0.12));
+
+  flex: 1;
+  overflow-y: auto;
+
+  padding-block: var(--dsn-drawer-body-padding-block);
+  padding-inline: var(--dsn-drawer-body-padding-inline);
+
+  background-color: var(--_bg);
+  background-image:
+    /* Top-cover (local): verbergt de bovenschaduw als je helemaal boven bent */
+    linear-gradient(to bottom, var(--_bg) 0%, transparent 100%),
+    /* Onder-cover (local): verbergt de onderschaduw als je helemaal onder bent */
+    linear-gradient(to top, var(--_bg) 0%, transparent 100%),
+    /* Bovenschaduw (scroll): altijd aanwezig */
+    linear-gradient(to bottom, var(--_shadow) 0%, transparent 100%),
+    /* Onderschaduw (scroll): altijd aanwezig */
+    linear-gradient(to top, var(--_shadow) 0%, transparent 100%);
+  background-repeat: no-repeat;
+  background-size:
+    100% 4rem,
+    100% 4rem,
+    100% 2rem,
+    100% 2rem;
+  background-position: top, bottom, top, bottom;
+  background-attachment: local, local, scroll, scroll;
+}
+
+/* ===== Footer ===== */
+
+.dsn-drawer__footer {
+  flex-shrink: 0;
+
+  padding-block-start: var(--dsn-drawer-footer-padding-block-start);
+  padding-block-end: var(--dsn-drawer-footer-padding-block-end);
+  padding-inline: var(--dsn-drawer-footer-padding-inline);
+
+  /* Scheidingslijn boven de footer */
+  border-block-start: var(--dsn-drawer-border-width) solid
+    var(--dsn-drawer-border-color);
+}

--- a/packages/components-react/src/Drawer/Drawer.css
+++ b/packages/components-react/src/Drawer/Drawer.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/drawer/drawer.css';

--- a/packages/components-react/src/Drawer/Drawer.test.tsx
+++ b/packages/components-react/src/Drawer/Drawer.test.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  Drawer,
+  DrawerHeader,
+  DrawerHeading,
+  DrawerBody,
+  DrawerFooter,
+} from './Drawer';
+
+// jsdom heeft geen volledige HTMLDialogElement implementatie.
+// Mock showModal, show en close voor alle tests.
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn();
+  HTMLDialogElement.prototype.show = vi.fn();
+  HTMLDialogElement.prototype.close = vi.fn();
+});
+
+const DefaultDrawer = ({
+  isOpen = true,
+  onClose,
+  modal = true,
+  side = 'right' as const,
+}: {
+  isOpen?: boolean;
+  onClose?: () => void;
+  modal?: boolean;
+  side?: 'right' | 'left';
+}) => (
+  <Drawer isOpen={isOpen} onClose={onClose} modal={modal} side={side}>
+    <DrawerHeader>
+      <DrawerHeading>Drawertitel</DrawerHeading>
+    </DrawerHeader>
+    <DrawerBody>
+      <p>Drawerinhoud</p>
+    </DrawerBody>
+    <DrawerFooter>
+      <button type="button">Toepassen</button>
+    </DrawerFooter>
+  </Drawer>
+);
+
+describe('Drawer', () => {
+  // ===========================
+  // Rendering
+  // ===========================
+
+  it('renders as a <dialog> element', () => {
+    const { container } = render(<DefaultDrawer />);
+    expect(container.querySelector('dialog')).toBeInTheDocument();
+  });
+
+  it('renders children content', () => {
+    render(<DefaultDrawer />);
+    expect(screen.getByText('Drawerinhoud')).toBeInTheDocument();
+  });
+
+  it('applies dsn-drawer class', () => {
+    const { container } = render(<DefaultDrawer />);
+    expect(container.querySelector('dialog')).toHaveClass('dsn-drawer');
+  });
+
+  it('applies custom className', () => {
+    render(
+      <Drawer isOpen={true} className="custom-drawer">
+        <DrawerBody>Inhoud</DrawerBody>
+      </Drawer>
+    );
+    expect(document.querySelector('dialog')).toHaveClass('custom-drawer');
+  });
+
+  // ===========================
+  // Side modifier klassen
+  // ===========================
+
+  it('applies dsn-drawer--side-right by default', () => {
+    const { container } = render(<DefaultDrawer />);
+    expect(container.querySelector('dialog')).toHaveClass(
+      'dsn-drawer--side-right'
+    );
+  });
+
+  it('applies dsn-drawer--side-right when side="right"', () => {
+    const { container } = render(<DefaultDrawer side="right" />);
+    expect(container.querySelector('dialog')).toHaveClass(
+      'dsn-drawer--side-right'
+    );
+    expect(container.querySelector('dialog')).not.toHaveClass(
+      'dsn-drawer--side-left'
+    );
+  });
+
+  it('applies dsn-drawer--side-left when side="left"', () => {
+    const { container } = render(<DefaultDrawer side="left" />);
+    expect(container.querySelector('dialog')).toHaveClass(
+      'dsn-drawer--side-left'
+    );
+    expect(container.querySelector('dialog')).not.toHaveClass(
+      'dsn-drawer--side-right'
+    );
+  });
+
+  // ===========================
+  // isOpen / showModal / show / close
+  // ===========================
+
+  it('calls showModal when isOpen becomes true and modal=true', () => {
+    render(<DefaultDrawer isOpen={true} modal={true} />);
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+    expect(HTMLDialogElement.prototype.show).not.toHaveBeenCalled();
+  });
+
+  it('calls show when isOpen becomes true and modal=false', () => {
+    render(<DefaultDrawer isOpen={true} modal={false} />);
+    expect(HTMLDialogElement.prototype.show).toHaveBeenCalled();
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+  });
+
+  it('does not call showModal or show when isOpen is false', () => {
+    render(<DefaultDrawer isOpen={false} />);
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+    expect(HTMLDialogElement.prototype.show).not.toHaveBeenCalled();
+  });
+
+  // ===========================
+  // aria-labelledby
+  // ===========================
+
+  it('has aria-labelledby that matches heading id', () => {
+    render(<DefaultDrawer />);
+    const dialog = document.querySelector('dialog')!;
+    const labelledById = dialog.getAttribute('aria-labelledby');
+    expect(labelledById).toBeTruthy();
+    const heading = document.getElementById(labelledById!);
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent('Drawertitel');
+  });
+
+  // ===========================
+  // onClose callback
+  // ===========================
+
+  it('calls onClose when close button is clicked', async () => {
+    const onClose = vi.fn();
+    render(<DefaultDrawer onClose={onClose} />);
+    const closeButton = screen.getByText('Sluiten').closest('button')!;
+    await userEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  // ===========================
+  // Sub-components rendering
+  // ===========================
+
+  it('renders header with dsn-drawer__header class', () => {
+    const { container } = render(<DefaultDrawer />);
+    expect(container.querySelector('.dsn-drawer__header')).toBeInTheDocument();
+  });
+
+  it('renders body with dsn-drawer__body class', () => {
+    const { container } = render(<DefaultDrawer />);
+    expect(container.querySelector('.dsn-drawer__body')).toBeInTheDocument();
+  });
+
+  it('renders footer with dsn-drawer__footer class', () => {
+    const { container } = render(<DefaultDrawer />);
+    expect(container.querySelector('.dsn-drawer__footer')).toBeInTheDocument();
+  });
+
+  it('renders heading with dsn-drawer-heading class', () => {
+    const { container } = render(<DefaultDrawer />);
+    expect(container.querySelector('.dsn-drawer-heading')).toBeInTheDocument();
+  });
+
+  // ===========================
+  // DrawerHeading levels
+  // ===========================
+
+  it('renders heading as h2 by default', () => {
+    render(
+      <Drawer isOpen={true}>
+        <DrawerHeader>
+          <DrawerHeading>Titel</DrawerHeading>
+        </DrawerHeader>
+        <DrawerBody>Inhoud</DrawerBody>
+      </Drawer>
+    );
+    expect(document.querySelector('h2.dsn-drawer-heading')).toBeInTheDocument();
+  });
+
+  it('renders heading at specified level', () => {
+    render(
+      <Drawer isOpen={true}>
+        <DrawerHeader>
+          <DrawerHeading level={3}>Titel</DrawerHeading>
+        </DrawerHeader>
+        <DrawerBody>Inhoud</DrawerBody>
+      </Drawer>
+    );
+    expect(document.querySelector('h3.dsn-drawer-heading')).toBeInTheDocument();
+  });
+
+  // ===========================
+  // Ref forwarding
+  // ===========================
+
+  it('forwards ref to the dialog element', () => {
+    const ref = { current: null as HTMLDialogElement | null };
+    render(
+      <Drawer ref={ref} isOpen={true}>
+        <DrawerBody>Inhoud</DrawerBody>
+      </Drawer>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.tagName).toBe('DIALOG');
+  });
+
+  // ===========================
+  // HTML attributes
+  // ===========================
+
+  it('spreads additional HTML attributes', () => {
+    render(
+      <Drawer isOpen={true} data-testid="mijn-drawer">
+        <DrawerBody>Inhoud</DrawerBody>
+      </Drawer>
+    );
+    expect(screen.getByTestId('mijn-drawer')).toBeInTheDocument();
+  });
+});

--- a/packages/components-react/src/Drawer/Drawer.tsx
+++ b/packages/components-react/src/Drawer/Drawer.tsx
@@ -1,0 +1,311 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import './Drawer.css';
+
+// =============================================================================
+// Context
+// =============================================================================
+
+interface DrawerContextValue {
+  headingId: string;
+  onClose?: () => void;
+}
+
+const DrawerContext = React.createContext<DrawerContextValue>({
+  headingId: '',
+});
+
+// =============================================================================
+// Drawer (root)
+// =============================================================================
+
+export interface DrawerProps extends Omit<
+  React.HTMLAttributes<HTMLDialogElement>,
+  'children'
+> {
+  /**
+   * Bepaalt of het zijpaneel getoond wordt.
+   */
+  isOpen: boolean;
+
+  /**
+   * Callback die wordt aangeroepen wanneer het zijpaneel sluit
+   * (sluitknop, Escape-toets).
+   */
+  onClose?: () => void;
+
+  /**
+   * Modaal of non-modaal gedrag.
+   * - `true` (standaard): opent via `.showModal()` — achtergrond geblokkeerd,
+   *   natieve focus-trap, Escape sluit via `cancel`-event.
+   * - `false`: opent via `.show()` — achtergrond blijft interactief,
+   *   Escape sluit via `keydown`-listener.
+   * @default true
+   */
+  modal?: boolean;
+
+  /**
+   * De kant van de viewport vanwaar het zijpaneel inschuift.
+   * @default "right"
+   */
+  side?: 'right' | 'left';
+
+  /**
+   * De subcomponenten van het zijpaneel:
+   * `DrawerHeader`, `DrawerBody`, `DrawerFooter`
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * Drawer component
+ * Zijpaneel dat vanuit links of rechts de viewport inschuift.
+ *
+ * Gebruik `modal={true}` (standaard) voor gefocuste taken waarbij de achtergrond
+ * geblokkeerd moet worden. Gebruik `modal={false}` als de gebruiker de achtergrondpagina
+ * nodig heeft voor context.
+ *
+ * @example
+ * ```tsx
+ * <Drawer isOpen={isOpen} onClose={() => setIsOpen(false)}>
+ *   <DrawerHeader>
+ *     <DrawerHeading>Filteropties</DrawerHeading>
+ *   </DrawerHeader>
+ *   <DrawerBody>
+ *     <Paragraph>Inhoud van het zijpaneel</Paragraph>
+ *   </DrawerBody>
+ *   <DrawerFooter>
+ *     <ActionGroup>
+ *       <Button variant="strong" onClick={() => setIsOpen(false)}>Toepassen</Button>
+ *       <Button variant="default" onClick={() => setIsOpen(false)}>Annuleren</Button>
+ *     </ActionGroup>
+ *   </DrawerFooter>
+ * </Drawer>
+ * ```
+ */
+export const Drawer = React.forwardRef<HTMLDialogElement, DrawerProps>(
+  (
+    {
+      className,
+      isOpen,
+      onClose,
+      modal = true,
+      side = 'right',
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const internalRef = React.useRef<HTMLDialogElement>(null);
+    const dialogRef =
+      (ref as React.RefObject<HTMLDialogElement>) ?? internalRef;
+    const headingId = React.useId();
+
+    React.useEffect(() => {
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+
+      if (isOpen && !dialog.open) {
+        if (modal) {
+          dialog.showModal();
+        } else {
+          dialog.show();
+        }
+      } else if (!isOpen && dialog.open) {
+        dialog.close();
+      }
+    }, [isOpen, modal, dialogRef]);
+
+    // Non-modaal: handmatige Escape-afhandeling via keydown
+    React.useEffect(() => {
+      if (modal) return;
+      const dialog = dialogRef.current;
+      if (!dialog || !isOpen) return;
+
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          onClose?.();
+        }
+      };
+
+      dialog.addEventListener('keydown', handleKeyDown);
+      return () => dialog.removeEventListener('keydown', handleKeyDown);
+    }, [modal, isOpen, onClose, dialogRef]);
+
+    // Modaal: native cancel-event (Escape via browser)
+    const handleCancel = (event: React.SyntheticEvent<HTMLDialogElement>) => {
+      event.preventDefault();
+      onClose?.();
+    };
+
+    const classes = classNames(
+      'dsn-drawer',
+      side === 'left' ? 'dsn-drawer--side-left' : 'dsn-drawer--side-right',
+      className
+    );
+
+    return (
+      <DrawerContext.Provider value={{ headingId, onClose }}>
+        <dialog
+          ref={dialogRef}
+          className={classes}
+          aria-labelledby={headingId}
+          onCancel={handleCancel}
+          {...props}
+        >
+          {children}
+        </dialog>
+      </DrawerContext.Provider>
+    );
+  }
+);
+
+Drawer.displayName = 'Drawer';
+
+// =============================================================================
+// DrawerHeader
+// =============================================================================
+
+export interface DrawerHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Inhoud van de header — doorgaans een `DrawerHeading`
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * DrawerHeader
+ * De headerstrook van het zijpaneel met heading en sluitknop.
+ */
+export const DrawerHeader = React.forwardRef<HTMLDivElement, DrawerHeaderProps>(
+  ({ className, children, ...props }, ref) => {
+    const { onClose } = React.useContext(DrawerContext);
+
+    return (
+      <div
+        ref={ref}
+        className={classNames('dsn-drawer__header', className)}
+        {...props}
+      >
+        {children}
+        <Button
+          variant="subtle"
+          size="small"
+          iconOnly
+          onClick={onClose}
+          iconStart={<Icon name="x" aria-hidden />}
+        >
+          Sluiten
+        </Button>
+      </div>
+    );
+  }
+);
+
+DrawerHeader.displayName = 'DrawerHeader';
+
+// =============================================================================
+// DrawerHeading
+// =============================================================================
+
+export interface DrawerHeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  /**
+   * Semantisch heading-niveau. Kies op basis van documenthiërarchie, niet visuele grootte.
+   * @default 2
+   */
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+
+  /**
+   * De zichtbare heading-tekst
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * DrawerHeading
+ * De heading van het zijpaneel. ID wordt automatisch gegenereerd voor aria-labelledby.
+ */
+export const DrawerHeading = React.forwardRef<
+  HTMLHeadingElement,
+  DrawerHeadingProps
+>(({ className, level = 2, children, ...props }, ref) => {
+  const { headingId } = React.useContext(DrawerContext);
+  const Tag = `h${level}` as React.ElementType;
+
+  return (
+    <Tag
+      ref={ref}
+      id={headingId}
+      className={classNames('dsn-drawer-heading', className)}
+      {...props}
+    >
+      {children}
+    </Tag>
+  );
+});
+
+DrawerHeading.displayName = 'DrawerHeading';
+
+// =============================================================================
+// DrawerBody
+// =============================================================================
+
+export interface DrawerBodyProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * De hoofdinhoud van het zijpaneel
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * DrawerBody
+ * De scrollbare inhoudssectie van het zijpaneel met scroll-affordance schaduw.
+ */
+export const DrawerBody = React.forwardRef<HTMLDivElement, DrawerBodyProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={classNames('dsn-drawer__body', className)}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+DrawerBody.displayName = 'DrawerBody';
+
+// =============================================================================
+// DrawerFooter
+// =============================================================================
+
+export interface DrawerFooterProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * De acties van het zijpaneel — doorgaans een `ActionGroup` met knoppen
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * DrawerFooter
+ * De voettekst van het zijpaneel met actieknoppen.
+ */
+export const DrawerFooter = React.forwardRef<HTMLDivElement, DrawerFooterProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={classNames('dsn-drawer__footer', className)}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+DrawerFooter.displayName = 'DrawerFooter';

--- a/packages/components-react/src/Drawer/index.ts
+++ b/packages/components-react/src/Drawer/index.ts
@@ -1,0 +1,14 @@
+export {
+  Drawer,
+  DrawerHeader,
+  DrawerHeading,
+  DrawerBody,
+  DrawerFooter,
+} from './Drawer';
+export type {
+  DrawerProps,
+  DrawerHeaderProps,
+  DrawerHeadingProps,
+  DrawerBodyProps,
+  DrawerFooterProps,
+} from './Drawer';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -71,3 +71,4 @@ export * from './FormFieldLegend';
 export * from './Image';
 export * from './Card';
 export * from './ModalDialog';
+export * from './Drawer';

--- a/packages/design-tokens/src/tokens/components/drawer.json
+++ b/packages/design-tokens/src/tokens/components/drawer.json
@@ -1,0 +1,109 @@
+{
+  "dsn": {
+    "drawer": {
+      "background": {
+        "value": "{dsn.color.neutral.bg-elevated}",
+        "type": "color",
+        "comment": "Achtergrondkleur van het zijpaneel — bg-elevated benadrukt elevatie boven de pagina"
+      },
+      "border-width": {
+        "value": "{dsn.border.width.thin}",
+        "type": "borderWidth",
+        "comment": "Randbreedte van het zijpaneel"
+      },
+      "border-color": {
+        "value": "{dsn.color.neutral.border-subtle}",
+        "type": "color",
+        "comment": "Randkleur van het zijpaneel"
+      },
+      "box-shadow": {
+        "value": "{dsn.box-shadow.lg}",
+        "type": "shadow",
+        "comment": "Schaduw van het zijpaneel — hoogste elevatie (lg)"
+      },
+      "max-width": {
+        "value": "25rem",
+        "type": "dimension",
+        "comment": "Maximale breedte van het zijpaneel (400px)"
+      },
+      "min-gap": {
+        "value": "3rem",
+        "type": "dimension",
+        "comment": "Minimale zichtbare ruimte van de achtergrondpagina naast het zijpaneel (48px)"
+      },
+      "heading": {
+        "font-family": {
+          "value": "{dsn.heading.font-family}",
+          "type": "fontFamily",
+          "comment": "Lettertype van de zijpaneel-heading"
+        },
+        "font-weight": {
+          "value": "{dsn.heading.font-weight}",
+          "type": "fontWeight",
+          "comment": "Vetgedrukt van de zijpaneel-heading"
+        },
+        "color": {
+          "value": "{dsn.heading.color}",
+          "type": "color",
+          "comment": "Kleur van de zijpaneel-heading"
+        },
+        "font-size": {
+          "value": "{dsn.text.font-size.lg}",
+          "type": "fontSize",
+          "comment": "Tekstgrootte van de zijpaneel-heading"
+        },
+        "line-height": {
+          "value": "{dsn.text.line-height.lg}",
+          "type": "lineHeight",
+          "comment": "Regelafstand van de zijpaneel-heading"
+        }
+      },
+      "header": {
+        "padding-block-start": {
+          "value": "{dsn.space.block.xl}",
+          "type": "spacing",
+          "comment": "Bovenkant padding van de header (16px)"
+        },
+        "padding-block-end": {
+          "value": "{dsn.space.block.xl}",
+          "type": "spacing",
+          "comment": "Onderkant padding van de header (16px)"
+        },
+        "padding-inline": {
+          "value": "{dsn.space.inline.xl}",
+          "type": "spacing",
+          "comment": "Horizontale padding van de header (16px)"
+        }
+      },
+      "body": {
+        "padding-block": {
+          "value": "{dsn.space.block.3xl}",
+          "type": "spacing",
+          "comment": "Verticale padding van de body (24px)"
+        },
+        "padding-inline": {
+          "value": "{dsn.space.inline.xl}",
+          "type": "spacing",
+          "comment": "Horizontale padding van de body (16px)"
+        }
+      },
+      "footer": {
+        "padding-block-start": {
+          "value": "{dsn.space.block.xl}",
+          "type": "spacing",
+          "comment": "Bovenkant padding van de footer (16px)"
+        },
+        "padding-block-end": {
+          "value": "{dsn.space.block.xl}",
+          "type": "spacing",
+          "comment": "Onderkant padding van de footer (16px)"
+        },
+        "padding-inline": {
+          "value": "{dsn.space.inline.xl}",
+          "type": "spacing",
+          "comment": "Horizontale padding van de footer (16px)"
+        }
+      }
+    }
+  }
+}

--- a/packages/storybook/src/Drawer.docs.md
+++ b/packages/storybook/src/Drawer.docs.md
@@ -1,0 +1,96 @@
+# Drawer
+
+Zijpaneel dat vanuit links of rechts de viewport inschuift voor subtaken en contextuele inhoud.
+
+## Doel
+
+Het Drawer component toont een zijpaneel dat over de pagina-inhoud schuift. In tegenstelling tot het ModalDialog blijft de achtergrondpagina zichtbaar naast het paneel, waardoor de gebruiker de context kan behouden. Een Drawer kan modaal zijn (achtergrond geblokkeerd) of non-modaal (achtergrond interactief). Het is gebaseerd op het native `<dialog>` element.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- De gebruiker rij- of itemdetails naast een lijst wil bekijken of bewerken.
+- Een filterpaneel live de resultaten op de achtergrondpagina moet bijwerken (non-modal).
+- Een subtaak uitgevoerd moet worden terwijl de context van de onderliggende pagina zichtbaar blijft.
+- Aanvullende navigatie- of instellingenopties getoond moeten worden naast de huidige pagina.
+
+## Don't use when
+
+- De gebruiker de achtergrondpagina _niet_ nodig heeft — gebruik dan **ModalDialog**.
+- Een onomkeerbare actie bevestigd moet worden (bijv. verwijderen) — gebruik dan **ModalDialog**.
+- De inhoud een volwaardige werkstroom is die een eigen URL rechtvaardigt — gebruik dan een aparte pagina.
+
+## Best practices
+
+### Drawer vs. ModalDialog
+
+| Situatie                                              | Component          |
+| ----------------------------------------------------- | ------------------ |
+| Korte, gefocuste actie (bevestigen, kleine keuze)     | ModalDialog        |
+| Bevestigen van permanent verwijderen                  | ModalDialog        |
+| Gebruiker heeft achtergrondpagina nodig voor context  | Drawer             |
+| Rij- of itemdetails bekijken/bewerken naast een lijst | Drawer             |
+| Filterpaneel met live-bijwerkende resultaten          | Drawer (non-modal) |
+| Inhoud verdient een eigen URL                         | Aparte pagina      |
+
+### Modal vs. non-modal
+
+- **Modal** (`modal={true}`, standaard): achtergrond geblokkeerd via de native `::backdrop`. Gebruik dit wanneer de gebruiker de subtaak volledig moet afronden voordat hij terugkeert naar de pagina.
+- **Non-modal** (`modal={false}`): achtergrond blijft interactief. Gebruik dit voor filtervensters of infovensters waarbij de gebruiker de pagina naast het paneel wil bedienen.
+
+### Sluitgedrag
+
+- **Sluitknop** in de header sluit het zijpaneel altijd — altijd aanwezig.
+- **Escape-toets** sluit het zijpaneel (modaal via het native `cancel`-event; non-modaal via `keydown`-listener).
+- **Primaire actie** (bijv. Toepassen) sluit het paneel en voert de actie uit.
+- **Secundaire actie** (bijv. Annuleren) sluit het paneel zonder actie.
+
+### Positie
+
+- Gebruik `side="right"` (standaard) voor de meeste subtaken — consistent met platformconventies.
+- Gebruik `side="left"` voor navigatiepanelen die logisch aan de linker kant horen.
+
+### Heading-niveau
+
+- Gebruik `level={2}` (standaard) als de paginatitel `<h1>` is.
+- Kies het niveau op basis van de documenthiërarchie — het visuele uiterlijk is altijd gelijk.
+
+### Lange inhoud
+
+- De `DrawerBody` scrollt automatisch bij lange inhoud (scroll-affordance schaduw).
+- Header en footer blijven sticky zichtbaar tijdens scrollen.
+
+## Design tokens
+
+| Token                                     | Beschrijving                                            |
+| ----------------------------------------- | ------------------------------------------------------- |
+| `--dsn-drawer-background`                 | Achtergrondkleur (bg-elevated)                          |
+| `--dsn-drawer-border-width`               | Randbreedte van de scheidingslijn met de pagina         |
+| `--dsn-drawer-border-color`               | Randkleur van de scheidingslijn (neutral.border-subtle) |
+| `--dsn-drawer-box-shadow`                 | Schaduw (box-shadow.lg — hoogste elevatie)              |
+| `--dsn-drawer-max-width`                  | Maximale breedte (25rem / 400px)                        |
+| `--dsn-drawer-min-gap`                    | Minimale zichtbare achtergrondruimte (3rem / 48px)      |
+| `--dsn-drawer-heading-font-family`        | Lettertype van de heading                               |
+| `--dsn-drawer-heading-font-weight`        | Vetgedrukt van de heading                               |
+| `--dsn-drawer-heading-font-size`          | Tekstgrootte van de heading                             |
+| `--dsn-drawer-heading-line-height`        | Regelafstand van de heading                             |
+| `--dsn-drawer-heading-color`              | Kleur van de heading                                    |
+| `--dsn-drawer-header-padding-block-start` | Bovenkant padding van de header (16px)                  |
+| `--dsn-drawer-header-padding-block-end`   | Onderkant padding van de header (16px)                  |
+| `--dsn-drawer-header-padding-inline`      | Horizontale padding van de header (16px)                |
+| `--dsn-drawer-body-padding-block`         | Verticale padding van de body (24px)                    |
+| `--dsn-drawer-body-padding-inline`        | Horizontale padding van de body (16px)                  |
+| `--dsn-drawer-footer-padding-block-start` | Bovenkant padding van de footer (16px)                  |
+| `--dsn-drawer-footer-padding-block-end`   | Onderkant padding van de footer (16px)                  |
+| `--dsn-drawer-footer-padding-inline`      | Horizontale padding van de footer (16px)                |
+
+## Accessibility
+
+- Het zijpaneel gebruikt het native `<dialog>` element met impliciete `role="dialog"` semantiek.
+- `.showModal()` (modal variant) activeert automatisch de native focus-trap, `aria-modal`-gedrag en `inert`-attribuut op de achtergrond.
+- `.show()` (non-modal variant) toont het paneel zonder focus-trap — de gebruiker kan via Tab navigeren tussen het paneel en de achtergrond.
+- `aria-labelledby` koppelt het zijpaneel automatisch aan de `DrawerHeading` — geen handmatige ID nodig.
+- De sluitknop gebruikt `dsn-button__label` met de tekst "Sluiten" — nooit `aria-label`.
+- Escape sluit het zijpaneel (modaal via het native `cancel`-event; non-modaal via `keydown`-listener).
+- Animaties zijn uitgeschakeld bij `prefers-reduced-motion: reduce`.

--- a/packages/storybook/src/Drawer.docs.mdx
+++ b/packages/storybook/src/Drawer.docs.mdx
@@ -1,0 +1,46 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as DrawerStories from './Drawer.stories';
+import docs from './Drawer.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={DrawerStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={DrawerStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={DrawerStories.Default}
+  html={`<dialog class="dsn-drawer dsn-drawer--side-right" open aria-labelledby="drawer-title">
+  <div class="dsn-drawer__header">
+    <h2 class="dsn-drawer-heading" id="drawer-title">Zijpaneel titel</h2>
+    <button type="button" class="dsn-button dsn-button--subtle dsn-button--size-small dsn-button--icon-only">
+      <svg class="dsn-icon" aria-hidden="true"><!-- x --></svg>
+      <span class="dsn-button__label">Sluiten</span>
+    </button>
+  </div>
+  <div class="dsn-drawer__body">
+    <p class="dsn-paragraph">Tekst</p>
+  </div>
+  <div class="dsn-drawer__footer">
+    <div class="dsn-action-group">
+      <button type="button" class="dsn-button dsn-button--strong dsn-button--size-medium">
+        <span class="dsn-button__label">Toepassen</span>
+      </button>
+      <button type="button" class="dsn-button dsn-button--default dsn-button--size-medium">
+        <span class="dsn-button__label">Annuleren</span>
+      </button>
+    </div>
+  </div>
+</dialog>`}
+/>
+
+<Controls of={DrawerStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/Drawer.stories.tsx
+++ b/packages/storybook/src/Drawer.stories.tsx
@@ -1,0 +1,333 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Drawer,
+  DrawerHeader,
+  DrawerHeading,
+  DrawerBody,
+  DrawerFooter,
+  ActionGroup,
+  Button,
+  Paragraph,
+} from '@dsn/components-react';
+import {
+  TEKST,
+  VEEL_TEKST,
+  TEKST_AR,
+  VEEL_TEKST_AR,
+  rtlDecorator,
+} from './story-helpers';
+
+const meta: Meta<typeof Drawer> = {
+  title: 'Components/Drawer',
+  component: Drawer,
+  parameters: {
+    dsn: {
+      htmlTemplate: () => {
+        return `<button type="button" class="dsn-button dsn-button--default dsn-button--size-medium" onclick="this.nextElementSibling.showModal()">
+  <span class="dsn-button__label">Zijpaneel openen</span>
+</button>
+<dialog class="dsn-drawer dsn-drawer--side-right" aria-labelledby="drawer-title">
+  <div class="dsn-drawer__header">
+    <h2 class="dsn-drawer-heading" id="drawer-title">Zijpaneel titel</h2>
+    <button type="button" class="dsn-button dsn-button--subtle dsn-button--size-small dsn-button--icon-only" onclick="this.closest('dialog').close()">
+      <svg class="dsn-icon" aria-hidden="true"><!-- x --></svg>
+      <span class="dsn-button__label">Sluiten</span>
+    </button>
+  </div>
+  <div class="dsn-drawer__body">
+    <p class="dsn-paragraph">${TEKST}</p>
+  </div>
+  <div class="dsn-drawer__footer">
+    <div class="dsn-action-group">
+      <button type="button" class="dsn-button dsn-button--strong dsn-button--size-medium" onclick="this.closest('dialog').close()">
+        <span class="dsn-button__label">Toepassen</span>
+      </button>
+      <button type="button" class="dsn-button dsn-button--default dsn-button--size-medium" onclick="this.closest('dialog').close()">
+        <span class="dsn-button__label">Annuleren</span>
+      </button>
+    </div>
+  </div>
+</dialog>`;
+      },
+    },
+  },
+  argTypes: {
+    isOpen: { control: false },
+    onClose: { control: false },
+    children: { control: false },
+    modal: {
+      control: 'boolean',
+      description:
+        'Modaal (`true`): achtergrond geblokkeerd via `.showModal()`. Non-modaal (`false`): achtergrond blijft interactief.',
+    },
+    side: {
+      control: 'radio',
+      options: ['right', 'left'],
+      description: 'De kant van de viewport vanwaar het zijpaneel inschuift.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+// =============================================================================
+// Helper: trigger + drawer wrapper
+// =============================================================================
+
+function DrawerWithTrigger({
+  triggerLabel = 'Zijpaneel openen',
+  modal = true,
+  side = 'right' as const,
+  children,
+}: {
+  triggerLabel?: string;
+  modal?: boolean;
+  side?: 'right' | 'left';
+  children: (close: () => void) => React.ReactNode;
+}) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  return (
+    <>
+      <Button variant="default" onClick={() => setIsOpen(true)}>
+        {triggerLabel}
+      </Button>
+      <Drawer
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        modal={modal}
+        side={side}
+      >
+        {children(() => setIsOpen(false))}
+      </Drawer>
+    </>
+  );
+}
+
+// =============================================================================
+// DEFAULT (modal, side-right)
+// =============================================================================
+
+export const Default: Story = {
+  args: {
+    modal: true,
+    side: 'right',
+  },
+  render: (args) => (
+    <DrawerWithTrigger modal={args.modal} side={args.side}>
+      {(close) => (
+        <>
+          <DrawerHeader>
+            <DrawerHeading>Zijpaneel titel</DrawerHeading>
+          </DrawerHeader>
+          <DrawerBody>
+            <Paragraph>{TEKST}</Paragraph>
+          </DrawerBody>
+          <DrawerFooter>
+            <ActionGroup>
+              <Button variant="strong" onClick={close}>
+                Toepassen
+              </Button>
+              <Button variant="default" onClick={close}>
+                Annuleren
+              </Button>
+            </ActionGroup>
+          </DrawerFooter>
+        </>
+      )}
+    </DrawerWithTrigger>
+  ),
+};
+
+// =============================================================================
+// NON-MODAL
+// =============================================================================
+
+export const NonModal: Story = {
+  name: 'Non-modal (achtergrond interactief)',
+  render: () => (
+    <DrawerWithTrigger triggerLabel="Non-modal zijpaneel openen" modal={false}>
+      {(close) => (
+        <>
+          <DrawerHeader>
+            <DrawerHeading>Filteropties</DrawerHeading>
+          </DrawerHeader>
+          <DrawerBody>
+            <Paragraph>
+              De achtergrondpagina blijft interactief. Gebruik dit voor
+              filtervensters waarbij de gebruiker de resultaten live wil
+              bijwerken.
+            </Paragraph>
+          </DrawerBody>
+          <DrawerFooter>
+            <ActionGroup>
+              <Button variant="strong" onClick={close}>
+                Filters toepassen
+              </Button>
+              <Button variant="default" onClick={close}>
+                Wissen
+              </Button>
+            </ActionGroup>
+          </DrawerFooter>
+        </>
+      )}
+    </DrawerWithTrigger>
+  ),
+};
+
+// =============================================================================
+// SIDE LEFT
+// =============================================================================
+
+export const SideLeft: Story = {
+  name: 'Side: Left',
+  render: () => (
+    <DrawerWithTrigger triggerLabel="Zijpaneel links openen" side="left">
+      {(close) => (
+        <>
+          <DrawerHeader>
+            <DrawerHeading>Navigatie</DrawerHeading>
+          </DrawerHeader>
+          <DrawerBody>
+            <Paragraph>{TEKST}</Paragraph>
+          </DrawerBody>
+          <DrawerFooter>
+            <ActionGroup>
+              <Button variant="default" onClick={close}>
+                Sluiten
+              </Button>
+            </ActionGroup>
+          </DrawerFooter>
+        </>
+      )}
+    </DrawerWithTrigger>
+  ),
+};
+
+// =============================================================================
+// WITH LONG CONTENT
+// =============================================================================
+
+export const WithLongContent: Story = {
+  name: 'With long content (scrollable body)',
+  render: () => (
+    <DrawerWithTrigger triggerLabel="Uitgebreid zijpaneel openen">
+      {(close) => (
+        <>
+          <DrawerHeader>
+            <DrawerHeading>Uitgebreide informatie</DrawerHeading>
+          </DrawerHeader>
+          <DrawerBody>
+            <Paragraph>{VEEL_TEKST}</Paragraph>
+            <Paragraph>{VEEL_TEKST}</Paragraph>
+            <Paragraph>{VEEL_TEKST}</Paragraph>
+            <Paragraph>{VEEL_TEKST}</Paragraph>
+            <Paragraph>{VEEL_TEKST}</Paragraph>
+          </DrawerBody>
+          <DrawerFooter>
+            <ActionGroup>
+              <Button variant="strong" onClick={close}>
+                Toepassen
+              </Button>
+              <Button variant="default" onClick={close}>
+                Annuleren
+              </Button>
+            </ActionGroup>
+          </DrawerFooter>
+        </>
+      )}
+    </DrawerWithTrigger>
+  ),
+};
+
+// =============================================================================
+// SHORT TEXT
+// =============================================================================
+
+export const ShortText: Story = {
+  name: 'Short text',
+  render: () => (
+    <DrawerWithTrigger triggerLabel="A">
+      {(close) => (
+        <>
+          <DrawerHeader>
+            <DrawerHeading>A</DrawerHeading>
+          </DrawerHeader>
+          <DrawerBody>
+            <Paragraph>A</Paragraph>
+          </DrawerBody>
+          <DrawerFooter>
+            <ActionGroup>
+              <Button variant="strong" onClick={close}>
+                A
+              </Button>
+            </ActionGroup>
+          </DrawerFooter>
+        </>
+      )}
+    </DrawerWithTrigger>
+  ),
+};
+
+// =============================================================================
+// RTL
+// =============================================================================
+
+export const RTL: Story = {
+  name: 'RTL',
+  decorators: [rtlDecorator],
+  render: () => (
+    <div dir="rtl" lang="ar">
+      <DrawerWithTrigger triggerLabel={TEKST_AR}>
+        {(close) => (
+          <>
+            <DrawerHeader>
+              <DrawerHeading>{TEKST_AR}</DrawerHeading>
+            </DrawerHeader>
+            <DrawerBody>
+              <Paragraph>{TEKST_AR}</Paragraph>
+            </DrawerBody>
+            <DrawerFooter>
+              <ActionGroup>
+                <Button variant="strong" onClick={close}>
+                  {TEKST_AR}
+                </Button>
+              </ActionGroup>
+            </DrawerFooter>
+          </>
+        )}
+      </DrawerWithTrigger>
+    </div>
+  ),
+};
+
+export const RTLLongText: Story = {
+  name: 'RTL long text',
+  decorators: [rtlDecorator],
+  render: () => (
+    <div dir="rtl" lang="ar">
+      <DrawerWithTrigger triggerLabel={TEKST_AR}>
+        {(close) => (
+          <>
+            <DrawerHeader>
+              <DrawerHeading>{TEKST_AR}</DrawerHeading>
+            </DrawerHeader>
+            <DrawerBody>
+              <Paragraph>{VEEL_TEKST_AR}</Paragraph>
+              <Paragraph>{VEEL_TEKST_AR}</Paragraph>
+              <Paragraph>{VEEL_TEKST_AR}</Paragraph>
+            </DrawerBody>
+            <DrawerFooter>
+              <ActionGroup>
+                <Button variant="strong" onClick={close}>
+                  {TEKST_AR}
+                </Button>
+              </ActionGroup>
+            </DrawerFooter>
+          </>
+        )}
+      </DrawerWithTrigger>
+    </div>
+  ),
+};


### PR DESCRIPTION
Sluit #115.

## Summary

- Implementeert het `Drawer` component als native `<dialog>`-element
- Modal variant (`.showModal()`) met `::backdrop` en native focus-trap
- Non-modal variant (`.show()`) met handmatige Escape-listener, achtergrond blijft interactief
- Slide-animatie via `@starting-style` + `translateX` (rechts of links)
- Scroll-affordance schaduw in `DrawerBody` (Lea Verou techniek, zelfde als ModalDialog)
- 19 design tokens, geen border-radius, border alleen aan de kant van de pagina
- Storybook controls voor `side` en `modal` op de Default story

## Components

- `Drawer` — root, context provider, `isOpen` / `onClose` / `modal` / `side` props
- `DrawerHeader` — flex container met sluitknop via context
- `DrawerHeading` — semantische heading, auto-gekoppeld via `aria-labelledby`
- `DrawerBody` — scrollbare sectie met scroll-affordance
- `DrawerFooter` — actieknoppen container

## Test plan

- [x] `pnpm test` — 1169 tests, 57 suites, allemaal groen
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [x] Visueel geverifieerd in Storybook: Default (right), Side Left, backdrop, controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)