### PR TITLE
feat(Navigation): MenuLink + MenuButton + gedeelde menu-item tokens (v5.18.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pnpm --filter @dsn/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (1187 tests across 58 test suites)
+# Run tests (1225 tests across 60 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -200,6 +200,14 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **NumberBadge** | Yes      | Yes   | —             |
 | **StatusBadge** | Yes      | Yes   | —             |
 | **Table**       | Yes      | Yes   | —             |
+
+**Navigation Components (3)**
+
+| Component                | HTML/CSS | React | Web Component |
+| ------------------------ | -------- | ----- | ------------- |
+| **BreadcrumbNavigation** | Yes      | Yes   | —             |
+| **MenuButton**           | Yes      | Yes   | —             |
+| **MenuLink**             | Yes      | Yes   | —             |
 
 **Form Components (25)**
 
@@ -374,7 +382,7 @@ Comprehensive documentation is available in the `/docs` folder:
 
 - **Pre-commit hooks** via Husky + lint-staged (ESLint + Prettier)
 - **Type checking** across all packages (`pnpm type-check`)
-- **1187 tests** covering React components, Web Components, and utilities
+- **1225 tests** covering React components, Web Components, and utilities
 - **CI/CD** via GitHub Actions (lint, type-check, test, build)
 
 ## Tech Stack

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1,6 +1,6 @@
 # Components
 
-**Last Updated:** April 3, 2026
+**Last Updated:** April 4, 2026
 
 Complete component specifications and guidelines for the Design System Starter Kit.
 
@@ -1586,7 +1586,7 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 ## Navigation Components
 
-**Status:** Complete (HTML/CSS, React) — 1 component total
+**Status:** Complete (HTML/CSS, React) — 3 components total
 
 ### BreadcrumbNavigation
 
@@ -1679,6 +1679,148 @@ const [isOpen, setIsOpen] = React.useState(false);
 **Placement:** Vóór `<main>`, na de primaire navigatie — zodat een skip-link alle navigatie in één keer kan overslaan.
 
 **Tests:** React (25 tests)
+
+---
+
+### MenuLink
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-{html|react}/src/MenuLink/`
+
+**Tokens:** `tokens/components/menu-item.json` (gedeeld) + `tokens/components/menu-link.json` (MenuLink-specifiek)
+
+**Props:** `href`, `level` (1–4), `current`, `iconStart`, `iconEnd`, `numberBadge`, `subItems`, `expanded`, `onExpandToggle`, `children`, `className`
+
+**Features:**
+
+- Semantisch een `<a>`, visueel consistent met MenuButton — gebruik voor URL-navigatie
+- Rendeert als `<li class="dsn-menu-link">` — altijd in een `<ul>` plaatsen
+- `level` prop (1–4) stelt hiërarchische inspringing in via `margin-inline-start` op de link
+- `current` prop voegt `aria-current="page"` toe en toont een `border-inline-start` indicator (3px)
+- `subItems` prop toont een uitklapknop naast de link; `expanded` beheert de open/dichte staat
+- `numberBadge` slot voor een `<NumberBadge>` rechts van het label
+- Gedeelde visuele stijl via `--dsn-menu-item-*` tokens; current-staat via `--dsn-menu-link-current-*`
+
+**CSS-klassen:**
+
+| Klasse                         | Element    | Beschrijving                                              |
+| ------------------------------ | ---------- | --------------------------------------------------------- |
+| `dsn-menu-link`                | `<li>`     | Basiscomponent — altijd aanwezig                          |
+| `dsn-menu-link--level-2`       | `<li>`     | Inspringing: 1× `level-indent`                            |
+| `dsn-menu-link--level-3`       | `<li>`     | Inspringing: 2× `level-indent`                            |
+| `dsn-menu-link--level-4`       | `<li>`     | Inspringing: 3× `level-indent`                            |
+| `dsn-menu-link__link`          | `<a>`      | De navigatielink — bevat icoon, label, badge              |
+| `dsn-menu-link__label`         | `<span>`   | Zichtbare linktekst                                       |
+| `dsn-menu-link__divider`       | `<span>`   | Decoratieve scheidingslijn tussen link en uitklapknop     |
+| `dsn-menu-link__expand-button` | `<button>` | Uitklapknop; `aria-expanded` toggle; chevron roteert 180° |
+
+**Usage:**
+
+```html
+<!-- HTML/CSS — level 1, standaard -->
+<ul style="list-style: none; margin: 0; padding: 0;">
+  <li class="dsn-menu-link">
+    <a class="dsn-menu-link__link" href="/dashboard">
+      <svg class="dsn-icon" aria-hidden="true"><!-- home --></svg>
+      <span class="dsn-menu-link__label">Dashboard</span>
+    </a>
+  </li>
+  <!-- level 2, actieve pagina -->
+  <li class="dsn-menu-link dsn-menu-link--level-2">
+    <a class="dsn-menu-link__link" href="/rapporten" aria-current="page">
+      <span class="dsn-menu-link__label">Rapporten</span>
+    </a>
+  </li>
+</ul>
+```
+
+```tsx
+// React
+<MenuLink href="/dashboard" iconStart={<Icon name="home" aria-hidden />}>
+  Dashboard
+</MenuLink>
+<MenuLink href="/rapporten" level={2} current>
+  Rapporten
+</MenuLink>
+<MenuLink href="/inbox" numberBadge={<NumberBadge variant="negative">5</NumberBadge>}>
+  Inbox
+</MenuLink>
+```
+
+**Tests:** React (27 tests)
+
+---
+
+### MenuButton
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-{html|react}/src/MenuButton/`
+
+**Tokens:** `tokens/components/menu-item.json` (gedeeld met MenuLink)
+
+**Props:** `iconStart`, `iconEnd`, `dotBadge`, `children`, `className` + alle native `<button>` attributen
+
+**Features:**
+
+- Semantisch een `<button>`, visueel consistent met MenuLink — gebruik voor JS-acties (uitloggen, modal openen, etc.)
+- Rendeert als `<li class="dsn-menu-button">` — altijd in een `<ul>` plaatsen
+- `dotBadge` slot voor een `<DotBadge>` die rechtsboven de tekst zweeft (gerenderd in de label-span, `position: relative`)
+- Geen disabled state — niet van toepassing in navigatiecontext
+- Volledig gedeelde visuele stijl via `--dsn-menu-item-*` tokens
+
+**CSS-klassen:**
+
+| Klasse                    | Element    | Beschrijving                                                             |
+| ------------------------- | ---------- | ------------------------------------------------------------------------ |
+| `dsn-menu-button`         | `<li>`     | Basiscomponent — altijd aanwezig                                         |
+| `dsn-menu-button__button` | `<button>` | De knop — button-reset + volledige breedte, flexbox layout               |
+| `dsn-menu-button__label`  | `<span>`   | Zichtbare knoptekst; `flex: 1`; `position: relative` voor dotBadge anker |
+
+**Usage:**
+
+```html
+<!-- HTML/CSS -->
+<ul style="list-style: none; margin: 0; padding: 0;">
+  <li class="dsn-menu-button">
+    <button type="button" class="dsn-menu-button__button">
+      <svg class="dsn-icon" aria-hidden="true"><!-- settings --></svg>
+      <span class="dsn-menu-button__label">Instellingen</span>
+    </button>
+  </li>
+  <!-- met DotBadge -->
+  <li class="dsn-menu-button">
+    <button type="button" class="dsn-menu-button__button">
+      <svg class="dsn-icon" aria-hidden="true"><!-- bell --></svg>
+      <span class="dsn-menu-button__label">
+        Meldingen
+        <span class="dsn-visually-hidden">, nieuwe meldingen beschikbaar</span>
+        <span
+          class="dsn-dot-badge dsn-dot-badge--negative"
+          aria-hidden="true"
+        ></span>
+      </span>
+    </button>
+  </li>
+</ul>
+```
+
+```tsx
+// React
+<MenuButton iconStart={<Icon name="settings" aria-hidden />}>
+  Instellingen
+</MenuButton>
+<MenuButton
+  iconStart={<Icon name="bell" aria-hidden />}
+  dotBadge={<DotBadge variant="negative" />}
+>
+  Meldingen
+  <span className="dsn-visually-hidden">, nieuwe meldingen beschikbaar</span>
+</MenuButton>
+```
+
+**Tests:** React (13 tests)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Design System Documentation
 
-**Version:** 5.16.0
-**Last Updated:** March 27, 2026
+**Version:** 5.18.0
+**Last Updated:** April 4, 2026
 
 Complete documentation voor het Design System Starter Kit.
 
@@ -91,8 +91,8 @@ Complete documentation voor het Design System Starter Kit.
 
 - **Tokens per configuration:** ~1100 (400 semantic + 700 component)
 - **Configurations:** 8 (2 themes × 2 modes × 2 project types)
-- **Components:** 46 (4 layout + 9 content + 8 display/feedback + 25 form + Drawer; HTML/CSS + React)
-- **Tests:** 1169 across 57 test suites
+- **Components:** 49 (5 layout + 10 content + 9 display/feedback + 3 navigation + 25 form; HTML/CSS + React)
+- **Tests:** 1225 across 60 test suites
 - **Storybook stories:** 130+
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,39 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 5.18.0 (April 4, 2026)
+
+### MenuButton component + gedeelde menu-item tokens
+
+#### Added
+
+- **MenuButton** component — navigatieknop voor JavaScript-acties (uitloggen, modal openen, etc.); semantisch een `<button>`, visueel identiek aan MenuLink
+- `iconStart`, `iconEnd`, `dotBadge` props; `dotBadge` zweeft rechtsboven de tekst via `position: relative` op de label-span
+- 13 React tests
+
+#### Changed
+
+- **Tokens gerefactored:** gedeelde visuele stijl van MenuLink en MenuButton samengebracht in nieuw bestand `tokens/components/menu-item.json` (`dsn.menu-item.*` namespace)
+- `tokens/components/menu-link.json` bevat nu alleen nog MenuLink-specifieke tokens (`current.*` en `level-indent`)
+- `tokens/components/menu-button.json` verwijderd — vervangen door de gedeelde `menu-item.json`
+- Kleurverwijzingen van MenuLink en MenuButton gewijzigd van `action-1` naar `action-2` — consistent met `Link`
+
+---
+
+### MenuLink component
+
+#### Added
+
+- **MenuLink** component — navigatielink met niveau-hiërarchie, actieve pagina-staat en uitklapbare subnavigatie
+- `level` prop (1–4): toenemende `padding-inline-start` inspringing via `margin-inline-start` op de link
+- `current` prop: `aria-current="page"` + visuele `border-inline-start` indicator (3px, `action-2` kleur)
+- `subItems` + `expanded` + `onExpandToggle`: uitklapknop naast de link met `aria-expanded` en roterende chevron
+- `iconStart`, `iconEnd`, `numberBadge` props
+- Storybook stories: Default, Current, Met icoon start/end, Met NumberBadge, Met uitklapknop, Niveauhiërarchie, Volledig navigatiemenu, Alle staten, RTL, RTL long text
+- 27 React tests
+
+---
+
 ## Version 5.17.0 (April 3, 2026)
 
 ### NumberBadge component (issue #130)

--- a/packages/components-html/src/menu-button/menu-button.css
+++ b/packages/components-html/src/menu-button/menu-button.css
@@ -1,0 +1,105 @@
+/**
+ * MenuButton Component
+ * Navigatieknop voor JS-acties met icoon- en badge-ondersteuning.
+ * Semantisch een `<button>`, visueel consistent met MenuLink.
+ *
+ * Gedeelde visuele stijl via --dsn-menu-item-* tokens (menu-item.json).
+ *
+ * Structuur:
+ * <li class="dsn-menu-button">
+ *   <button type="button" class="dsn-menu-button__button">
+ *     <svg class="dsn-icon" aria-hidden="true"><!-- icoon-start --></svg>
+ *     <span class="dsn-menu-button__label">Label</span>
+ *     <span class="dsn-dot-badge dsn-dot-badge--negative" aria-hidden="true"></span>
+ *     <svg class="dsn-icon" aria-hidden="true"><!-- icoon-end --></svg>
+ *   </button>
+ * </li>
+ */
+
+/* =============================================================================
+   List item
+   ============================================================================= */
+
+.dsn-menu-button {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* =============================================================================
+   Button
+   ============================================================================= */
+
+.dsn-menu-button__button {
+  /* Button reset */
+  appearance: none;
+  background: none;
+  border: 0;
+  cursor: pointer;
+
+  /* Layout */
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--dsn-menu-item-gap);
+  padding-block: var(--dsn-menu-item-padding-block);
+  padding-inline: var(--dsn-menu-item-padding-inline);
+
+  /* Typography */
+  font-family: inherit;
+  font-size: var(--dsn-menu-item-font-size);
+  font-weight: var(--dsn-menu-item-font-weight);
+  line-height: var(--dsn-menu-item-line-height);
+  text-align: start;
+
+  /* Colors */
+  color: var(--dsn-menu-item-color);
+  background-color: var(--dsn-menu-item-background-color);
+
+  /* Transitions */
+  transition:
+    background-color var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default),
+    color var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default);
+}
+
+.dsn-menu-button__button > .dsn-icon {
+  width: var(--dsn-menu-item-icon-size);
+  height: var(--dsn-menu-item-icon-size);
+  flex-shrink: 0;
+}
+
+.dsn-menu-button__label {
+  /* De <button> zelf is full-width via width: 100%.
+     Het label vult de resterende ruimte zodat iconEnd rechts uitlijnt.
+     position: relative zodat de dotBadge zich absoluut rechtsboven de tekst positioneert. */
+  flex: 1;
+  text-align: start;
+  position: relative;
+}
+
+/* =============================================================================
+   States
+   ============================================================================= */
+
+.dsn-menu-button__button:hover {
+  color: var(--dsn-menu-item-hover-color);
+  background-color: var(--dsn-menu-item-hover-background-color);
+}
+
+.dsn-menu-button__button:active {
+  color: var(--dsn-menu-item-active-color);
+  background-color: var(--dsn-menu-item-active-background-color);
+}
+
+.dsn-menu-button__button:focus-visible {
+  background-color: var(--dsn-focus-background-color);
+  color: var(--dsn-focus-color);
+  outline: var(--dsn-focus-outline-width) var(--dsn-focus-outline-style)
+    var(--dsn-focus-outline-color);
+  outline-offset: var(--dsn-focus-outline-offset);
+  box-shadow: 0 0 0
+    calc(var(--dsn-focus-outline-offset) + var(--dsn-focus-outline-width))
+    var(--dsn-focus-inverse-outline-color);
+}

