### PR TITLE
chore: repo-URLs bijwerken na hernaming naar design-system-starter-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ MIT - Jeffrey Lauwers
 ## Links
 
 - [Repository](https://github.com/jeffreylauwers/design-system-starter-kit)
-- [Live Storybook](https://jeffreylauwers.github.io/design-system-starterkit/)
+- [Live Storybook](https://jeffreylauwers.github.io/design-system-starter-kit/)
 - [Documentation](./docs/)
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -710,7 +710,7 @@ The component architecture was refactored in v4.2.0 but tests weren't updated:
 **GitHub Pages Setup**
 
 - **Automated Storybook deployment** — GitHub Actions workflow deploys Storybook to GitHub Pages on every push to main
-- **Live Storybook URL** — [https://jeffreylauwers.github.io/design-system-starterkit/](https://jeffreylauwers.github.io/design-system-starterkit/)
+- **Live Storybook URL** — [https://jeffreylauwers.github.io/design-system-starter-kit/](https://jeffreylauwers.github.io/design-system-starter-kit/)
 - **Base path configuration** — Vite base path configured via `STORYBOOK_BASE_PATH` environment variable
 - **Relative asset paths** — Design tokens use relative paths (`./design-tokens/dist/css`) for GitHub Pages compatibility
 

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "storybook dev -p 6006",
     "build": "storybook build -o dist",
-    "build:gh-pages": "STORYBOOK_BASE_PATH=/design-system-starterkit/ storybook build -o dist",
+    "build:gh-pages": "STORYBOOK_BASE_PATH=/design-system-starter-kit/ storybook build -o dist",
     "test-storybook": "test-storybook",
     "clean": "rm -rf dist"
   },

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -33,7 +33,7 @@ Het design system bestaat uit meerdere packages:
 <Markdown>
 {`\`\`\`bash
 # Clone de repository
-git clone https://github.com/jeffreylauwers/design-system-starterkit.git
+git clone https://github.com/jeffreylauwers/design-system-starter-kit.git
 
 # Installeer dependencies
 pnpm install
@@ -128,8 +128,8 @@ Gebruik de toolbar bovenaan om te wisselen tussen:
 
 ## Bronnen
 
-- [GitHub Repository](https://github.com/jeffreylauwers/design-system-starterkit)
-- [Storybook (live)](https://jeffreylauwers.github.io/design-system-starterkit/)
+- [GitHub Repository](https://github.com/jeffreylauwers/design-system-starter-kit)
+- [Storybook (live)](https://jeffreylauwers.github.io/design-system-starter-kit/)
 - Documentatie per component — Zie de individuele component pagina's
 
 ## Development


### PR DESCRIPTION
## Summary

- Alle verwijzingen naar de oude repo-naam `design-system-starterkit` bijgewerkt naar `design-system-starter-kit`
- Aangepaste bestanden: `README.md`, `docs/changelog.md`, `packages/storybook/package.json`, `packages/storybook/src/Introduction.mdx`
- Belangrijk: `STORYBOOK_BASE_PATH` in `package.json` aangepast zodat de GitHub Pages deployment correct blijft werken

## Test plan

- [ ] CI groen (lint, type-check, tests)
- [ ] Storybook build slaagt met nieuwe base path

🤖 Generated with [Claude Code](https://claude.com/claude-code)