### PR TITLE
feat(PageHeader): navigatieheader met menu-drawer, zoekpaneel en sticky-gedrag

### DIFF
--- a/packages/components-html/src/page-header/page-header.css
+++ b/packages/components-html/src/page-header/page-header.css
@@ -1,0 +1,154 @@
+/**
+ * PageHeader Component
+ * Primaire navigatieheader voor een pagina. Mobile-first: menuknop (inline-start),
+ * gecentreerd logo, zoekknop (inline-end). Navigatie via Drawer; zoekpaneel inline.
+ *
+ * Structuur:
+ * <header class="dsn-page-header">
+ *   <div class="dsn-page-header__inner">
+ *     <div class="dsn-page-header__start">
+ *       <!-- Menuknop -->
+ *     </div>
+ *     <div class="dsn-page-header__logo">
+ *       <!-- Logo (svg, img, of <a> wrapper) -->
+ *     </div>
+ *     <div class="dsn-page-header__end">
+ *       <!-- Zoekknop -->
+ *     </div>
+ *   </div>
+ *   <div class="dsn-page-header__search-panel" id="..." hidden>
+ *     <div class="dsn-page-header__search-inner">
+ *       <!-- SearchInput + zoekknop -->
+ *     </div>
+ *   </div>
+ * </header>
+ */
+
+/* =============================================================================
+   Base
+   ============================================================================= */
+
+.dsn-page-header {
+  background-color: var(--dsn-page-header-background-color);
+  border-block-end: var(--dsn-page-header-border-block-end-width) solid
+    var(--dsn-page-header-border-block-end-color);
+}
+
+/* =============================================================================
+   Sticky gedrag
+   ============================================================================= */
+
+.dsn-page-header--sticky {
+  position: sticky;
+  inset-block-start: 0;
+  z-index: var(--dsn-page-header-z-index);
+}
+
+/* =============================================================================
+   Auto-hide (sticky + CSS-transitie)
+   JS toggle via data-hidden attribuut: scroll-down → "true", scroll-up → "false"
+   ============================================================================= */
+
+.dsn-page-header--auto-hide {
+  position: sticky;
+  inset-block-start: 0;
+  z-index: var(--dsn-page-header-z-index);
+  transition: transform var(--dsn-transition-duration-normal)
+    var(--dsn-transition-easing-default);
+}
+
+.dsn-page-header--auto-hide[data-hidden='true'] {
+  transform: translateY(-100%);
+}
+
+/* =============================================================================
+   Inner — CSS-grid centreert logo onafhankelijk van knopbreedte
+   ============================================================================= */
+
+.dsn-page-header__inner {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding-block: var(--dsn-page-header-padding-block);
+  padding-inline: var(--dsn-page-header-padding-inline);
+}
+
+/* =============================================================================
+   Start-slot (inline-start — menuknop)
+   ============================================================================= */
+
+.dsn-page-header__start {
+  display: flex;
+  align-items: center;
+}
+
+/* =============================================================================
+   Logo-slot (gecentreerd via middelste grid-kolom)
+   De SVG/img zelf krijgt de max-block-size — niet de wrapper.
+   SVG-attributen width/height worden overschreven door CSS block-size + inline-size: auto.
+   ============================================================================= */
+
+.dsn-page-header__logo {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.dsn-page-header__logo svg,
+.dsn-page-header__logo img {
+  display: block;
+  block-size: var(--dsn-page-header-logo-max-block-size);
+  inline-size: auto;
+}
+
+/* =============================================================================
+   Knoppen in de header krijgen compacte inline padding
+   ============================================================================= */
+
+.dsn-page-header__inner .dsn-button {
+  padding-inline: var(--dsn-space-row-md);
+}
+
+/* =============================================================================
+   End-slot (inline-end — zoekknop)
+   ============================================================================= */
+
+.dsn-page-header__end {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+/* =============================================================================
+   Zoekpaneel (standaard verborgen via [hidden])
+   ============================================================================= */
+
+.dsn-page-header__search-panel {
+  background-color: var(--dsn-page-header-search-panel-background-color);
+  padding-block: var(--dsn-page-header-search-panel-padding-block);
+  padding-inline: var(--dsn-page-header-search-panel-padding-inline);
+}
+
+.dsn-page-header__search-inner {
+  display: flex;
+  gap: var(--dsn-space-inline-md);
+  align-items: flex-start;
+}
+
+/* SearchInput wrapper vult beschikbare ruimte volledig — overschrijft de standaard
+   form-control max-inline-size zodat het veld de volledige breedte pakt */
+.dsn-page-header__search-inner .dsn-search-input-wrapper {
+  flex: 1;
+  min-inline-size: 0;
+  max-inline-size: none;
+}
+
+/* Input op gelijke hoogte als de Zoeken-knop: padding-block terugbrengen naar
+   8px zodat padding + line-height < min-block-size (48px) — en min-block-size
+   de hoogte bepaalt, net als bij de button */
+.dsn-page-header__search-inner .dsn-text-input {
+  max-inline-size: none;
+  inline-size: 100%;
+  --dsn-text-input-padding-block-start: var(--dsn-space-block-md);
+  --dsn-text-input-padding-block-end: var(--dsn-space-block-md);
+}

--- a/packages/components-react/src/PageHeader/PageHeader.css
+++ b/packages/components-react/src/PageHeader/PageHeader.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/page-header/page-header.css';

--- a/packages/components-react/src/PageHeader/PageHeader.test.tsx
+++ b/packages/components-react/src/PageHeader/PageHeader.test.tsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PageHeader } from './PageHeader';
+
+const defaultLogo = (
+  <a href="/">
+    <span>Logo</span>
+  </a>
+);
+
+describe('PageHeader', () => {
+  // ---------------------------------------------------------------------------
+  // Structuur
+  // ---------------------------------------------------------------------------
+
+  it('rendert een <header>-element', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    expect(container.querySelector('header')).toBeTruthy();
+  });
+
+  it('heeft de basis dsn-page-header klasse', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    expect(container.querySelector('header')).toHaveClass('dsn-page-header');
+  });
+
+  it('rendert de inner-wrapper met dsn-page-header__inner', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    expect(container.querySelector('.dsn-page-header__inner')).toBeTruthy();
+  });
+
+  it('rendert het logo in dsn-page-header__logo', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    const logoSlot = container.querySelector('.dsn-page-header__logo');
+    expect(logoSlot).toBeTruthy();
+    expect(logoSlot?.querySelector('a')).toBeTruthy();
+  });
+
+  it('rendert een menuknop in dsn-page-header__start', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    const start = container.querySelector('.dsn-page-header__start');
+    expect(start?.querySelector('button')).toBeTruthy();
+  });
+
+  it('rendert een zoekknop in dsn-page-header__end', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    const end = container.querySelector('.dsn-page-header__end');
+    expect(end?.querySelector('button')).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Zoekpaneel
+  // ---------------------------------------------------------------------------
+
+  it('zoekpaneel is standaard verborgen', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    const panel = container.querySelector('.dsn-page-header__search-panel');
+    expect(panel).toHaveAttribute('hidden');
+  });
+
+  it('zoekknop heeft aria-expanded="false" bij gesloten paneel', () => {
+    render(<PageHeader logoSlot={defaultLogo} />);
+    const searchButton = screen.getByRole('button', { name: /zoeken/i });
+    expect(searchButton).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('zoekpaneel opent bij klik op zoekknop', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    const searchButton = screen.getByRole('button', { name: /zoeken/i });
+    fireEvent.click(searchButton);
+    const panel = container.querySelector('.dsn-page-header__search-panel');
+    expect(panel).not.toHaveAttribute('hidden');
+  });
+
+  it('zoekknop heeft aria-expanded="true" bij geopend paneel', () => {
+    render(<PageHeader logoSlot={defaultLogo} />);
+    const searchButton = screen.getByRole('button', { name: /zoeken/i });
+    fireEvent.click(searchButton);
+    expect(searchButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('zoekknop toont "Sluiten" tekst bij geopend paneel', () => {
+    render(<PageHeader logoSlot={defaultLogo} />);
+    const searchButton = screen.getByRole('button', { name: /zoeken/i });
+    fireEvent.click(searchButton);
+    expect(screen.getByRole('button', { name: /sluiten/i })).toBeTruthy();
+  });
+
+  it('zoekpaneel sluit bij klik op sluitknop', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    const searchButton = screen.getByRole('button', { name: /zoeken/i });
+    fireEvent.click(searchButton);
+    const closeButton = screen.getByRole('button', { name: /sluiten/i });
+    fireEvent.click(closeButton);
+    const panel = container.querySelector('.dsn-page-header__search-panel');
+    expect(panel).toHaveAttribute('hidden');
+  });
+
+  it('zoekpaneel heeft aria-controls dat verwijst naar het zoekpaneel-id', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    const searchButton = screen.getByRole('button', { name: /zoeken/i });
+    const panelId = searchButton.getAttribute('aria-controls');
+    expect(panelId).toBeTruthy();
+    expect(container.querySelector(`#${CSS.escape(panelId!)}`)).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Drawer
+  // ---------------------------------------------------------------------------
+
+  it('drawer is standaard gesloten', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    const drawer = container.querySelector('.dsn-drawer');
+    expect(drawer).toBeTruthy();
+    expect(drawer).not.toHaveAttribute('open');
+  });
+
+  it('rendert primaire navigatie in de drawer', () => {
+    render(
+      <PageHeader
+        logoSlot={defaultLogo}
+        primaryNavigation={
+          <ul>
+            <li>Home</li>
+          </ul>
+        }
+      />
+    );
+    expect(screen.getByText('Home')).toBeTruthy();
+  });
+
+  it('rendert service-navigatie in de drawer', () => {
+    render(
+      <PageHeader
+        logoSlot={defaultLogo}
+        secondaryNavigation={
+          <ul>
+            <li>Contact</li>
+          </ul>
+        }
+      />
+    );
+    expect(screen.getByText('Contact')).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Sticky modifiers
+  // ---------------------------------------------------------------------------
+
+  it('heeft geen sticky modifier bij sticky="none"', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} sticky="none" />
+    );
+    const header = container.querySelector('header');
+    expect(header).not.toHaveClass('dsn-page-header--sticky');
+    expect(header).not.toHaveClass('dsn-page-header--auto-hide');
+  });
+
+  it('heeft dsn-page-header--sticky bij sticky="sticky"', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} sticky="sticky" />
+    );
+    expect(container.querySelector('header')).toHaveClass(
+      'dsn-page-header--sticky'
+    );
+  });
+
+  it('heeft dsn-page-header--auto-hide bij sticky="auto-hide"', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} sticky="auto-hide" />
+    );
+    expect(container.querySelector('header')).toHaveClass(
+      'dsn-page-header--auto-hide'
+    );
+  });
+
+  it('heeft data-hidden="false" bij sticky="auto-hide"', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} sticky="auto-hide" />
+    );
+    expect(container.querySelector('header')).toHaveAttribute(
+      'data-hidden',
+      'false'
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Callbacks
+  // ---------------------------------------------------------------------------
+
+  it('roept onSearchOpen aan bij openen zoekpaneel', () => {
+    const onSearchOpen = vi.fn();
+    render(<PageHeader logoSlot={defaultLogo} onSearchOpen={onSearchOpen} />);
+    fireEvent.click(screen.getByRole('button', { name: /zoeken/i }));
+    expect(onSearchOpen).toHaveBeenCalledOnce();
+  });
+
+  it('roept onSearchClose aan bij sluiten zoekpaneel', () => {
+    const onSearchClose = vi.fn();
+    render(<PageHeader logoSlot={defaultLogo} onSearchClose={onSearchClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /zoeken/i }));
+    fireEvent.click(screen.getByRole('button', { name: /sluiten/i }));
+    expect(onSearchClose).toHaveBeenCalledOnce();
+  });
+
+  // ---------------------------------------------------------------------------
+  // className en ref
+  // ---------------------------------------------------------------------------
+
+  it('accepteert extra className', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} className="custom" />
+    );
+    expect(container.querySelector('header')).toHaveClass(
+      'dsn-page-header',
+      'custom'
+    );
+  });
+
+  it('stuurt HTML-attributen door', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} data-testid="ph" />
+    );
+    expect(container.querySelector('header')).toHaveAttribute(
+      'data-testid',
+      'ph'
+    );
+  });
+});

