### PR TITLE
feat(MenuLink): navigatielink met level-hiërarchie, current-state en uitklapbare subnavigatie

### DIFF
--- a/packages/components-html/src/menu-link/menu-link.css
+++ b/packages/components-html/src/menu-link/menu-link.css
@@ -1,0 +1,187 @@
+/**
+ * MenuLink Component
+ * Navigatielink met niveau-hiërarchie, actieve staat en uitklapbare subnavigatie.
+ * Semantisch een `<a>`, visueel consistent met MenuButton.
+ *
+ * Structuur:
+ * <li class="dsn-menu-link">
+ *   <a class="dsn-menu-link__link" href="/pagina">
+ *     <svg class="dsn-icon" aria-hidden="true"><!-- icoon-start --></svg>
+ *     <span class="dsn-menu-link__label">Pagina</span>
+ *     <span class="dsn-number-badge dsn-number-badge--negative" aria-hidden="true">5</span>
+ *     <svg class="dsn-icon" aria-hidden="true"><!-- icoon-end --></svg>
+ *   </a>
+ *   <!-- optioneel: scheidingslijn + uitklapknop -->
+ *   <span class="dsn-menu-link__divider" aria-hidden="true"></span>
+ *   <button type="button" class="dsn-button dsn-button--subtle dsn-button--size-small dsn-button--icon-only dsn-menu-link__expand-button" aria-expanded="false">
+ *     <svg class="dsn-icon" aria-hidden="true"><!-- chevron-right --></svg>
+ *     <span class="dsn-button__label">
+ *       Uitklappen
+ *       <span class="dsn-visually-hidden"> voor Pagina</span>
+ *     </span>
+ *   </button>
+ * </li>
+ *
+ * Niveau-varianten (op het <li>-element):
+ *   dsn-menu-link--level-2   (1× level-indent via margin-inline-start)
+ *   dsn-menu-link--level-3   (2× level-indent via margin-inline-start)
+ *   dsn-menu-link--level-4   (3× level-indent via margin-inline-start)
+ *
+ * Actieve pagina — border-inline-start indicator op de <a>:
+ *   aria-current="page" op het <a>-element → current-kleuren + indicator
+ *
+ * Uitklapbaar:
+ *   aria-expanded="true/false" op dsn-menu-link__expand-button
+ */
+
+/* =============================================================================
+   List item
+   ============================================================================= */
+
+.dsn-menu-link {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: stretch;
+  /* Ruimte tussen de link, de scheiding en de uitklapknop */
+  column-gap: var(--dsn-space-inline-sm);
+}
+
+/* =============================================================================
+   Link
+   ============================================================================= */
+
+.dsn-menu-link__link {
+  display: inline-flex;
+  align-items: center;
+  flex: 1;
+  gap: var(--dsn-menu-link-gap);
+  padding-block: var(--dsn-menu-link-padding-block);
+  padding-inline: var(--dsn-menu-link-padding-inline);
+  font-family: inherit;
+  font-size: var(--dsn-menu-link-font-size);
+  font-weight: var(--dsn-menu-link-font-weight);
+  line-height: var(--dsn-menu-link-line-height);
+  text-decoration: none;
+  color: var(--dsn-menu-link-color);
+  background-color: var(--dsn-menu-link-background-color);
+  transition:
+    background-color var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default),
+    color var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default);
+}
+
+.dsn-menu-link__link > .dsn-icon {
+  width: var(--dsn-menu-link-icon-size);
+  height: var(--dsn-menu-link-icon-size);
+  flex-shrink: 0;
+}
+
+.dsn-menu-link__label {
+  /* Geen flex: 1 — badge en iconEnd staan direct achter de tekst.
+     De <a> zelf is flex: 1 en vult de volledige breedte. */
+}
+
+/* =============================================================================
+   States
+   ============================================================================= */
+
+.dsn-menu-link__link:hover {
+  color: var(--dsn-menu-link-hover-color);
+  background-color: var(--dsn-menu-link-hover-background-color);
+}
+
+.dsn-menu-link__link:active {
+  color: var(--dsn-menu-link-active-color);
+  background-color: var(--dsn-menu-link-active-background-color);
+}
+
+.dsn-menu-link__link:focus-visible {
+  background-color: var(--dsn-focus-background-color);
+  color: var(--dsn-focus-color);
+  outline: var(--dsn-focus-outline-width) var(--dsn-focus-outline-style)
+    var(--dsn-focus-outline-color);
+  outline-offset: var(--dsn-focus-outline-offset);
+  box-shadow: 0 0 0
+    calc(var(--dsn-focus-outline-offset) + var(--dsn-focus-outline-width))
+    var(--dsn-focus-inverse-outline-color);
+}
+
+/* =============================================================================
+   Current (actieve pagina) — border-inline-start indicator
+   ============================================================================= */
+
+.dsn-menu-link__link[aria-current='page'] {
+  color: var(--dsn-menu-link-current-color);
+  background-color: var(--dsn-menu-link-current-background-color);
+  border-inline-start: var(--dsn-menu-link-current-indicator-width) solid
+    var(--dsn-menu-link-current-indicator-color);
+  /* Compenseer de indicator-breedte zodat de tekst horizontaal uitlijnt met niet-actieve items */
+  padding-inline-start: calc(
+    var(--dsn-menu-link-padding-inline) -
+      var(--dsn-menu-link-current-indicator-width)
+  );
+}
+
+.dsn-menu-link__link[aria-current='page']:hover {
+  color: var(--dsn-menu-link-current-hover-color);
+  background-color: var(--dsn-menu-link-current-hover-background-color);
+}
+
+.dsn-menu-link__link[aria-current='page']:active {
+  color: var(--dsn-menu-link-current-active-color);
+  background-color: var(--dsn-menu-link-current-active-background-color);
+}
+
+/* =============================================================================
+   Niveau-inspringing (level-indent) — via margin-inline-start
+   Zodat de border-inline-start indicator dicht bij de tekst blijft.
+   ============================================================================= */
+
+.dsn-menu-link--level-2 .dsn-menu-link__link {
+  margin-inline-start: var(--dsn-menu-link-level-indent);
+}
+
+.dsn-menu-link--level-3 .dsn-menu-link__link {
+  margin-inline-start: calc(2 * var(--dsn-menu-link-level-indent));
+}
+
+.dsn-menu-link--level-4 .dsn-menu-link__link {
+  margin-inline-start: calc(3 * var(--dsn-menu-link-level-indent));
+}
+
+/* =============================================================================
+   Scheidingslijn (divider) — losse <span> tussen link en uitklapknop
+   ============================================================================= */
+
+.dsn-menu-link__divider {
+  display: block;
+  flex-shrink: 0;
+  inline-size: 1px;
+  align-self: stretch;
+  background-color: var(--dsn-color-neutral-border-subtle);
+}
+
+/* =============================================================================
+   Uitklapknop (expand button)
+   ============================================================================= */
+
+.dsn-menu-link__expand-button {
+  flex-shrink: 0;
+}
+
+/* Chevron (chevron-down) — 180° rotatie wanneer uitgevouwen, zelfde als Details */
+.dsn-menu-link__expand-button > .dsn-icon {
+  transition: transform var(--dsn-transition-duration-normal)
+    var(--dsn-transition-easing-default);
+}
+
+.dsn-menu-link__expand-button[aria-expanded='false'] > .dsn-icon {
+  transform: rotate(0deg);
+}
+
+.dsn-menu-link__expand-button[aria-expanded='true'] > .dsn-icon {
+  transform: rotate(180deg);
+}