--- a/packages/components-html/src/menu-link/menu-link.css
+++ b/packages/components-html/src/menu-link/menu-link.css
@@ -3,6 +3,9 @@
  * Navigatielink met niveau-hiërarchie, actieve staat en uitklapbare subnavigatie.
  * Semantisch een `<a>`, visueel consistent met MenuButton.
  *
+ * Gedeelde visuele stijl via --dsn-menu-item-* tokens (menu-item.json).
+ * MenuLink-specifieke tokens via --dsn-menu-link-* (current-staat, level-indent).
+ *
  * Structuur:
  * <li class="dsn-menu-link">
  *   <a class="dsn-menu-link__link" href="/pagina">
@@ -56,16 +59,16 @@
   display: inline-flex;
   align-items: center;
   flex: 1;
-  gap: var(--dsn-menu-link-gap);
-  padding-block: var(--dsn-menu-link-padding-block);
-  padding-inline: var(--dsn-menu-link-padding-inline);
+  gap: var(--dsn-menu-item-gap);
+  padding-block: var(--dsn-menu-item-padding-block);
+  padding-inline: var(--dsn-menu-item-padding-inline);
   font-family: inherit;
-  font-size: var(--dsn-menu-link-font-size);
-  font-weight: var(--dsn-menu-link-font-weight);
-  line-height: var(--dsn-menu-link-line-height);
+  font-size: var(--dsn-menu-item-font-size);
+  font-weight: var(--dsn-menu-item-font-weight);
+  line-height: var(--dsn-menu-item-line-height);
   text-decoration: none;