--- a/packages/components-react/src/PageHeader/PageHeader.tsx
+++ b/packages/components-react/src/PageHeader/PageHeader.tsx
@@ -1,0 +1,274 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import { SearchInput } from '../SearchInput';
+import { Drawer, DrawerBody, DrawerHeader, DrawerHeading } from '../Drawer';
+import { Stack } from '../Stack';
+import './PageHeader.css';
+
+export type PageHeaderSticky = 'none' | 'sticky' | 'auto-hide';
+
+export interface PageHeaderProps extends Omit<
+  React.HTMLAttributes<HTMLElement>,
+  'children'
+> {
+  /**
+   * Logo-inhoud — `<svg>`, `<img>`, of een `<a>` die een logo omhult.
+   * De CSS past automatisch `max-block-size` toe op de directe child.
+   */
+  logoSlot: React.ReactNode;
+
+  /**
+   * Scrollgedrag van de header.
+   * - `none` (standaard): header scrollt mee met de pagina
+   * - `sticky`: header blijft bovenaan de viewport vastgeplakt
+   * - `auto-hide`: sticky + verbergt bij scroll-down, toont bij scroll-up
+   * @default 'none'
+   */
+  sticky?: PageHeaderSticky;
+
+  /**
+   * Primaire navigatie-inhoud in de Drawer — doorgaans een `<Menu>` met `<MenuLink>`-items.
+   */
+  primaryNavigation?: React.ReactNode;
+
+  /**
+   * Servicemenu-inhoud in de Drawer — bijv. Contact, taalwissel, Mijn omgeving.
+   */
+  secondaryNavigation?: React.ReactNode;
+
+  /**
+   * Callback wanneer de navigatielade opent.
+   */
+  onMenuOpen?: () => void;
+
+  /**
+   * Callback wanneer de navigatielade sluit.
+   */
+  onMenuClose?: () => void;
+
+  /**
+   * Callback wanneer het zoekpaneel opent.
+   */
+  onSearchOpen?: () => void;
+
+  /**
+   * Callback wanneer het zoekpaneel sluit.
+   */
+  onSearchClose?: () => void;
+
+  className?: string;
+}
+
+/**
+ * PageHeader component
+ * Primaire navigatieheader voor een pagina. Mobile-first implementatie.
+ *
+ * Op mobile toont de header drie elementen:
+ * - Menuknop (inline-start) — opent een `Drawer` met primaire en service-navigatie
+ * - Logo (gecentreerd, onafhankelijk van knopbreedte via CSS-grid 1fr auto 1fr)
+ * - Zoekknop (inline-end) — opent een zoekpaneel direct onder de header
+ *
+ * @example
+ * ```tsx
+ * <PageHeader
+ *   logoSlot={
+ *     <a href="/">
+ *       <Logo aria-hidden={true} />
+ *       <span className="dsn-visually-hidden">Starter Kit — terug naar homepage</span>
+ *     </a>
+ *   }
+ *   primaryNavigation={
+ *     <Menu orientation="vertical">
+ *       <MenuLink href="/home" level={1}>Home</MenuLink>
+ *       <MenuLink href="/over" level={1}>Over ons</MenuLink>
+ *     </Menu>
+ *   }
+ *   secondaryNavigation={
+ *     <Menu orientation="vertical">
+ *       <MenuLink href="/contact" level={1}>Contact</MenuLink>
+ *     </Menu>
+ *   }
+ * />
+ * ```
+ */
+export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
+  (
+    {
+      className,
+      logoSlot,
+      sticky = 'none',
+      primaryNavigation,
+      secondaryNavigation,
+      onMenuOpen,
+      onMenuClose,
+      onSearchOpen,
+      onSearchClose,
+      ...props
+    },
+    ref
+  ) => {
+    const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+    const [isSearchOpen, setIsSearchOpen] = React.useState(false);
+
+    const headerRef = React.useRef<HTMLElement>(null);
+    const combinedRef = (ref as React.RefObject<HTMLElement>) ?? headerRef;
+
+    const menuButtonRef = React.useRef<HTMLButtonElement>(null);
+    const searchButtonRef = React.useRef<HTMLButtonElement>(null);
+    const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+    const searchPanelId = React.useId();
+    const primaryNavId = React.useId();
+    const serviceNavId = React.useId();
+
+    // Auto-hide: detecteer scrollrichting en toggle data-hidden attribuut
+    React.useEffect(() => {
+      if (sticky !== 'auto-hide') return;
+
+      let lastScrollY = window.scrollY;
+
+      const handleScroll = () => {
+        const currentScrollY = window.scrollY;
+        const isScrollingDown =
+          currentScrollY > lastScrollY && currentScrollY > 100;
+        combinedRef.current?.setAttribute(
+          'data-hidden',
+          String(isScrollingDown)
+        );
+        lastScrollY = currentScrollY;
+      };
+
+      window.addEventListener('scroll', handleScroll, { passive: true });
+      return () => window.removeEventListener('scroll', handleScroll);
+    }, [sticky, combinedRef]);
+
+    // Focus management: bij openen zoekpaneel → focus naar input
+    React.useEffect(() => {
+      if (isSearchOpen) {
+        searchInputRef.current?.focus();
+      }
+    }, [isSearchOpen]);
+
+    const handleMenuOpen = () => {
+      setIsMenuOpen(true);
+      onMenuOpen?.();
+    };
+
+    const handleMenuClose = () => {
+      setIsMenuOpen(false);
+      onMenuClose?.();
+      // Focus terug naar menuknop
+      menuButtonRef.current?.focus();
+    };
+
+    const handleSearchToggle = () => {
+      const opening = !isSearchOpen;
+      setIsSearchOpen(opening);
+      if (opening) {
+        onSearchOpen?.();
+      } else {
+        onSearchClose?.();
+        // Focus terug naar zoek/sluit-knop (na state-update, via useEffect werkt ook)
+        searchButtonRef.current?.focus();
+      }
+    };
+
+    const classes = classNames(
+      'dsn-page-header',
+      sticky === 'sticky' && 'dsn-page-header--sticky',
+      sticky === 'auto-hide' && 'dsn-page-header--auto-hide',
+      className
+    );
+
+    return (
+      <>
+        <header
+          ref={combinedRef}
+          className={classes}
+          {...(sticky === 'auto-hide' ? { 'data-hidden': 'false' } : {})}
+          {...props}
+        >
+          <div className="dsn-page-header__inner">
+            {/* Inline-start: menuknop */}
+            <div className="dsn-page-header__start">
+              <Button
+                ref={menuButtonRef}
+                variant="subtle"
+                onClick={handleMenuOpen}
+                iconStart={<Icon name="menu" aria-hidden />}
+              >
+                Menu
+              </Button>
+            </div>
+
+            {/* Gecentreerd logo */}
+            <div className="dsn-page-header__logo">{logoSlot}</div>
+
+            {/* Inline-end: zoekknop / sluitknop */}
+            <div className="dsn-page-header__end">
+              <Button
+                ref={searchButtonRef}
+                variant="subtle"
+                aria-expanded={isSearchOpen}
+                aria-controls={searchPanelId}
+                onClick={handleSearchToggle}
+                iconStart={
+                  <Icon name={isSearchOpen ? 'x' : 'search'} aria-hidden />
+                }
+              >
+                {isSearchOpen ? 'Sluiten' : 'Zoeken'}
+              </Button>
+            </div>
+          </div>
+
+          {/* Zoekpaneel */}
+          <div
+            id={searchPanelId}
+            className="dsn-page-header__search-panel"
+            hidden={!isSearchOpen}
+          >
+            <div className="dsn-page-header__search-inner">
+              <SearchInput
+                ref={searchInputRef}
+                placeholder="Zoeken…"
+                aria-label="Zoekopdracht"
+              />
+              <Button variant="strong">Zoeken</Button>
+            </div>
+          </div>
+        </header>
+
+        {/* Navigatielade (sibling aan PageHeader, altijd in DOM) */}
+        <Drawer isOpen={isMenuOpen} onClose={handleMenuClose} side="left">
+          <DrawerHeader>
+            <DrawerHeading>Menu</DrawerHeading>
+          </DrawerHeader>
+          <DrawerBody>
+            <Stack space="5xl">
+              {primaryNavigation && (
+                <nav aria-labelledby={primaryNavId}>
+                  <h3 id={primaryNavId} className="dsn-visually-hidden">
+                    Hoofdmenu
+                  </h3>
+                  {primaryNavigation}
+                </nav>
+              )}
+              {secondaryNavigation && (
+                <nav aria-labelledby={serviceNavId}>
+                  <h3 id={serviceNavId} className="dsn-visually-hidden">
+                    Servicemenu
+                  </h3>
+                  {secondaryNavigation}
+                </nav>
+              )}
+            </Stack>
+          </DrawerBody>
+        </Drawer>
+      </>
+    );
+  }
+);
+
+PageHeader.displayName = 'PageHeader';