--- a/packages/components-react/src/MenuLink/MenuLink.css
+++ b/packages/components-react/src/MenuLink/MenuLink.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/menu-link/menu-link.css';

--- a/packages/components-react/src/MenuLink/MenuLink.test.tsx
+++ b/packages/components-react/src/MenuLink/MenuLink.test.tsx
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MenuLink } from './MenuLink';
+
+describe('MenuLink', () => {
+  // ---------------------------------------------------------------------------
+  // Structuur
+  // ---------------------------------------------------------------------------
+
+  it('renders een <li> met een <a> erin', () => {
+    const { container } = render(<MenuLink href="/test">Pagina</MenuLink>);
+    const li = container.firstChild;
+    expect(li?.nodeName).toBe('LI');
+    const a = li?.firstChild;
+    expect(a?.nodeName).toBe('A');
+  });
+
+  it('heeft de basis dsn-menu-link klasse op het <li>-element', () => {
+    const { container } = render(<MenuLink href="/test">Pagina</MenuLink>);
+    expect(container.firstChild).toHaveClass('dsn-menu-link');
+  });
+
+  it('heeft de dsn-menu-link__link klasse op het <a>-element', () => {
+    render(<MenuLink href="/test">Pagina</MenuLink>);
+    const a = document.querySelector('a');
+    expect(a).toHaveClass('dsn-menu-link__link');
+  });
+
+  it('rendert children in een dsn-menu-link__label span', () => {
+    const { container } = render(<MenuLink href="/test">Pagina</MenuLink>);
+    const label = container.querySelector('.dsn-menu-link__label');
+    expect(label).toBeTruthy();
+    expect(label?.textContent).toBe('Pagina');
+  });
+
+  it('stuurt href door naar het <a>-element', () => {
+    render(<MenuLink href="/dashboard">Dashboard</MenuLink>);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/dashboard');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Level
+  // ---------------------------------------------------------------------------
+
+  it('voegt geen level-modifier toe bij level 1 (default)', () => {
+    const { container } = render(<MenuLink href="/test">Pagina</MenuLink>);
+    const li = container.firstChild as HTMLElement;
+    expect(li.classList.contains('dsn-menu-link--level-1')).toBe(false);
+    expect(li.classList.contains('dsn-menu-link--level-2')).toBe(false);
+  });
+
+  it.each([2, 3, 4] as const)(
+    'voegt dsn-menu-link--level-%i toe bij level %i',
+    (level) => {
+      const { container } = render(
+        <MenuLink href="/test" level={level}>
+          Pagina
+        </MenuLink>
+      );
+      expect(container.firstChild).toHaveClass(`dsn-menu-link--level-${level}`);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Current
+  // ---------------------------------------------------------------------------
+
+  it('heeft geen aria-current bij current=false (default)', () => {
+    render(<MenuLink href="/test">Pagina</MenuLink>);
+    expect(screen.getByRole('link')).not.toHaveAttribute('aria-current');
+  });
+
+  it('heeft aria-current="page" bij current=true', () => {
+    render(
+      <MenuLink href="/test" current>
+        Pagina
+      </MenuLink>
+    );
+    expect(screen.getByRole('link')).toHaveAttribute('aria-current', 'page');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Iconen
+  // ---------------------------------------------------------------------------
+
+  it('rendert iconStart voor het label', () => {
+    const { container } = render(
+      <MenuLink href="/test" iconStart={<svg data-testid="icon-start" />}>
+        Pagina
+      </MenuLink>
+    );
+    const a = container.querySelector('a');
+    const children = Array.from(a?.children ?? []);
+    const iconIndex = children.findIndex(
+      (c) => c.getAttribute('data-testid') === 'icon-start'
+    );
+    const labelIndex = children.findIndex((c) =>
+      c.classList.contains('dsn-menu-link__label')
+    );
+    expect(iconIndex).toBeLessThan(labelIndex);
+  });
+
+  it('rendert iconEnd na het label', () => {
+    const { container } = render(
+      <MenuLink href="/test" iconEnd={<svg data-testid="icon-end" />}>
+        Pagina
+      </MenuLink>
+    );
+    const a = container.querySelector('a');
+    const children = Array.from(a?.children ?? []);
+    const iconIndex = children.findIndex(
+      (c) => c.getAttribute('data-testid') === 'icon-end'
+    );
+    const labelIndex = children.findIndex((c) =>
+      c.classList.contains('dsn-menu-link__label')
+    );
+    expect(iconIndex).toBeGreaterThan(labelIndex);
+  });
+
+  it('rendert numberBadge na het label', () => {
+    const { container } = render(
+      <MenuLink
+        href="/test"
+        numberBadge={
+          <span data-testid="badge" aria-hidden="true">
+            5
+          </span>
+        }
+      >
+        Pagina
+      </MenuLink>
+    );
+    const a = container.querySelector('a');
+    const children = Array.from(a?.children ?? []);
+    const badgeIndex = children.findIndex(
+      (c) => c.getAttribute('data-testid') === 'badge'
+    );
+    const labelIndex = children.findIndex((c) =>
+      c.classList.contains('dsn-menu-link__label')
+    );
+    expect(badgeIndex).toBeGreaterThan(labelIndex);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Expand button
+  // ---------------------------------------------------------------------------
+
+  it('toont geen uitklapknop als subItems=false (default)', () => {
+    const { container } = render(<MenuLink href="/test">Pagina</MenuLink>);
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('toont een uitklapknop als subItems=true', () => {
+    const { container } = render(
+      <MenuLink href="/test" subItems>
+        Pagina
+      </MenuLink>
+    );
+    expect(container.querySelector('button')).toBeTruthy();
+  });
+
+  it('heeft aria-expanded="false" op de uitklapknop als expanded=false', () => {
+    const { container } = render(
+      <MenuLink href="/test" subItems expanded={false}>
+        Pagina
+      </MenuLink>
+    );
+    expect(container.querySelector('button')).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+  });
+
+  it('heeft aria-expanded="true" op de uitklapknop als expanded=true', () => {
+    const { container } = render(
+      <MenuLink href="/test" subItems expanded>
+        Pagina
+      </MenuLink>
+    );
+    expect(container.querySelector('button')).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+  });
+
+  it('roept onExpandToggle aan bij klik op de uitklapknop', async () => {
+    const user = userEvent.setup();
+    const handleToggle = vi.fn();
+    const { container } = render(
+      <MenuLink href="/test" subItems onExpandToggle={handleToggle}>
+        Pagina
+      </MenuLink>
+    );
+    await user.click(container.querySelector('button')!);
+    expect(handleToggle).toHaveBeenCalledOnce();
+  });
+
+  it('toont "Uitklappen voor Pagina" als de children een string is', () => {
+    const { container } = render(
+      <MenuLink href="/test" subItems>
+        Pagina
+      </MenuLink>
+    );
+    const button = container.querySelector('button');
+    expect(button?.textContent).toContain('Uitklappen');
+    expect(button?.textContent).toContain('voor Pagina');
+  });
+
+  it('toont "Inklappen" als expanded=true', () => {
+    const { container } = render(
+      <MenuLink href="/test" subItems expanded>
+        Pagina
+      </MenuLink>
+    );
+    const button = container.querySelector('button');
+    expect(button?.textContent).toContain('Inklappen');
+  });
+
+  it('heeft dsn-menu-link__expand-button klasse op de uitklapknop', () => {
+    const { container } = render(
+      <MenuLink href="/test" subItems>
+        Pagina
+      </MenuLink>
+    );
+    expect(container.querySelector('button')).toHaveClass(
+      'dsn-menu-link__expand-button'
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Accessibility
+  // ---------------------------------------------------------------------------
+
+  it('heeft type="button" op de uitklapknop', () => {
+    const { container } = render(
+      <MenuLink href="/test" subItems>
+        Pagina
+      </MenuLink>
+    );
+    expect(container.querySelector('button')).toHaveAttribute('type', 'button');
+  });
+
+  // ---------------------------------------------------------------------------
+  // className en ref
+  // ---------------------------------------------------------------------------
+
+  it('past className toe op het <li>-element', () => {
+    const { container } = render(
+      <MenuLink href="/test" className="custom">
+        Pagina
+      </MenuLink>
+    );
+    expect(container.firstChild).toHaveClass('custom');
+    expect(container.firstChild).toHaveClass('dsn-menu-link');
+  });
+
+  it('stuurt HTML-attributen door naar het <a>-element', () => {
+    render(
+      <MenuLink href="/test" data-testid="my-link">
+        Pagina
+      </MenuLink>
+    );
+    expect(screen.getByTestId('my-link').nodeName).toBe('A');
+  });
+
+  it('forwards ref naar het <a>-element', () => {
+    const ref = { current: null as HTMLAnchorElement | null };
+    render(
+      <MenuLink href="/test" ref={ref}>
+        Pagina
+      </MenuLink>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
+  });
+});

--- a/packages/components-react/src/MenuLink/MenuLink.tsx
+++ b/packages/components-react/src/MenuLink/MenuLink.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import { Icon } from '../Icon';
+import './MenuLink.css';
+
+export type MenuLinkLevel = 1 | 2 | 3 | 4;
+
+export interface MenuLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  /**
+   * Navigatie-URL van de link
+   */
+  href?: string;
+
+  /**
+   * Hiërarchisch niveau — bepaalt de `padding-inline-start` inspringing
+   * @default 1
+   */
+  level?: MenuLinkLevel;
+
+  /**
+   * Markeert de actieve/huidige pagina.
+   * Voegt `aria-current="page"` toe aan het `<a>`-element.
+   * @default false
+   */
+  current?: boolean;
+
+  /**
+   * Icoon links van het label
+   */
+  iconStart?: React.ReactNode;
+
+  /**
+   * Icoon rechts van het label — gebruik hier bij voorkeur geen NumberBadge (zie `numberBadge`)
+   */
+  iconEnd?: React.ReactNode;
+
+  /**
+   * NumberBadge element rechts van het label (naast iconEnd)
+   * Verwacht een `<NumberBadge>` component.
+   */
+  numberBadge?: React.ReactNode;
+
+  /**
+   * Toont een uitklapknop naast de link (voor subnavigatie).
+   * @default false
+   */
+  subItems?: boolean;
+
+  /**
+   * Geeft aan of de subnavigatie momenteel uitgevouwen is.
+   * Alleen relevant wanneer `subItems` true is.
+   * @default false
+   */
+  expanded?: boolean;
+
+  /**
+   * Callback die aangeroepen wordt wanneer op de uitklapknop geklikt wordt.
+   */
+  onExpandToggle?: () => void;
+
+  /**
+   * Zichtbare linktekst — ook gebruikt voor de toegankelijke naam van de uitklapknop
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Aanvullende CSS-klassen voor het `<li>`-element
+   */
+  className?: string;
+}
+
+/**
+ * MenuLink component
+ * Navigatielink met niveau-hiërarchie, actieve staat en uitklapbare subnavigatie.
+ * Semantisch een `<a>`, visueel consistent met MenuButton.
+ *
+ * Gebruik in een `<ul>`-element (het `<nav>`-element met lijst).
+ *
+ * @example
+ * ```tsx
+ * // Basisgebruik (level 1)
+ * <MenuLink href="/dashboard">Dashboard</MenuLink>
+ *
+ * // Actieve pagina
+ * <MenuLink href="/rapporten" current>Rapporten</MenuLink>
+ *
+ * // Level 2 (subpagina)
+ * <MenuLink href="/rapporten/maandelijks" level={2}>Maandelijks</MenuLink>
+ *
+ * // Met icoon en NumberBadge
+ * <MenuLink
+ *   href="/inbox"
+ *   iconStart={<Icon name="mail" aria-hidden />}
+ *   numberBadge={<NumberBadge variant="negative">5</NumberBadge>}
+ * >
+ *   Inbox
+ * </MenuLink>
+ *
+ * // Met uitklapknop
+ * <MenuLink
+ *   href="/rapporten"
+ *   subItems
+ *   expanded={isExpanded}
+ *   onExpandToggle={() => setIsExpanded(!isExpanded)}
+ * >
+ *   Rapporten
+ * </MenuLink>
+ * ```
+ */
+export const MenuLink = React.forwardRef<HTMLAnchorElement, MenuLinkProps>(
+  (
+    {
+      href,
+      level = 1,
+      current = false,
+      iconStart,
+      iconEnd,
+      numberBadge,
+      subItems = false,
+      expanded = false,
+      onExpandToggle,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const liClasses = classNames(
+      'dsn-menu-link',
+      level > 1 && `dsn-menu-link--level-${level}`,
+      className
+    );
+
+    const childrenText = typeof children === 'string' ? children : undefined;
+
+    return (
+      <li className={liClasses}>
+        <a
+          ref={ref}
+          className="dsn-menu-link__link"
+          href={href}
+          aria-current={current ? 'page' : undefined}
+          {...props}
+        >
+          {iconStart}
+          <span className="dsn-menu-link__label">{children}</span>
+          {numberBadge}
+          {iconEnd}
+        </a>
+
+        {subItems && (
+          <span className="dsn-menu-link__divider" aria-hidden="true" />
+        )}
+        {subItems && (
+          <button
+            type="button"
+            className="dsn-button dsn-button--subtle dsn-button--size-small dsn-button--icon-only dsn-menu-link__expand-button"
+            aria-expanded={expanded}
+            onClick={onExpandToggle}
+          >
+            <Icon name="chevron-down" aria-hidden />
+            <span className="dsn-button__label">
+              {expanded ? 'Inklappen' : 'Uitklappen'}
+              {childrenText && (
+                <span className="dsn-visually-hidden">
+                  {' '}
+                  voor {childrenText}
+                </span>
+              )}
+            </span>
+          </button>
+        )}
+      </li>
+    );
+  }
+);
+
+MenuLink.displayName = 'MenuLink';

--- a/packages/components-react/src/MenuLink/index.ts
+++ b/packages/components-react/src/MenuLink/index.ts
@@ -1,0 +1,1 @@
+export * from './MenuLink';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -59,6 +59,7 @@ export * from './Details';
 
 // Navigation Components
 export * from './BreadcrumbNavigation';
+export * from './MenuLink';
 
 // Form Field Components
 export * from './FormField';

--- a/packages/design-tokens/src/tokens/components/menu-link.json
+++ b/packages/design-tokens/src/tokens/components/menu-link.json
@@ -1,0 +1,126 @@
+{
+  "dsn": {
+    "menu-link": {
+      "font-size": {
+        "value": "{dsn.text.font-size.md}",
+        "type": "dimension",
+        "comment": "MenuLink font size"
+      },
+      "font-weight": {
+        "value": "{dsn.text.font-weight.default}",
+        "type": "fontWeight",
+        "comment": "MenuLink font weight — regular voor navigatielinks"
+      },
+      "line-height": {
+        "value": "{dsn.text.line-height.md}",
+        "type": "lineHeight",
+        "comment": "MenuLink line height"
+      },
+      "padding-block": {
+        "value": "{dsn.space.block.md}",
+        "type": "dimension",
+        "comment": "Verticale padding van de link"
+      },
+      "padding-inline": {
+        "value": "{dsn.space.inline.lg}",
+        "type": "dimension",
+        "comment": "Horizontale padding van de link"
+      },
+      "gap": {
+        "value": "{dsn.space.inline.md}",
+        "type": "dimension",
+        "comment": "Ruimte tussen icoon, label en badge"
+      },
+      "icon-size": {
+        "value": "{dsn.icon.size.md}",
+        "type": "dimension",
+        "comment": "Icoongrootte in de link"
+      },
+      "level-indent": {
+        "value": "{dsn.space.inline.3xl}",
+        "type": "dimension",
+        "comment": "Inspringing per hiërarchisch niveau (level 2–4) — via margin-inline-start op de link"
+      },
+      "color": {
+        "value": "{dsn.color.action-1.color-default}",
+        "type": "color",
+        "comment": "Standaard tekstkleur"
+      },
+      "background-color": {
+        "value": "{dsn.color.transparent}",
+        "type": "color",
+        "comment": "Standaard achtergrondkleur"
+      },
+      "hover": {
+        "color": {
+          "value": "{dsn.color.action-1.color-hover}",
+          "type": "color",
+          "comment": "Hover tekstkleur"
+        },
+        "background-color": {
+          "value": "{dsn.color.action-1.bg-hover}",
+          "type": "color",
+          "comment": "Hover achtergrondkleur"
+        }
+      },
+      "active": {
+        "color": {
+          "value": "{dsn.color.action-1.color-active}",
+          "type": "color",
+          "comment": "Active tekstkleur"
+        },
+        "background-color": {
+          "value": "{dsn.color.action-1.bg-active}",
+          "type": "color",
+          "comment": "Active achtergrondkleur"
+        }
+      },
+      "current": {
+        "color": {
+          "value": "{dsn.color.action-2.color-default}",
+          "type": "color",
+          "comment": "Tekstkleur voor de actieve/huidige pagina — niet inverse, volgt action-2 subtle-active stijl"
+        },
+        "background-color": {
+          "value": "{dsn.color.action-2.bg-active}",
+          "type": "color",
+          "comment": "Achtergrondkleur voor de actieve/huidige pagina — action-2.bg-active (zelfde als Button Subtle active)"
+        },
+        "indicator-color": {
+          "value": "{dsn.color.action-2.color-default}",
+          "type": "color",
+          "comment": "Kleur van de border-inline-start indicator bij de actieve pagina"
+        },
+        "indicator-width": {
+          "value": "3px",
+          "type": "dimension",
+          "comment": "Breedte van de border-inline-start indicator bij de actieve pagina"
+        },
+        "hover": {
+          "color": {
+            "value": "{dsn.color.action-2.color-default}",
+            "type": "color",
+            "comment": "Hover tekstkleur voor de actieve/huidige pagina"
+          },
+          "background-color": {
+            "value": "{dsn.color.action-2.bg-active}",
+            "type": "color",
+            "comment": "Hover achtergrondkleur voor de actieve/huidige pagina — blijft bg-active"
+          }
+        },
+        "active": {
+          "color": {
+            "value": "{dsn.color.action-2.color-default}",
+            "type": "color",
+            "comment": "Active tekstkleur voor de actieve/huidige pagina"
+          },
+          "background-color": {
+            "value": "{dsn.color.action-2.bg-active}",
+            "type": "color",
+            "comment": "Active achtergrondkleur voor de actieve/huidige pagina"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -61,7 +61,7 @@ function App() {
 
 ## Componenten overzicht
 
-**47 componenten totaal** — alle beschikbaar als HTML/CSS én React.
+**48 componenten totaal** — alle beschikbaar als HTML/CSS én React.
 
 ### Layout Components (5)
 
@@ -96,9 +96,10 @@ function App() {
 - **Card** — Configureerbare container voor gestructureerde content (afbeelding, heading, beschrijving, actie) met stretched-link techniek en CardGroup voor gelijke hoogte
 - **ModalDialog** — Modaal dialoogvenster voor korte, gefocuste acties (bevestigen, kleine keuze) — blokkeert achtergrond via native `<dialog>` met focus-trap
 
-### Navigation Components (1)
+### Navigation Components (2)
 
 - **BreadcrumbNavigation** — Hiërarchisch navigatiepad met compacte variant via container query
+- **MenuLink** — Navigatielink met niveau-hiërarchie (level 1–4), actieve pagina-staat en uitklapbare subnavigatie
 
 ### Form Components (25)
 

--- a/packages/storybook/src/MenuLink.docs.md
+++ b/packages/storybook/src/MenuLink.docs.md
@@ -1,0 +1,162 @@
+# MenuLink
+
+Navigatielink met niveau-hiërarchie, actieve staat en uitklapbare subnavigatie.
+
+## Doel
+
+MenuLink is een navigatie-item dat semantisch een `<a>`-element is en visueel consistent is met MenuButton. Het wordt gebruikt in primaire en secundaire navigatie — zoals een Page Header of Drawer.
+
+De `level`-prop (1–4) geeft de paginahiërarchie weer via toenemende `padding-inline-start`. De `current`-prop markeert de actieve pagina. Een uitklapknop verschijnt wanneer een pagina subpagina's heeft.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Je een navigatielink wil tonen in een menu of sidebar.
+- De link naar een URL navigeert (in tegenstelling tot `MenuButton` voor JS-acties).
+- Je een hiërarchie van paginaniveaus wil uitdrukken (niveau 1 t/m 4).
+- Je de actieve/huidige pagina wil markeren in de navigatie.
+- Een pagina subpagina's heeft die uitgevouwen kunnen worden.
+
+## Don't use when
+
+- De actie een JavaScript-handeling is (geen URL-navigatie) — gebruik dan `MenuButton`.
+- Je buiten een nav-context werkt — gebruik dan een reguliere `Button`, `ButtonLink` of `Link`.
+
+## Best practices
+
+### HTML-structuur
+
+MenuLink genereert een `<li>`-element en moet altijd binnen een `<ul>` geplaatst worden:
+
+```html
+<nav aria-label="Primaire navigatie">
+  <ul>
+    <li class="dsn-menu-link">
+      <a class="dsn-menu-link__link" href="/dashboard">
+        <svg class="dsn-icon" aria-hidden="true"><!-- home --></svg>
+        <span class="dsn-menu-link__label">Dashboard</span>
+      </a>
+    </li>
+    <li class="dsn-menu-link">
+      <a class="dsn-menu-link__link" href="/rapporten" aria-current="page">
+        <svg class="dsn-icon" aria-hidden="true"><!-- chart-bar --></svg>
+        <span class="dsn-menu-link__label">Rapporten</span>
+      </a>
+      <span class="dsn-menu-link__divider" aria-hidden="true"></span>
+      <button
+        type="button"
+        class="dsn-button dsn-button--subtle dsn-button--size-small dsn-button--icon-only dsn-menu-link__expand-button"
+        aria-expanded="true"
+      >
+        <svg class="dsn-icon" aria-hidden="true"><!-- chevron-down --></svg>
+        <span class="dsn-button__label">
+          Inklappen
+          <span class="dsn-visually-hidden"> voor Rapporten</span>
+        </span>
+      </button>
+    </li>
+    <li class="dsn-menu-link dsn-menu-link--level-2">
+      <a class="dsn-menu-link__link" href="/rapporten/maandelijks">
+        <span class="dsn-menu-link__label">Maandelijks</span>
+      </a>
+    </li>
+  </ul>
+</nav>
+```
+
+### Niveau-hiërarchie
+
+Gebruik `level` om de hiërarchische positie van een pagina uit te drukken. Level 1 is de basislaag — geen modifier-klasse in de DOM. Elk hoger niveau voegt een `padding-inline-start` toe via `dsn-menu-link--level-{n}`.
+
+```html
+<!-- Level 1 (standaard, geen modifier) -->
+<li class="dsn-menu-link">...</li>
+
+<!-- Level 2 -->
+<li class="dsn-menu-link dsn-menu-link--level-2">...</li>
+
+<!-- Level 3 -->
+<li class="dsn-menu-link dsn-menu-link--level-3">...</li>
+```
+
+### Actieve pagina (current)
+
+Gebruik `current` om de actieve pagina te markeren. Dit voegt `aria-current="page"` toe aan het `<a>`-element en past de visuele stijl aan.
+
+```html
+<a class="dsn-menu-link__link" href="/rapporten" aria-current="page">
+  <span class="dsn-menu-link__label">Rapporten</span>
+</a>
+```
+
+### NumberBadge
+
+Gebruik `numberBadge` om een telbadge rechts van het label te tonen. Voeg screenreader-context toe via `dsn-visually-hidden` in het label wanneer het getal afgekapt is:
+
+```html
+<a class="dsn-menu-link__link" href="/inbox">
+  <svg class="dsn-icon" aria-hidden="true"><!-- mail --></svg>
+  <span class="dsn-menu-link__label">
+    Inbox
+    <span class="dsn-visually-hidden">, 128 ongelezen berichten</span>
+  </span>
+  <span class="dsn-number-badge dsn-number-badge--negative" aria-hidden="true"
+    >99+</span
+  >
+</a>
+```
+
+### Uitklapknop
+
+De uitklapknop is een zelfstandige `<button>` naast de `<a>`. Gebruik altijd `aria-expanded` en geef de knop een toegankelijke naam via `dsn-button__label` met een `dsn-visually-hidden` span voor de paginanaam — nooit `aria-label`.
+
+```html
+<span class="dsn-menu-link__divider" aria-hidden="true"></span>
+<button
+  type="button"
+  class="dsn-button dsn-button--subtle dsn-button--size-small dsn-button--icon-only dsn-menu-link__expand-button"
+  aria-expanded="false"
+>
+  <svg class="dsn-icon" aria-hidden="true"><!-- chevron-down --></svg>
+  <span class="dsn-button__label">
+    Uitklappen
+    <span class="dsn-visually-hidden"> voor Rapporten</span>
+  </span>
+</button>
+```
+
+## Design tokens
+
+| Token                                             | Beschrijving                                                         |
+| ------------------------------------------------- | -------------------------------------------------------------------- |
+| `--dsn-menu-link-font-size`                       | Lettergrootte                                                        |
+| `--dsn-menu-link-font-weight`                     | Letterdikte (regular)                                                |
+| `--dsn-menu-link-line-height`                     | Regelhoogte                                                          |
+| `--dsn-menu-link-padding-block`                   | Verticale padding                                                    |
+| `--dsn-menu-link-padding-inline`                  | Horizontale padding                                                  |
+| `--dsn-menu-link-gap`                             | Ruimte tussen icoon en label                                         |
+| `--dsn-menu-link-icon-size`                       | Icoongrootte                                                         |
+| `--dsn-menu-link-level-indent`                    | Inspringing per niveau (level 2–4) via margin-inline-start           |
+| `--dsn-menu-link-color`                           | Tekstkleur (standaard)                                               |
+| `--dsn-menu-link-background-color`                | Achtergrondkleur (standaard)                                         |
+| `--dsn-menu-link-hover-color`                     | Tekstkleur bij hover                                                 |
+| `--dsn-menu-link-hover-background-color`          | Achtergrondkleur bij hover                                           |
+| `--dsn-menu-link-active-color`                    | Tekstkleur bij active                                                |
+| `--dsn-menu-link-active-background-color`         | Achtergrondkleur bij active                                          |
+| `--dsn-menu-link-current-color`                   | Tekstkleur voor de actieve/huidige pagina                            |
+| `--dsn-menu-link-current-background-color`        | Achtergrondkleur voor de actieve/huidige pagina (action-2.bg-active) |
+| `--dsn-menu-link-current-indicator-color`         | Kleur van de border-inline-start indicator                           |
+| `--dsn-menu-link-current-indicator-width`         | Breedte van de border-inline-start indicator (3px)                   |
+| `--dsn-menu-link-current-hover-color`             | Hover tekstkleur voor de actieve pagina                              |
+| `--dsn-menu-link-current-hover-background-color`  | Hover achtergrondkleur voor de actieve pagina                        |
+| `--dsn-menu-link-current-active-color`            | Active tekstkleur voor de actieve pagina                             |
+| `--dsn-menu-link-current-active-background-color` | Active achtergrondkleur voor de actieve pagina                       |
+
+## Accessibility
+
+- Gebruik `aria-current="page"` (via de `current` prop) om de actieve pagina aan screenreaders door te geven. Gebruik nooit enkel kleur om de actieve staat aan te duiden.
+- De uitklapknop gebruikt altijd `dsn-button__label` voor zijn toegankelijke naam — nooit `aria-label`. Voeg de paginanaam toe via een geneste `dsn-visually-hidden` span.
+- `aria-expanded` op de uitklapknop geeft de uit-/ingeklapte staat door aan screenreaders.
+- Het icoon in de link en de uitklapknop heeft altijd `aria-hidden="true"`.
+- Zorg dat de omliggende `<ul>` in een `<nav>` staat met een beschrijvende `aria-label`.

--- a/packages/storybook/src/MenuLink.docs.mdx
+++ b/packages/storybook/src/MenuLink.docs.mdx
@@ -1,0 +1,31 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as MenuLinkStories from './MenuLink.stories';
+import docs from './MenuLink.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={MenuLinkStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={MenuLinkStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={MenuLinkStories.Default}
+  html={`<ul style="list-style: none; margin: 0; padding: 0;">
+  <li class="dsn-menu-link">
+    <a class="dsn-menu-link__link" href="/dashboard">
+      <span class="dsn-menu-link__label">Dashboard</span>
+    </a>
+  </li>
+</ul>`}
+/>
+
+<Controls of={MenuLinkStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/MenuLink.stories.tsx
+++ b/packages/storybook/src/MenuLink.stories.tsx
@@ -1,0 +1,260 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Icon, MenuLink, NumberBadge } from '@dsn/components-react';
+import DocsPage from './MenuLink.docs.mdx';
+
+const meta: Meta<typeof MenuLink> = {
+  title: 'Components/MenuLink',
+  component: MenuLink,
+  parameters: {
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const level =
+          args.level && args.level > 1
+            ? ` dsn-menu-link--level-${args.level}`
+            : '';
+        const ariaCurrent = args.current ? ' aria-current="page"' : '';
+        return `<ul style="list-style: none; margin: 0; padding: 0;">\n  <li class="dsn-menu-link${level}">\n    <a class="dsn-menu-link__link" href="/pagina"${ariaCurrent}>\n      <span class="dsn-menu-link__label">${args.children ?? 'Dashboard'}</span>\n    </a>\n  </li>\n</ul>`;
+      },
+    },
+  },
+  argTypes: {
+    level: {
+      control: 'select',
+      options: [1, 2, 3, 4],
+    },
+    current: { control: 'boolean' },
+    subItems: { control: 'boolean' },
+    expanded: { control: 'boolean' },
+    children: { control: 'text' },
+  },
+  args: {
+    href: '/dashboard',
+    children: 'Dashboard',
+    level: 1,
+    current: false,
+    subItems: false,
+    expanded: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MenuLink>;
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {
+  render: (args) => (
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      <MenuLink {...args} />
+    </ul>
+  ),
+};
+
+// =============================================================================
+// CURRENT (ACTIEVE PAGINA)
+// =============================================================================
+
+export const Current: Story = {
+  name: 'Current (actieve pagina)',
+  args: { current: true, children: 'Rapporten' },
+  render: (args) => (
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      <MenuLink {...args} />
+    </ul>
+  ),
+};
+
+// =============================================================================
+// MET ICOON
+// =============================================================================
+
+export const WithIconStart: Story = {
+  name: 'Met icoon (iconStart)',
+  args: {
+    iconStart: <Icon name="home" aria-hidden />,
+    children: 'Dashboard',
+  },
+  render: (args) => (
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      <MenuLink {...args} />
+    </ul>
+  ),
+};
+
+export const WithNumberBadge: Story = {
+  name: 'Met NumberBadge',
+  args: {
+    href: '/inbox',
+    iconStart: <Icon name="mail" aria-hidden />,
+    numberBadge: <NumberBadge variant="negative">5</NumberBadge>,
+    children: 'Inbox',
+  },
+  render: (args) => (
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      <MenuLink {...args} />
+    </ul>
+  ),
+};
+
+// =============================================================================
+// NIVEAU-HIËRARCHIE
+// =============================================================================
+
+export const Levels: Story = {
+  name: 'Niveau-hiërarchie (level 1–4)',
+  render: () => (
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      <MenuLink href="/rapporten" current>
+        Rapporten
+      </MenuLink>
+      <MenuLink href="/rapporten/maandelijks" level={2}>
+        Maandelijks
+      </MenuLink>
+      <MenuLink href="/rapporten/maandelijks/januari" level={3}>
+        Januari
+      </MenuLink>
+      <MenuLink href="/rapporten/maandelijks/januari/week-1" level={4}>
+        Week 1
+      </MenuLink>
+    </ul>
+  ),
+};
+
+// =============================================================================
+// UITKLAPBAAR
+// =============================================================================
+
+export const WithExpandButton: Story = {
+  name: 'Met uitklapknop (subItems)',
+  args: {
+    href: '/rapporten',
+    children: 'Rapporten',
+    subItems: true,
+    expanded: false,
+  },
+  render: (args) => (
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      <MenuLink {...args} />
+    </ul>
+  ),
+};
+
+export const ExpandedWithSubItems: Story = {
+  name: "Uitgevouwen met subpagina's",
+  render: () => (
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      <MenuLink
+        href="/rapporten"
+        iconStart={<Icon name="file-description" aria-hidden />}
+        subItems
+        expanded
+      >
+        Rapporten
+      </MenuLink>
+      <MenuLink href="/rapporten/maandelijks" level={2}>
+        Maandelijks
+      </MenuLink>
+      <MenuLink href="/rapporten/kwartaal" level={2} current>
+        Kwartaal
+      </MenuLink>
+      <MenuLink href="/rapporten/jaarlijks" level={2}>
+        Jaarlijks
+      </MenuLink>
+    </ul>
+  ),
+};
+
+// =============================================================================
+// VOLLEDIG NAVIGATIEMENU
+// =============================================================================
+
+export const FullNavigation: Story = {
+  name: 'Volledig navigatiemenu',
+  render: () => (
+    <nav aria-label="Primaire navigatie" style={{ maxWidth: '280px' }}>
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+        <MenuLink
+          href="/dashboard"
+          iconStart={<Icon name="home" aria-hidden />}
+        >
+          Dashboard
+        </MenuLink>
+
+        <MenuLink
+          href="/inbox"
+          iconStart={<Icon name="mail" aria-hidden />}
+          numberBadge={<NumberBadge variant="negative">5</NumberBadge>}
+        >
+          Inbox
+        </MenuLink>
+
+        <MenuLink
+          href="/rapporten"
+          iconStart={<Icon name="file-description" aria-hidden />}
+          subItems
+          expanded
+          current
+        >
+          Rapporten
+        </MenuLink>
+
+        <MenuLink href="/rapporten/maandelijks" level={2}>
+          Maandelijks
+        </MenuLink>
+
+        <MenuLink href="/rapporten/kwartaal" level={2}>
+          Kwartaal
+        </MenuLink>
+
+        <MenuLink
+          href="/instellingen"
+          iconStart={<Icon name="settings" aria-hidden />}
+        >
+          Instellingen
+        </MenuLink>
+      </ul>
+    </nav>
+  ),
+};
+
+// =============================================================================
+// ALLE VARIANTEN
+// =============================================================================
+
+export const AllStates: Story = {
+  name: 'Alle staten',
+  render: () => (
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      <MenuLink href="/standaard">Standaard</MenuLink>
+      <MenuLink href="/actief" current>
+        Actief (current)
+      </MenuLink>
+      <MenuLink href="/icoon" iconStart={<Icon name="home" aria-hidden />}>
+        Met icoon
+      </MenuLink>
+      <MenuLink
+        href="/badge"
+        iconStart={<Icon name="mail" aria-hidden />}
+        numberBadge={<NumberBadge variant="negative">12</NumberBadge>}
+      >
+        Met NumberBadge
+      </MenuLink>
+      <MenuLink href="/uitklap" subItems>
+        Met uitklapknop
+      </MenuLink>
+      <MenuLink href="/level-2" level={2}>
+        Level 2
+      </MenuLink>
+      <MenuLink href="/level-3" level={3}>
+        Level 3
+      </MenuLink>
+      <MenuLink href="/level-4" level={4}>
+        Level 4
+      </MenuLink>
+    </ul>
+  ),
+};


### PR DESCRIPTION
Sluit #127.

## Summary

- Nieuwe `MenuLink` component — semantisch een `<a>` binnen een `<li>`, visueel consistent met MenuButton
- Level 1–4 hiërarchie via `margin-inline-start` op de link (indicator blijft dicht bij de tekst)
- Current state via `aria-current="page"` + `border-inline-start` indicator + `action-2.bg-active` achtergrond (subtiel, niet inverse)
- Uitklapknop met `chevron-down` (180° rotatie, zelfde als Details) en losse `<span>` als divider
- Ondersteuning voor `iconStart`, `iconEnd`, `NumberBadge`
- 26 tests, volledig TypeScript-schoon, 0 lint-fouten

## Test plan

- [ ] Storybook: Components / MenuLink — alle 8 stories controleren
- [ ] Current state: subtiele blauwe achtergrond + linker border-indicator zichtbaar
- [ ] Level 2–4: inspringing via margin (indicator dicht bij tekst)
- [ ] Uitklapknop: chevron-down wijst naar boven wanneer `expanded=true`
- [ ] Divider: losse `<span>` met gelijke witruimte aan weerszijden
- [ ] NumberBadge: direct achter de tekst (niet uiterst rechts)
- [ ] Dark mode en Wireframe theme: tokens correct toegepast
- [ ] `pnpm test` — alle 1213 tests groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)