-  color: var(--dsn-menu-link-color);
-  background-color: var(--dsn-menu-link-background-color);
+  color: var(--dsn-menu-item-color);
+  background-color: var(--dsn-menu-item-background-color);
   transition:
     background-color var(--dsn-transition-duration-normal)
       var(--dsn-transition-easing-default),
@@ -74,8 +77,8 @@
 }
 
 .dsn-menu-link__link > .dsn-icon {
-  width: var(--dsn-menu-link-icon-size);
-  height: var(--dsn-menu-link-icon-size);
+  width: var(--dsn-menu-item-icon-size);
+  height: var(--dsn-menu-item-icon-size);
   flex-shrink: 0;
 }
 
@@ -89,13 +92,13 @@
    ============================================================================= */
 
 .dsn-menu-link__link:hover {
-  color: var(--dsn-menu-link-hover-color);
-  background-color: var(--dsn-menu-link-hover-background-color);
+  color: var(--dsn-menu-item-hover-color);
+  background-color: var(--dsn-menu-item-hover-background-color);
 }
 
 .dsn-menu-link__link:active {
-  color: var(--dsn-menu-link-active-color);
-  background-color: var(--dsn-menu-link-active-background-color);
+  color: var(--dsn-menu-item-active-color);
+  background-color: var(--dsn-menu-item-active-background-color);
 }
 
 .dsn-menu-link__link:focus-visible {
@@ -121,7 +124,7 @@
     var(--dsn-menu-link-current-indicator-color);
   /* Compenseer de indicator-breedte zodat de tekst horizontaal uitlijnt met niet-actieve items */
   padding-inline-start: calc(
-    var(--dsn-menu-link-padding-inline) -
+    var(--dsn-menu-item-padding-inline) -
       var(--dsn-menu-link-current-indicator-width)
   );
 }

--- a/packages/components-react/src/MenuButton/MenuButton.css
+++ b/packages/components-react/src/MenuButton/MenuButton.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/menu-button/menu-button.css';