--- a/packages/components-react/src/PageHeader/index.ts
+++ b/packages/components-react/src/PageHeader/index.ts
@@ -1,0 +1,1 @@
+export * from './PageHeader';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -65,6 +65,7 @@ export * from './BreadcrumbNavigation';
 export * from './Menu';
 export * from './MenuButton';
 export * from './MenuLink';
+export * from './PageHeader';
 
 // Form Field Components
 export * from './FormField';

--- a/packages/design-tokens/src/tokens/components/page-header.json
+++ b/packages/design-tokens/src/tokens/components/page-header.json
@@ -1,0 +1,60 @@
+{
+  "dsn": {
+    "page-header": {
+      "background-color": {
+        "value": "{dsn.color.neutral.bg-document}",
+        "type": "color",
+        "comment": "Achtergrondkleur van de PageHeader — zelfde als pagina-achtergrond; de border-block-end doet het visuele scheidingswerk"
+      },
+      "border-block-end-width": {
+        "value": "{dsn.border.width.thick}",
+        "type": "dimension",
+        "comment": "Breedte van de onderkantrand (4px) — duidelijke visuele scheiding in lijn met overheids design system-patronen"
+      },
+      "border-block-end-color": {
+        "value": "{dsn.color.accent-1.color-default}",
+        "type": "color",
+        "comment": "Kleur van de onderkantrand — merkkleur die de header verankert aan het accent-1 palet"
+      },
+      "padding-block": {
+        "value": "{dsn.space.block.md}",
+        "type": "spacing",
+        "comment": "Verticale padding van de header-binnenbalk"
+      },
+      "padding-inline": {
+        "value": "{dsn.space.row.md}",
+        "type": "spacing",
+        "comment": "Horizontale padding van de header-binnenbalk"
+      },
+      "z-index": {
+        "value": "300",
+        "type": "number",
+        "comment": "Z-index voor sticky/auto-hide gedrag — bewust lager dan backdrop (400) zodat Drawer/Modal-backdrop over de header schuift"
+      },
+      "logo": {
+        "max-block-size": {
+          "value": "2rem",
+          "type": "dimension",
+          "comment": "Maximale hoogte van het logo in de PageHeader op mobile (32px). Breedte schaalt automatisch via inline-size: auto. White-label: overschrijf dit token per thema voor andere logo-proporties."
+        }
+      },
+      "search-panel": {
+        "background-color": {
+          "value": "{dsn.color.accent-1.bg-default}",
+          "type": "color",
+          "comment": "Achtergrondkleur van het zoekpaneel — merkkleur voor branding"
+        },
+        "padding-block": {
+          "value": "{dsn.space.block.md}",
+          "type": "spacing",
+          "comment": "Verticale padding van het zoekpaneel"
+        },
+        "padding-inline": {
+          "value": "{dsn.space.inline.xl}",
+          "type": "spacing",
+          "comment": "Horizontale padding van het zoekpaneel"
+        }
+      }
+    }
+  }
+}

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -61,7 +61,7 @@ function App() {
 
 ## Componenten overzicht
 
-**49 componenten totaal** — alle beschikbaar als HTML/CSS én React.
+**50 componenten totaal** — alle beschikbaar als HTML/CSS én React.
 
 ### Layout Components (5)
 
@@ -100,12 +100,13 @@ function App() {
 
 - **Logo** — Theme-aware SVG logo component met design token kleuren — past zich automatisch aan aan elk thema en elke kleurmodus
 
-### Navigation Components (4)
+### Navigation Components (5)
 
 - **BreadcrumbNavigation** — Hiërarchisch navigatiepad met compacte variant via container query
 - **Menu** — Containercomponent voor MenuLink- en MenuButton-items in verticale of horizontale navigatielijst
 - **MenuButton** — Navigatieknop voor JavaScript-acties (uitloggen, modal openen) — semantisch `<button>`, visueel consistent met MenuLink
 - **MenuLink** — Navigatielink met niveau-hiërarchie (level 1–4), actieve pagina-staat en uitklapbare subnavigatie
+- **PageHeader** — Paginabrede koptekstbalk met logo-slot, navigatie-slot en acties-slot — theme-aware achtergrond via design tokens
 
 ### Form Components (25)
 
@@ -164,4 +165,4 @@ MIT License — zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.20.0 | **Laatste update:** 5 april 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.21.0 | **Laatste update:** 5 april 2026 | **Auteur:** Jeffrey Lauwers

--- a/packages/storybook/src/PageHeader.docs.md
+++ b/packages/storybook/src/PageHeader.docs.md
@@ -1,0 +1,122 @@
+# PageHeader
+
+Primaire navigatieheader voor een pagina met menuknop, gecentreerd logo en zoekknop.
+
+## Doel
+
+`PageHeader` is de paginabrede navigatiekop aan de bovenkant van een pagina. De mobile-first implementatie toont drie vaste elementen: een menuknop (inline-start) die een `Drawer` opent, een gecentreerd logo (onafhankelijk van de knopbreedte dankzij CSS-grid `1fr auto 1fr`), en een zoekknop (inline-end) die een zoekpaneel direct onder de header laat verschijnen.
+
+De navigatie-inhoud (primair en service) wordt via props doorgegeven en in de `DrawerBody` gewikkeld in een `<Stack space="5xl">` zodat de ruimte tussen beide navigaties consistent is.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Je een globale paginaheader nodig hebt voor een website of applicatie.
+- Primaire navigatie via een overlay-lade (`Drawer`) wordt aangeboden.
+- De pagina een zoekfunctie heeft die inline in de header wordt getriggerd.
+
+## Don't use when
+
+- De navigatie permanent zichtbaar is op de huidige viewport (large viewport) — gebruik in dat geval de nog te bouwen large-viewport variant.
+
+## Best practices
+
+### Logo-slot
+
+Het `logoSlot` accepteert vrije inhoud: een `<svg>`, een `<img>`, of een `<a>` die een logo omhult. De CSS past `max-block-size` toe op de directe child via `.dsn-page-header__logo > *`:
+
+```html
+<!-- <a> met logo (aanbevolen — navigatielink naar homepage) -->
+<div class="dsn-page-header__logo">
+  <a href="/">
+    <svg class="dsn-logo" aria-hidden="true"><!-- paden --></svg>
+    <span class="dsn-visually-hidden"
+      >Naam organisatie — terug naar homepage</span
+    >
+  </a>
+</div>
+```
+
+### Sticky gedrag
+
+Kies het scrollgedrag via de `sticky`-prop:
+
+```html
+<!-- Sticky -->
+<header class="dsn-page-header dsn-page-header--sticky">...</header>
+
+<!-- Auto-hide: JS beheert data-hidden; CSS-transitie animeert -->
+<header class="dsn-page-header dsn-page-header--auto-hide" data-hidden="false">
+  ...
+</header>
+```
+
+Bij `auto-hide` detecteert de React-component de scrollrichting via een `scroll`-eventlistener en schakelt `data-hidden` om.
+
+### Navigatielade
+
+De navigatielade is een `<Drawer side="left">` die altijd in de DOM aanwezig is. De inhoud wordt via `primaryNavigation` en `secondaryNavigation` meegegeven:
+
+```tsx
+<PageHeader
+  logoSlot={...}
+  primaryNavigation={
+    <Menu orientation="vertical">
+      <MenuLink href="/home" level={1}>Home</MenuLink>
+    </Menu>
+  }
+  secondaryNavigation={
+    <Menu orientation="vertical">
+      <MenuLink href="/contact" level={1}>Contact</MenuLink>
+    </Menu>
+  }
+/>
+```
+
+### Zoekpaneel
+
+Het zoekpaneel verschijnt direct onder de header-binnenbalk. Het paneel bevat een `SearchInput` en een zoekknop:
+
+```html
+<div class="dsn-page-header__search-panel" id="search-panel" hidden>
+  <div class="dsn-page-header__search-inner">
+    <div class="dsn-search-input-wrapper">
+      <input
+        type="search"
+        class="dsn-text-input dsn-search-input"
+        placeholder="Zoeken…"
+        aria-label="Zoekopdracht"
+      />
+    </div>
+    <button type="button" class="dsn-button dsn-button--strong">
+      <span class="dsn-button__label">Zoeken</span>
+    </button>
+  </div>
+</div>
+```
+
+## Design tokens
+
+| Token                                             | Standaard                            | Omschrijving                               |
+| ------------------------------------------------- | ------------------------------------ | ------------------------------------------ |
+| `--dsn-page-header-background-color`              | `{dsn.color.neutral.bg-document}`    | Achtergrondkleur                           |
+| `--dsn-page-header-border-block-end-width`        | `{dsn.border.width.thick}`           | Breedte onderkantrand (4px)                |
+| `--dsn-page-header-border-block-end-color`        | `{dsn.color.accent-1.color-default}` | Kleur onderkantrand (merkkleur)            |
+| `--dsn-page-header-padding-block`                 | `{dsn.space.block.md}`               | Verticale padding binnenbalk               |
+| `--dsn-page-header-padding-inline`                | `{dsn.space.inline.xl}`              | Horizontale padding binnenbalk             |
+| `--dsn-page-header-z-index`                       | `300`                                | Z-index voor sticky — onder backdrop (400) |
+| `--dsn-page-header-logo-max-block-size`           | `2rem`                               | Maximale hoogte logo (32px)                |
+| `--dsn-page-header-search-panel-background-color` | `{dsn.color.neutral.bg-subtle}`      | Achtergrond zoekpaneel                     |
+| `--dsn-page-header-search-panel-padding-block`    | `{dsn.space.block.md}`               | Verticale padding zoekpaneel               |
+| `--dsn-page-header-search-panel-padding-inline`   | `{dsn.space.inline.xl}`              | Horizontale padding zoekpaneel             |
+
+## Accessibility
+
+- `<header>` heeft impliciete `role="banner"` — geen extra ARIA nodig.
+- De menuknop en zoekknop gebruiken altijd een `dsn-button__label` span voor de toegankelijke naam — nooit `aria-label`.
+- Zoekknop heeft `aria-expanded` (false/true) en `aria-controls` gericht op het zoekpaneel-ID.
+- Bij openen zoekpaneel: focus verplaatst automatisch naar het `<input>` van de `SearchInput`.
+- Bij sluiten zoekpaneel: focus keert terug naar de zoek-/sluitknop.
+- Elke `<nav>` in de Drawer heeft een unieke toegankelijke naam via `aria-labelledby` + visueel verborgen `<h3>`.
+- Drawer-focusbeheer wordt verzorgd door het bestaande `Drawer`-component.

--- a/packages/storybook/src/PageHeader.docs.mdx
+++ b/packages/storybook/src/PageHeader.docs.mdx
@@ -1,0 +1,58 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as PageHeaderStories from './PageHeader.stories';
+import docs from './PageHeader.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={PageHeaderStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={PageHeaderStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={PageHeaderStories.Default}
+  html={`<header class="dsn-page-header">
+  <div class="dsn-page-header__inner">
+    <div class="dsn-page-header__start">
+      <button type="button" class="dsn-button dsn-button--subtle">
+        <svg class="dsn-icon" aria-hidden="true"><!-- menu icon --></svg>
+        <span class="dsn-button__label">Menu</span>
+      </button>
+    </div>
+    <div class="dsn-page-header__logo">
+      <a href="/">
+        <svg class="dsn-logo" aria-hidden="true"><!-- logo paden --></svg>
+        <span class="dsn-visually-hidden">Naam organisatie — terug naar homepage</span>
+      </a>
+    </div>
+    <div class="dsn-page-header__end">
+      <button type="button" class="dsn-button dsn-button--subtle"
+              aria-expanded="false" aria-controls="search-panel">
+        <svg class="dsn-icon" aria-hidden="true"><!-- search icon --></svg>
+        <span class="dsn-button__label">Zoeken</span>
+      </button>
+    </div>
+  </div>
+  <div class="dsn-page-header__search-panel" id="search-panel" hidden>
+    <div class="dsn-page-header__search-inner">
+      <div class="dsn-search-input-wrapper">
+        <input type="search" class="dsn-text-input dsn-search-input"
+               placeholder="Zoeken…" aria-label="Zoekopdracht" />
+      </div>
+      <button type="button" class="dsn-button dsn-button--strong">
+        <span class="dsn-button__label">Zoeken</span>
+      </button>
+    </div>
+  </div>
+</header>`}
+/>
+
+<Controls of={PageHeaderStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/PageHeader.stories.tsx
+++ b/packages/storybook/src/PageHeader.stories.tsx
@@ -1,0 +1,303 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Logo, Menu, MenuLink, PageHeader } from '@dsn/components-react';
+import DocsPage from './PageHeader.docs.mdx';
+
+// =============================================================================
+// META
+// =============================================================================
+
+const logoSlot = (
+  <a href="/">
+    <Logo aria-hidden={true} />
+    <span className="dsn-visually-hidden">
+      Starter Kit — terug naar homepage
+    </span>
+  </a>
+);
+
+/**
+ * Primaire navigatie met alle niveaus (1–4) uitklapbaar.
+ *
+ * Structuur:
+ * - Level 1a (current)
+ * - Level 1b
+ *   - Level 2a
+ *   - Level 2b
+ *     - Level 3a
+ *     - Level 3b
+ *       - Level 4a
+ *       - Level 4b
+ *     - Level 3c
+ *     - Level 3d
+ *   - Level 2c
+ *   - Level 2d
+ * - Level 1c
+ * - Level 1d
+ */
+function PrimaryNavigation() {
+  const [exp1b, setExp1b] = React.useState(false);
+  const [exp2b, setExp2b] = React.useState(false);
+  const [exp3b, setExp3b] = React.useState(false);
+
+  return (
+    <Menu orientation="vertical">
+      {/* Level 1a */}
+      <MenuLink href="/level-1a" level={1} current>
+        Level 1a
+      </MenuLink>
+
+      {/* Level 1b */}
+      <MenuLink
+        href="/level-1b"
+        level={1}
+        subItems
+        expanded={exp1b}
+        onExpandToggle={() => setExp1b((v) => !v)}
+      >
+        Level 1b
+      </MenuLink>
+      {exp1b && (
+        <>
+          <MenuLink href="/level-2a" level={2}>
+            Level 2a
+          </MenuLink>
+          <MenuLink
+            href="/level-2b"
+            level={2}
+            subItems
+            expanded={exp2b}
+            onExpandToggle={() => setExp2b((v) => !v)}
+          >
+            Level 2b
+          </MenuLink>
+          {exp2b && (
+            <>
+              <MenuLink href="/level-3a" level={3}>
+                Level 3a
+              </MenuLink>
+              <MenuLink
+                href="/level-3b"
+                level={3}
+                subItems
+                expanded={exp3b}
+                onExpandToggle={() => setExp3b((v) => !v)}
+              >
+                Level 3b
+              </MenuLink>
+              {exp3b && (
+                <>
+                  <MenuLink href="/level-4a" level={4}>
+                    Level 4a
+                  </MenuLink>
+                  <MenuLink href="/level-4b" level={4}>
+                    Level 4b
+                  </MenuLink>
+                </>
+              )}
+              <MenuLink href="/level-3c" level={3}>
+                Level 3c
+              </MenuLink>
+              <MenuLink href="/level-3d" level={3}>
+                Level 3d
+              </MenuLink>
+            </>
+          )}
+          <MenuLink href="/level-2c" level={2}>
+            Level 2c
+          </MenuLink>
+          <MenuLink href="/level-2d" level={2}>
+            Level 2d
+          </MenuLink>
+        </>
+      )}
+
+      {/* Level 1c */}
+      <MenuLink href="/level-1c" level={1}>
+        Level 1c
+      </MenuLink>
+
+      {/* Level 1d */}
+      <MenuLink href="/level-1d" level={1}>
+        Level 1d
+      </MenuLink>
+    </Menu>
+  );
+}
+
+const secondaryNavigation = (
+  <Menu orientation="vertical">
+    <MenuLink href="/contact" level={1}>
+      Contact
+    </MenuLink>
+    <MenuLink href="/english" level={1}>
+      English
+    </MenuLink>
+    <MenuLink href="/mijn-omgeving" level={1}>
+      Mijn omgeving
+    </MenuLink>
+  </Menu>
+);
+
+const meta: Meta<typeof PageHeader> = {
+  title: 'Components/PageHeader',
+  component: PageHeader,
+  parameters: {
+    docs: { page: DocsPage },
+    layout: 'fullscreen',
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (_args: any) => {
+        return `<header class="dsn-page-header">
+  <div class="dsn-page-header__inner">
+    <div class="dsn-page-header__start">
+      <button type="button" class="dsn-button dsn-button--subtle">
+        <svg class="dsn-icon" aria-hidden="true"><!-- menu icon --></svg>
+        <span class="dsn-button__label">Menu</span>
+      </button>
+    </div>
+    <div class="dsn-page-header__logo">
+      <a href="/">
+        <svg class="dsn-logo" aria-hidden="true"><!-- logo --></svg>
+        <span class="dsn-visually-hidden">Naam organisatie — terug naar homepage</span>
+      </a>
+    </div>
+    <div class="dsn-page-header__end">
+      <button type="button" class="dsn-button dsn-button--subtle" aria-expanded="false" aria-controls="search-panel">
+        <svg class="dsn-icon" aria-hidden="true"><!-- search icon --></svg>
+        <span class="dsn-button__label">Zoeken</span>
+      </button>
+    </div>
+  </div>
+  <div class="dsn-page-header__search-panel" id="search-panel" hidden>
+    <div class="dsn-page-header__search-inner">
+      <div class="dsn-search-input-wrapper">
+        <input type="search" class="dsn-text-input dsn-search-input" placeholder="Zoeken…" aria-label="Zoekopdracht" />
+      </div>
+      <button type="button" class="dsn-button dsn-button--strong">
+        <span class="dsn-button__label">Zoeken</span>
+      </button>
+    </div>
+  </div>
+</header>`;
+      },
+    },
+  },
+  argTypes: {
+    sticky: {
+      control: 'select',
+      options: ['none', 'sticky', 'auto-hide'],
+    },
+  },
+  args: {
+    sticky: 'none',
+    logoSlot,
+    primaryNavigation: <PrimaryNavigation />,
+    secondaryNavigation,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PageHeader>;
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {};
+
+// =============================================================================
+// VARIANTEN
+// =============================================================================
+
+export const WithStickyHeader: Story = {
+  name: 'With sticky header',
+  args: {
+    sticky: 'sticky',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'De header blijft bovenaan de viewport vastgeplakt bij het scrollen. `position: sticky; inset-block-start: 0`.',
+      },
+    },
+  },
+};
+
+export const WithAutoHide: Story = {
+  name: 'With auto-hide',
+  args: {
+    sticky: 'auto-hide',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Sticky header die verbergt bij scroll-down en terugkomt bij scroll-up. JS beheert `data-hidden` attribuut; CSS-transitie verzorgt de animatie.',
+      },
+    },
+  },
+};
+
+export const WithSearchOpen: Story = {
+  name: 'With search open',
+  render: (args) => {
+    return (
+      <PageHeader
+        {...args}
+        onSearchOpen={() => {
+          /* search panel opens via internal state */
+        }}
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Klik op de zoekknop om het zoekpaneel te openen. Focus verplaatst automatisch naar het zoekveld.',
+      },
+    },
+  },
+};
+
+export const WithMenuOpen: Story = {
+  name: 'With menu open',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Klik op de menuknop om de navigatielade te openen. De Drawer schuift in vanuit links.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// OVERZICHTSSTORIES
+// =============================================================================
+
+export const AllStates: Story = {
+  name: 'All states',
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+      <div>
+        <p
+          style={{
+            marginBottom: '0.5rem',
+            fontWeight: 'bold',
+            fontSize: '0.875rem',
+          }}
+        >
+          Default (zoekpaneel gesloten)
+        </p>
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation />}
+          secondaryNavigation={secondaryNavigation}
+        />
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

- Implementeert de `PageHeader` component (issue #138) met mobile-first CSS-grid layout (`1fr auto 1fr`) die het logo centreert onafhankelijk van de knopbreedte
- Menuknop (inline-start) opent een `Drawer` met primaire navigatie en servicemenu; zoekknop (inline-end) toont een inline zoekpaneel met `SearchInput` + zoekknop
- Sticky en auto-hide varianten via `sticky` prop; auto-hide gebruikt `data-hidden` attribuut + CSS-transitie

## Wijzigingen

- `packages/design-tokens/src/tokens/components/page-header.json` — component tokens (achtergrond, border, padding, z-index, logo-hoogte, zoekpaneel)
- `packages/components-html/src/page-header/page-header.css` — HTML/CSS implementatie
- `packages/components-react/src/PageHeader/PageHeader.tsx` — React wrapper met focus management en scroll-listener
- `packages/components-react/src/PageHeader/PageHeader.test.tsx` — 24 tests (structuur, zoekpaneel, drawer, sticky, callbacks)
- `packages/components-react/src/PageHeader/PageHeader.css` — CSS import
- `packages/components-react/src/PageHeader/index.ts` — barrel export
- `packages/components-react/src/index.ts` — export toegevoegd
- `packages/storybook/src/PageHeader.stories.tsx` — stories incl. uitklapbaar 4-niveau menu
- `packages/storybook/src/PageHeader.docs.mdx` — Storybook docs page
- `packages/storybook/src/PageHeader.docs.md` — documentatie (doel, best practices, tokens, accessibility)
- `packages/storybook/src/Introduction.mdx` — bijgewerkt naar 50 componenten, v5.21.0

## Test plan

- [ ] `pnpm test` — alle 1272 tests groen
- [ ] `pnpm --filter storybook exec tsc --noEmit` — 0 TypeScript-fouten
- [ ] `pnpm lint` — 0 lint-fouten
- [ ] Storybook: Default, WithStickyHeader, WithAutoHide, WithSearchOpen, WithMenuOpen, AllStates stories controleren
- [ ] Menuknop opent Drawer met Level 1–4 uitklapbare navigatie
- [ ] Zoekknop opent zoekpaneel; SearchInput vult volle breedte; hoogte gelijk aan Zoeken-knop
- [ ] Focus bij openen zoekpaneel → input; bij sluiten → terug naar zoekknop
- [ ] Logo gecentreerd onafhankelijk van knopbreedte (CSS-grid `1fr auto 1fr`)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)