--- a/packages/components-react/src/MenuButton/MenuButton.test.tsx
+++ b/packages/components-react/src/MenuButton/MenuButton.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MenuButton } from './MenuButton';
+
+describe('MenuButton', () => {
+  // ---------------------------------------------------------------------------
+  // Structuur
+  // ---------------------------------------------------------------------------
+
+  it('renders een <li> met een <button> erin', () => {
+    const { container } = render(<MenuButton>Label</MenuButton>);
+    const li = container.firstChild;
+    expect(li?.nodeName).toBe('LI');
+    const button = li?.firstChild;
+    expect(button?.nodeName).toBe('BUTTON');
+  });
+
+  it('heeft de basis dsn-menu-button klasse op het <li>-element', () => {
+    const { container } = render(<MenuButton>Label</MenuButton>);
+    expect(container.firstChild).toHaveClass('dsn-menu-button');
+  });
+
+  it('heeft de dsn-menu-button__button klasse op het <button>-element', () => {
+    render(<MenuButton>Label</MenuButton>);
+    const button = document.querySelector('button');
+    expect(button).toHaveClass('dsn-menu-button__button');
+  });
+
+  it('rendert children in een dsn-menu-button__label span', () => {
+    const { container } = render(<MenuButton>Label</MenuButton>);
+    const label = container.querySelector('.dsn-menu-button__label');
+    expect(label).toBeTruthy();
+    expect(label?.textContent).toBe('Label');
+  });
+
+  it('heeft type="button" als default', () => {
+    render(<MenuButton>Label</MenuButton>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Iconen
+  // ---------------------------------------------------------------------------
+
+  it('rendert iconStart voor het label', () => {
+    const { container } = render(
+      <MenuButton iconStart={<svg data-testid="icon-start" />}>
+        Label
+      </MenuButton>
+    );
+    const button = container.querySelector('button');
+    const children = Array.from(button?.children ?? []);
+    const iconIndex = children.findIndex(
+      (c) => c.getAttribute('data-testid') === 'icon-start'
+    );
+    const labelIndex = children.findIndex((c) =>
+      c.classList.contains('dsn-menu-button__label')
+    );
+    expect(iconIndex).toBeLessThan(labelIndex);
+  });
+
+  it('rendert iconEnd na het label', () => {
+    const { container } = render(
+      <MenuButton iconEnd={<svg data-testid="icon-end" />}>Label</MenuButton>
+    );
+    const button = container.querySelector('button');
+    const children = Array.from(button?.children ?? []);
+    const iconIndex = children.findIndex(
+      (c) => c.getAttribute('data-testid') === 'icon-end'
+    );
+    const labelIndex = children.findIndex((c) =>
+      c.classList.contains('dsn-menu-button__label')
+    );
+    expect(iconIndex).toBeGreaterThan(labelIndex);
+  });
+
+  it('rendert dotBadge in de dsn-menu-button__label span', () => {
+    const { container } = render(
+      <MenuButton
+        dotBadge={<span data-testid="dot-badge" aria-hidden="true" />}
+      >
+        Label
+      </MenuButton>
+    );
+    const label = container.querySelector('.dsn-menu-button__label');
+    expect(label?.querySelector('[data-testid="dot-badge"]')).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Interactie
+  // ---------------------------------------------------------------------------
+
+  it('roept onClick aan bij klik', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<MenuButton onClick={handleClick}>Label</MenuButton>);
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  // ---------------------------------------------------------------------------
+  // className en ref
+  // ---------------------------------------------------------------------------
+
+  it('past className toe op het <li>-element', () => {
+    const { container } = render(
+      <MenuButton className="custom">Label</MenuButton>
+    );
+    expect(container.firstChild).toHaveClass('custom');
+    expect(container.firstChild).toHaveClass('dsn-menu-button');
+  });
+
+  it('stuurt HTML-attributen door naar het <button>-element', () => {
+    render(<MenuButton data-testid="my-button">Label</MenuButton>);
+    expect(screen.getByTestId('my-button').nodeName).toBe('BUTTON');
+  });
+
+  it('forwards ref naar het <button>-element', () => {
+    const ref = { current: null as HTMLButtonElement | null };
+    render(<MenuButton ref={ref}>Label</MenuButton>);
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
+});

--- a/packages/components-react/src/MenuButton/MenuButton.tsx
+++ b/packages/components-react/src/MenuButton/MenuButton.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import './MenuButton.css';
+
+export interface MenuButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * Icoon links van het label
+   */
+  iconStart?: React.ReactNode;
+
+  /**
+   * Icoon rechts van het label
+   */
+  iconEnd?: React.ReactNode;
+
+  /**
+   * DotBadge element voor statusindicatie (bijv. nieuw/ongelezen zonder getal).
+   * Verwacht een `<DotBadge>` component.
+   */
+  dotBadge?: React.ReactNode;
+
+  /**
+   * Zichtbare knoptekst
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Aanvullende CSS-klassen voor het `<li>`-element
+   */
+  className?: string;
+}
+
+/**
+ * MenuButton component
+ * Navigatieknop voor JavaScript-acties — semantisch een `<button>`, visueel consistent met MenuLink.
+ *
+ * Gebruik in een `<ul>`-element wanneer de actie geen URL-navigatie is maar een JS-handeling triggert
+ * (bijv. uitloggen, een modal openen of een sectie in/uitklappen).
+ *
+ * @example
+ * ```tsx
+ * // Basisgebruik
+ * <MenuButton onClick={handleLogout}>Uitloggen</MenuButton>
+ *
+ * // Met icoon start
+ * <MenuButton iconStart={<Icon name="settings" aria-hidden />}>
+ *   Instellingen
+ * </MenuButton>
+ *
+ * // Met DotBadge (statusindicatie)
+ * <MenuButton
+ *   iconStart={<Icon name="bell" aria-hidden />}
+ *   dotBadge={<DotBadge variant="negative" />}
+ * >
+ *   Meldingen
+ *   <span className="dsn-visually-hidden">, nieuwe meldingen beschikbaar</span>
+ * </MenuButton>
+ * ```
+ */
+export const MenuButton = React.forwardRef<HTMLButtonElement, MenuButtonProps>(
+  (
+    {
+      iconStart,
+      iconEnd,
+      dotBadge,
+      className,
+      children,
+      type = 'button',
+      ...props
+    },
+    ref
+  ) => {
+    const liClasses = classNames('dsn-menu-button', className);
+
+    return (
+      <li className={liClasses}>
+        <button
+          ref={ref}
+          type={type}
+          className="dsn-menu-button__button"
+          {...props}
+        >
+          {iconStart}
+          <span className="dsn-menu-button__label">
+            {children}
+            {dotBadge}
+          </span>
+          {iconEnd}
+        </button>
+      </li>
+    );
+  }
+);
+
+MenuButton.displayName = 'MenuButton';

--- a/packages/components-react/src/MenuButton/index.ts
+++ b/packages/components-react/src/MenuButton/index.ts
@@ -1,0 +1,1 @@
+export * from './MenuButton';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -59,6 +59,7 @@ export * from './Details';
 
 // Navigation Components
 export * from './BreadcrumbNavigation';
+export * from './MenuButton';
 export * from './MenuLink';
 
 // Form Field Components

--- a/packages/design-tokens/src/tokens/components/menu-item.json
+++ b/packages/design-tokens/src/tokens/components/menu-item.json
@@ -1,0 +1,75 @@
+{
+  "dsn": {
+    "menu-item": {
+      "font-size": {
+        "value": "{dsn.text.font-size.md}",
+        "type": "dimension",
+        "comment": "Gedeeld: lettergrootte voor MenuLink en MenuButton"
+      },
+      "font-weight": {
+        "value": "{dsn.text.font-weight.default}",
+        "type": "fontWeight",
+        "comment": "Gedeeld: letterdikte — regular voor navigatie-items"
+      },
+      "line-height": {
+        "value": "{dsn.text.line-height.md}",
+        "type": "lineHeight",
+        "comment": "Gedeeld: regelhoogte"
+      },
+      "padding-block": {
+        "value": "{dsn.space.block.md}",
+        "type": "dimension",
+        "comment": "Gedeeld: verticale padding"
+      },
+      "padding-inline": {
+        "value": "{dsn.space.inline.lg}",
+        "type": "dimension",
+        "comment": "Gedeeld: horizontale padding"
+      },
+      "gap": {
+        "value": "{dsn.space.inline.md}",
+        "type": "dimension",
+        "comment": "Gedeeld: ruimte tussen icoon, label en badge"
+      },
+      "icon-size": {
+        "value": "{dsn.icon.size.md}",
+        "type": "dimension",
+        "comment": "Gedeeld: icoongrootte"
+      },
+      "color": {
+        "value": "{dsn.color.action-2.color-default}",
+        "type": "color",
+        "comment": "Gedeeld: standaard tekstkleur"
+      },
+      "background-color": {
+        "value": "{dsn.color.transparent}",
+        "type": "color",
+        "comment": "Gedeeld: standaard achtergrondkleur"
+      },
+      "hover": {
+        "color": {
+          "value": "{dsn.color.action-2.color-hover}",
+          "type": "color",
+          "comment": "Gedeeld: hover tekstkleur"
+        },
+        "background-color": {
+          "value": "{dsn.color.action-2.bg-hover}",
+          "type": "color",
+          "comment": "Gedeeld: hover achtergrondkleur"
+        }
+      },
+      "active": {
+        "color": {
+          "value": "{dsn.color.action-2.color-active}",
+          "type": "color",
+          "comment": "Gedeeld: active tekstkleur"
+        },
+        "background-color": {
+          "value": "{dsn.color.action-2.bg-active}",
+          "type": "color",
+          "comment": "Gedeeld: active achtergrondkleur"
+        }
+      }
+    }
+  }
+}

--- a/packages/design-tokens/src/tokens/components/menu-link.json
+++ b/packages/design-tokens/src/tokens/components/menu-link.json
@@ -1,128 +1,59 @@
 {
   "dsn": {
     "menu-link": {
-      "font-size": {
-        "value": "{dsn.text.font-size.md}",
-        "type": "dimension",
-        "comment": "MenuLink font size"
-      },
-      "font-weight": {
-        "value": "{dsn.text.font-weight.default}",
-        "type": "fontWeight",
-        "comment": "MenuLink font weight — regular voor navigatielinks"
-      },
-      "line-height": {
-        "value": "{dsn.text.line-height.md}",
-        "type": "lineHeight",
-        "comment": "MenuLink line height"
-      },
-      "padding-block": {
-        "value": "{dsn.space.block.md}",
-        "type": "dimension",
-        "comment": "Verticale padding van de link"
-      },
-      "padding-inline": {
-        "value": "{dsn.space.inline.lg}",
-        "type": "dimension",
-        "comment": "Horizontale padding van de link"
-      },
-      "gap": {
-        "value": "{dsn.space.inline.md}",
-        "type": "dimension",
-        "comment": "Ruimte tussen icoon, label en badge"
-      },
-      "icon-size": {
-        "value": "{dsn.icon.size.md}",
-        "type": "dimension",
-        "comment": "Icoongrootte in de link"
-      },
       "level-indent": {
         "value": "{dsn.space.inline.3xl}",
         "type": "dimension",
-        "comment": "Inspringing per hiërarchisch niveau (level 2–4) — via margin-inline-start op de link"
-      },
-      "color": {
-        "value": "{dsn.color.action-1.color-default}",
-        "type": "color",
-        "comment": "Standaard tekstkleur"
-      },
-      "background-color": {
-        "value": "{dsn.color.transparent}",
-        "type": "color",
-        "comment": "Standaard achtergrondkleur"
-      },
-      "hover": {
-        "color": {
-          "value": "{dsn.color.action-1.color-hover}",
-          "type": "color",
-          "comment": "Hover tekstkleur"
-        },
-        "background-color": {
-          "value": "{dsn.color.action-1.bg-hover}",
-          "type": "color",
-          "comment": "Hover achtergrondkleur"
-        }
-      },
-      "active": {
-        "color": {
-          "value": "{dsn.color.action-1.color-active}",
-          "type": "color",
-          "comment": "Active tekstkleur"
-        },
-        "background-color": {
-          "value": "{dsn.color.action-1.bg-active}",
-          "type": "color",
-          "comment": "Active achtergrondkleur"
-        }
+        "comment": "MenuLink-specifiek: inspringing per hiërarchisch niveau (level 2–4) — via margin-inline-start op de link"
       },
       "current": {
         "font-weight": {
           "value": "{dsn.text.font-weight.bold}",
           "type": "fontWeight",
-          "comment": "Font weight voor de actieve/huidige pagina — bold voor visuele nadruk"
+          "comment": "MenuLink-specifiek: font weight voor de actieve/huidige pagina — bold voor visuele nadruk"
         },
         "color": {
           "value": "{dsn.color.action-2.color-default}",
           "type": "color",
-          "comment": "Tekstkleur voor de actieve/huidige pagina — niet inverse, volgt action-2 subtle-active stijl"
+          "comment": "MenuLink-specifiek: tekstkleur voor de actieve/huidige pagina"
         },
         "background-color": {
           "value": "{dsn.color.action-2.bg-active}",
           "type": "color",
-          "comment": "Achtergrondkleur voor de actieve/huidige pagina — action-2.bg-active (zelfde als Button Subtle active)"
+          "comment": "MenuLink-specifiek: achtergrondkleur voor de actieve/huidige pagina"
         },
         "indicator-color": {
           "value": "{dsn.color.action-2.color-default}",
           "type": "color",
-          "comment": "Kleur van de border-inline-start indicator bij de actieve pagina"
+          "comment": "MenuLink-specifiek: kleur van de border-inline-start indicator"
         },
         "indicator-width": {
           "value": "3px",
           "type": "dimension",
-          "comment": "Breedte van de border-inline-start indicator bij de actieve pagina"
+          "comment": "MenuLink-specifiek: breedte van de border-inline-start indicator"
         },
         "hover": {
           "color": {
             "value": "{dsn.color.action-2.color-default}",
             "type": "color",
-            "comment": "Hover tekstkleur voor de actieve/huidige pagina"
+            "comment": "MenuLink-specifiek: hover tekstkleur voor de actieve pagina"
           },
           "background-color": {
             "value": "{dsn.color.action-2.bg-active}",
             "type": "color",
-            "comment": "Hover achtergrondkleur voor de actieve/huidige pagina — blijft bg-active"
+            "comment": "MenuLink-specifiek: hover achtergrondkleur voor de actieve pagina — blijft bg-active"
           }
         },
         "active": {
           "color": {
             "value": "{dsn.color.action-2.color-default}",
             "type": "color",
-            "comment": "Active tekstkleur voor de actieve/huidige pagina"
+            "comment": "MenuLink-specifiek: active tekstkleur voor de actieve pagina"
           },
           "background-color": {
             "value": "{dsn.color.action-2.bg-active}",
             "type": "color",
-            "comment": "Active achtergrondkleur voor de actieve/huidige pagina"
+            "comment": "MenuLink-specifiek: active achtergrondkleur voor de actieve pagina"
           }
         }
       }

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -61,7 +61,7 @@ function App() {
 
 ## Componenten overzicht
 
-**48 componenten totaal** — alle beschikbaar als HTML/CSS én React.
+**49 componenten totaal** — alle beschikbaar als HTML/CSS én React.
 
 ### Layout Components (5)
 
@@ -96,9 +96,10 @@ function App() {
 - **Card** — Configureerbare container voor gestructureerde content (afbeelding, heading, beschrijving, actie) met stretched-link techniek en CardGroup voor gelijke hoogte
 - **ModalDialog** — Modaal dialoogvenster voor korte, gefocuste acties (bevestigen, kleine keuze) — blokkeert achtergrond via native `<dialog>` met focus-trap
 
-### Navigation Components (2)
+### Navigation Components (3)
 
 - **BreadcrumbNavigation** — Hiërarchisch navigatiepad met compacte variant via container query
+- **MenuButton** — Navigatieknop voor JavaScript-acties (uitloggen, modal openen) — semantisch `<button>`, visueel consistent met MenuLink
 - **MenuLink** — Navigatielink met niveau-hiërarchie (level 1–4), actieve pagina-staat en uitklapbare subnavigatie
 
 ### Form Components (25)
@@ -158,4 +159,4 @@ MIT License — zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.17.0 | **Laatste update:** 3 april 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.18.0 | **Laatste update:** 4 april 2026 | **Auteur:** Jeffrey Lauwers

--- a/packages/storybook/src/MenuButton.docs.md
+++ b/packages/storybook/src/MenuButton.docs.md
@@ -1,0 +1,103 @@
+# MenuButton
+
+Navigatieknop voor JavaScript-acties met icoon- en badge-ondersteuning.
+
+## Doel
+
+MenuButton is een navigatie-item dat semantisch een `<button>`-element is en visueel consistent is met MenuLink. Het wordt gebruikt wanneer een actie in het navigatiemenu geen URL-navigatie is maar een JavaScript-handeling triggert — zoals uitloggen, een modal openen of een instellingenpaneel tonen.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- De actie een JavaScript-handeling is (geen URL-navigatie).
+- Je een navigatie-item wil tonen in een menu of sidebar dat een JS-actie triggert.
+- Je statusindicatie wil tonen bij een navigatie-item via een `DotBadge`.
+
+## Don't use when
+
+- De actie naar een URL navigeert — gebruik dan `MenuLink`.
+- Je buiten een nav-context werkt — gebruik dan een reguliere `Button` of `LinkButton`.
+
+## Best practices
+
+### HTML-structuur
+
+MenuButton genereert een `<li>`-element en moet altijd binnen een `<ul>` geplaatst worden:
+
+```html
+<nav aria-label="Primaire navigatie">
+  <ul>
+    <li class="dsn-menu-button">
+      <button type="button" class="dsn-menu-button__button">
+        <svg class="dsn-icon" aria-hidden="true"><!-- settings --></svg>
+        <span class="dsn-menu-button__label">Instellingen</span>
+      </button>
+    </li>
+    <li class="dsn-menu-button">
+      <button type="button" class="dsn-menu-button__button">
+        <svg class="dsn-icon" aria-hidden="true"><!-- logout --></svg>
+        <span class="dsn-menu-button__label">Uitloggen</span>
+      </button>
+    </li>
+  </ul>
+</nav>
+```
+
+### DotBadge
+
+Gebruik `dotBadge` voor statusindicatie zonder getal (bijv. nieuwe meldingen). De `DotBadge` wordt gerenderd in de label-span en zweeft rechtsboven de tekst. Voeg altijd screenreader-context toe via `dsn-visually-hidden` in het label wanneer de badge betekenis draagt:
+
+```html
+<button type="button" class="dsn-menu-button__button">
+  <svg class="dsn-icon" aria-hidden="true"><!-- bell --></svg>
+  <span class="dsn-menu-button__label">
+    Meldingen
+    <span class="dsn-visually-hidden">, nieuwe meldingen beschikbaar</span>
+    <span
+      class="dsn-dot-badge dsn-dot-badge--negative"
+      aria-hidden="true"
+    ></span>
+  </span>
+</button>
+```
+
+### Iconen
+
+Gebruik `iconStart` voor contextuele iconen links van het label. Gebruik `iconEnd` voor navigatieve iconen (bijv. een pijl) rechts van het label:
+
+```html
+<button type="button" class="dsn-menu-button__button">
+  <svg class="dsn-icon" aria-hidden="true"><!-- settings --></svg>
+  <span class="dsn-menu-button__label">Instellingen</span>
+  <svg class="dsn-icon" aria-hidden="true"><!-- arrow-right --></svg>
+</button>
+```
+
+## Design tokens
+
+MenuButton gebruikt uitsluitend de gedeelde `--dsn-menu-item-*` tokens. Deze tokens zijn ook van toepassing op `MenuLink` — wijzigingen hier gelden voor beide componenten.
+
+| Token                                     | Beschrijving                 |
+| ----------------------------------------- | ---------------------------- |
+| `--dsn-menu-item-font-size`               | Lettergrootte                |
+| `--dsn-menu-item-font-weight`             | Letterdikte (regular)        |
+| `--dsn-menu-item-line-height`             | Regelhoogte                  |
+| `--dsn-menu-item-padding-block`           | Verticale padding            |
+| `--dsn-menu-item-padding-inline`          | Horizontale padding          |
+| `--dsn-menu-item-gap`                     | Ruimte tussen icoon en label |
+| `--dsn-menu-item-icon-size`               | Icoongrootte                 |
+| `--dsn-menu-item-color`                   | Tekstkleur (standaard)       |
+| `--dsn-menu-item-background-color`        | Achtergrondkleur (standaard) |
+| `--dsn-menu-item-hover-color`             | Tekstkleur bij hover         |
+| `--dsn-menu-item-hover-background-color`  | Achtergrondkleur bij hover   |
+| `--dsn-menu-item-active-color`            | Tekstkleur bij active        |
+| `--dsn-menu-item-active-background-color` | Achtergrondkleur bij active  |
+
+## Accessibility
+
+- MenuButton is semantisch een `<button type="button">` — screenreaders kondigen het aan als knop.
+- Het icoon heeft altijd `aria-hidden="true"` — de toegankelijke naam komt van de knoptekst.
+- Wanneer `dotBadge` betekenis draagt (bijv. ongelezen berichten), voeg dan context toe via `dsn-visually-hidden` in het label — de `DotBadge` zelf heeft altijd `aria-hidden="true"`.
+- Gebruik nooit `aria-label` op de knop — gebruik altijd zichtbare tekst in `dsn-menu-button__label`.
+- Zorg dat de omliggende `<ul>` in een `<nav>` staat met een beschrijvende `aria-label`.

--- a/packages/storybook/src/MenuButton.docs.mdx
+++ b/packages/storybook/src/MenuButton.docs.mdx
@@ -1,0 +1,31 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as MenuButtonStories from './MenuButton.stories';
+import docs from './MenuButton.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={MenuButtonStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={MenuButtonStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={MenuButtonStories.Default}
+  html={`<ul style="list-style: none; margin: 0; padding: 0;">
+  <li class="dsn-menu-button">
+    <button type="button" class="dsn-menu-button__button">
+      <span class="dsn-menu-button__label">Dashboard</span>
+    </button>
+  </li>
+</ul>`}
+/>
+
+<Controls of={MenuButtonStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/MenuButton.stories.tsx
+++ b/packages/storybook/src/MenuButton.stories.tsx
@@ -1,0 +1,256 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DotBadge, Icon, MenuButton } from '@dsn/components-react';
+import type { IconName } from '@dsn/components-react/icon-registry.generated';
+import DocsPage from './MenuButton.docs.mdx';
+import {
+  TEKST,
+  VEEL_TEKST,
+  TEKST_AR,
+  VEEL_TEKST_AR,
+  rtlDecorator,
+} from './story-helpers';
+
+// =============================================================================
+// ICON OPTIONS (zelfde lijst als Link/Button/MenuLink stories)
+// =============================================================================
+
+const iconOptions: (IconName | undefined)[] = [
+  undefined,
+  'alert-triangle',
+  'archive',
+  'arrow-down',
+  'arrow-left',
+  'arrow-narrow-down',
+  'arrow-narrow-up',
+  'arrow-right',
+  'arrow-up',
+  'bell',
+  'calendar-event',
+  'check',
+  'chevron-down',
+  'chevron-left',
+  'chevron-right',
+  'chevron-up',
+  'circle-check',
+  'clock',
+  'dots-vertical',
+  'download',
+  'edit',
+  'exclamation-circle',
+  'external-link',
+  'eye',
+  'file-description',
+  'folder',
+  'heart-filled',
+  'heart',
+  'home',
+  'info-circle',
+  'loader',
+  'mail',
+  'menu',
+  'message-circle',
+  'minus',
+  'paperclip',
+  'plus',
+  'search',
+  'selector',
+  'settings',
+  'star-filled',
+  'star',
+  'trash',
+  'upload',
+  'user',
+  'x',
+];
+
+const iconMapping = iconOptions.reduce(
+  (acc, icon) => {
+    acc[icon ?? 'undefined'] = icon ? (
+      <Icon name={icon} aria-hidden />
+    ) : undefined;
+    return acc;
+  },
+  {} as Record<string, React.ReactNode>
+);
+
+// =============================================================================
+// DOT BADGE OPTIONS
+// =============================================================================
+
+const dotBadgeOptions: Record<string, React.ReactNode> = {
+  '(geen)': undefined,
+  negative: <DotBadge variant="negative" />,
+  positive: <DotBadge variant="positive" />,
+  warning: <DotBadge variant="warning" />,
+  info: <DotBadge variant="info" />,
+  neutral: <DotBadge variant="neutral" />,
+  'negative (pulse)': <DotBadge variant="negative" pulse />,
+};
+
+// =============================================================================
+// META
+// =============================================================================
+
+const meta: Meta<typeof MenuButton> = {
+  title: 'Components/MenuButton',
+  component: MenuButton,
+  parameters: {
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        return `<ul style="list-style: none; margin: 0; padding: 0;">\n  <li class="dsn-menu-button">\n    <button type="button" class="dsn-menu-button__button">\n      <span class="dsn-menu-button__label">${args.children ?? 'Dashboard'}</span>\n    </button>\n  </li>\n</ul>`;
+      },
+    },
+  },
+  argTypes: {
+    children: { control: 'text' },
+    iconStart: {
+      control: 'select',
+      options: iconOptions,
+      mapping: iconMapping,
+    },
+    iconEnd: {
+      control: 'select',
+      options: iconOptions,
+      mapping: iconMapping,
+    },
+    dotBadge: {
+      control: 'select',
+      options: Object.keys(dotBadgeOptions),
+      mapping: dotBadgeOptions,
+    },
+  },
+  args: {
+    children: TEKST,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MenuButton>;
+
+// Helper: wikkelt een enkel MenuButton in een semantisch correcte <ul>
+const renderSingle = (args: React.ComponentProps<typeof MenuButton>) => (
+  <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+    <MenuButton {...args} />
+  </ul>
+);
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {
+  render: renderSingle,
+};
+
+// =============================================================================
+// VARIANTEN
+// =============================================================================
+
+export const WithIconStart: Story = {
+  name: 'Met icoon start',
+  args: {
+    iconStart: <Icon name="settings" aria-hidden />,
+  },
+  render: renderSingle,
+};
+
+export const WithIconEnd: Story = {
+  name: 'Met icoon end',
+  args: {
+    iconEnd: <Icon name="arrow-right" aria-hidden />,
+  },
+  render: renderSingle,
+};
+
+export const WithDotBadge: Story = {
+  name: 'Met DotBadge',
+  args: {
+    iconStart: <Icon name="bell" aria-hidden />,
+    dotBadge: <DotBadge variant="negative" />,
+    children: (
+      <>
+        Meldingen
+        <span className="dsn-visually-hidden">
+          , nieuwe meldingen beschikbaar
+        </span>
+      </>
+    ),
+  },
+  render: renderSingle,
+};
+
+// =============================================================================
+// TEKST VARIANTEN
+// =============================================================================
+
+export const LongText: Story = {
+  name: 'Long text',
+  args: { children: VEEL_TEKST },
+  render: renderSingle,
+};
+
+// =============================================================================
+// OVERZICHTSSTORIES
+// =============================================================================
+
+export const AllStates: Story = {
+  name: 'Alle staten',
+  render: () => (
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      <MenuButton>Standaard</MenuButton>
+      <MenuButton iconStart={<Icon name="home" aria-hidden />}>
+        Met icoon start
+      </MenuButton>
+      <MenuButton iconEnd={<Icon name="arrow-right" aria-hidden />}>
+        Met icoon end
+      </MenuButton>
+      <MenuButton
+        iconStart={<Icon name="bell" aria-hidden />}
+        dotBadge={<DotBadge variant="negative" />}
+      >
+        Met DotBadge
+      </MenuButton>
+      <MenuButton
+        iconStart={<Icon name="bell" aria-hidden />}
+        dotBadge={<DotBadge variant="negative" pulse />}
+      >
+        Met DotBadge (pulse)
+      </MenuButton>
+    </ul>
+  ),
+};
+
+// =============================================================================
+// RTL
+// =============================================================================
+
+export const RTL: Story = {
+  name: 'RTL',
+  decorators: [rtlDecorator],
+  render: () => (
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      <MenuButton>{TEKST_AR}</MenuButton>
+      <MenuButton iconStart={<Icon name="home" aria-hidden />}>
+        {TEKST_AR}
+      </MenuButton>
+      <MenuButton iconEnd={<Icon name="arrow-left" aria-hidden />}>
+        {TEKST_AR}
+      </MenuButton>
+      <MenuButton
+        iconStart={<Icon name="bell" aria-hidden />}
+        dotBadge={<DotBadge variant="negative" />}
+      >
+        {TEKST_AR}
+      </MenuButton>
+    </ul>
+  ),
+};
+
+export const RTLLongText: Story = {
+  name: 'RTL long text',
+  decorators: [rtlDecorator],
+  args: { children: VEEL_TEKST_AR },
+  render: renderSingle,
+};

--- a/packages/storybook/src/MenuLink.docs.md
+++ b/packages/storybook/src/MenuLink.docs.md
@@ -128,22 +128,32 @@ De uitklapknop is een zelfstandige `<button>` naast de `<a>`. Gebruik altijd `ar
 
 ## Design tokens
 
+MenuLink gebruikt twee token-sets. De gedeelde `--dsn-menu-item-*` tokens zijn ook van toepassing op `MenuButton` — wijzigingen hier gelden voor beide componenten.
+
+### Gedeeld met MenuButton (`--dsn-menu-item-*`)
+
+| Token                                     | Beschrijving                 |
+| ----------------------------------------- | ---------------------------- |
+| `--dsn-menu-item-font-size`               | Lettergrootte                |
+| `--dsn-menu-item-font-weight`             | Letterdikte (regular)        |
+| `--dsn-menu-item-line-height`             | Regelhoogte                  |
+| `--dsn-menu-item-padding-block`           | Verticale padding            |
+| `--dsn-menu-item-padding-inline`          | Horizontale padding          |
+| `--dsn-menu-item-gap`                     | Ruimte tussen icoon en label |
+| `--dsn-menu-item-icon-size`               | Icoongrootte                 |
+| `--dsn-menu-item-color`                   | Tekstkleur (standaard)       |
+| `--dsn-menu-item-background-color`        | Achtergrondkleur (standaard) |
+| `--dsn-menu-item-hover-color`             | Tekstkleur bij hover         |
+| `--dsn-menu-item-hover-background-color`  | Achtergrondkleur bij hover   |
+| `--dsn-menu-item-active-color`            | Tekstkleur bij active        |
+| `--dsn-menu-item-active-background-color` | Achtergrondkleur bij active  |
+
+### MenuLink-specifiek (`--dsn-menu-link-*`)
+
 | Token                                             | Beschrijving                                                         |
 | ------------------------------------------------- | -------------------------------------------------------------------- |
-| `--dsn-menu-link-font-size`                       | Lettergrootte                                                        |
-| `--dsn-menu-link-font-weight`                     | Letterdikte (regular)                                                |
-| `--dsn-menu-link-line-height`                     | Regelhoogte                                                          |
-| `--dsn-menu-link-padding-block`                   | Verticale padding                                                    |
-| `--dsn-menu-link-padding-inline`                  | Horizontale padding                                                  |
-| `--dsn-menu-link-gap`                             | Ruimte tussen icoon en label                                         |
-| `--dsn-menu-link-icon-size`                       | Icoongrootte                                                         |
 | `--dsn-menu-link-level-indent`                    | Inspringing per niveau (level 2–4) via margin-inline-start           |
-| `--dsn-menu-link-color`                           | Tekstkleur (standaard)                                               |
-| `--dsn-menu-link-background-color`                | Achtergrondkleur (standaard)                                         |
-| `--dsn-menu-link-hover-color`                     | Tekstkleur bij hover                                                 |
-| `--dsn-menu-link-hover-background-color`          | Achtergrondkleur bij hover                                           |
-| `--dsn-menu-link-active-color`                    | Tekstkleur bij active                                                |
-| `--dsn-menu-link-active-background-color`         | Achtergrondkleur bij active                                          |
+| `--dsn-menu-link-current-font-weight`             | Letterdikte voor de actieve/huidige pagina (bold)                    |
 | `--dsn-menu-link-current-color`                   | Tekstkleur voor de actieve/huidige pagina                            |
 | `--dsn-menu-link-current-background-color`        | Achtergrondkleur voor de actieve/huidige pagina (action-2.bg-active) |
 | `--dsn-menu-link-current-indicator-color`         | Kleur van de border-inline-start indicator                           |


### PR DESCRIPTION
## Summary

- **MenuLink** — navigatielink met `level`-hiërarchie (1–4), `current`-staat (`aria-current="page"`), uitklapknop (`aria-expanded`), `iconStart`, `iconEnd`, `numberBadge`
- **MenuButton** — navigatieknop voor JS-acties, visueel consistent met MenuLink; ondersteunt `iconStart`, `iconEnd`, `dotBadge` (zweeft rechtsboven de tekst)
- **Gedeelde `menu-item.json` tokens** — één token-set (`--dsn-menu-item-*`) gedeeld door beide componenten; MenuLink heeft alleen `current.*` en `level-indent` als eigen tokens

## Wijzigingen

- 3 nieuwe componenten: MenuLink, MenuButton (+ BreadcrumbNavigation reeds op main)
- 1225 tests, 60 test suites — allemaal groen
- Design tokens: `menu-item.json` (shared) + `menu-link.json` (MenuLink-specifiek)
- Volledige Storybook-documentatie voor beide componenten
- Docs en changelog bijgewerkt voor v5.18.0

## Test plan

- [ ] `pnpm test` — alle 1225 tests groen
- [ ] `pnpm --filter storybook exec tsc --noEmit` — 0 TypeScript-fouten
- [ ] `pnpm lint` — 0 lint-fouten
- [ ] Storybook: MenuLink en MenuButton stories correct, RTL + LongText varianten werken
- [ ] DotBadge zweeft rechtsboven de tekst bij MenuButton
- [ ] MenuLink current-state toont `aria-current="page"` en bold tekst
- [ ] Uitklapknop toont `aria-expanded` correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)