### PR TITLE
fix(tokens): gelijke hoogte voor input fields en buttons

### DIFF
--- a/packages/design-tokens/src/tokens/components/date-input.json
+++ b/packages/design-tokens/src/tokens/components/date-input.json
@@ -2,9 +2,9 @@
   "dsn": {
     "date-input": {
       "button-inset-inline-end": {
-        "value": "{dsn.space.inline.md}",
+        "value": "{dsn.space.inline.sm}",
         "type": "dimension",
-        "comment": "Distance from the inline-end border to the calendar button (8px)"
+        "comment": "Distance from the inline-end border to the calendar button (4px)"
       },
       "icon-gap": {
         "value": "{dsn.space.text.md}",

--- a/packages/design-tokens/src/tokens/components/time-input.json
+++ b/packages/design-tokens/src/tokens/components/time-input.json
@@ -2,9 +2,9 @@
   "dsn": {
     "time-input": {
       "button-inset-inline-end": {
-        "value": "{dsn.space.inline.md}",
+        "value": "{dsn.space.inline.sm}",
         "type": "dimension",
-        "comment": "Distance from the inline-end border to the clock button (8px)"
+        "comment": "Distance from the inline-end border to the clock button (4px)"
       },
       "icon-color": {
         "value": "{dsn.color.action-2.color-default}",

--- a/packages/design-tokens/src/tokens/themes/start/base.json
+++ b/packages/design-tokens/src/tokens/themes/start/base.json
@@ -404,14 +404,14 @@
         "comment": "Form control line height"
       },
       "padding-block-start": {
-        "value": "{dsn.space.block.lg}",
+        "value": "{dsn.space.block.md}",
         "type": "dimension",
-        "comment": "Form control top padding"
+        "comment": "Form control top padding — 8px zodat min-block-size (48px) de hoogte bepaalt, gelijk aan de button"
       },
       "padding-block-end": {
-        "value": "{dsn.space.block.lg}",
+        "value": "{dsn.space.block.md}",
         "type": "dimension",
-        "comment": "Form control bottom padding"
+        "comment": "Form control bottom padding — 8px zodat min-block-size (48px) de hoogte bepaalt, gelijk aan de button"
       },
       "padding-inline-start": {
         "value": "{dsn.space.inline.lg}",


### PR DESCRIPTION
Closes #141

## Summary

- `dsn.form-control.padding-block-start/end` in `base.json`: van `{dsn.space.block.lg}` (12px) naar `{dsn.space.block.md}` (8px) — de juiste laag om dit te fixen
- `text-input.json` delegeert correct naar `{dsn.form-control.padding-block-*}` zoals voorheen
- Cascadeert via de token-hiërarchie naar **TextInput**, **Select**, **SearchInput**, **DateInput** en **TimeInput**
- **TextArea** wordt ook meegenomen — `min-block-size: 48px` zorgt voor voldoende hoogte
- `button-inset-inline-end` bij DateInput en TimeInput: van 8px → 4px voor compactere icoonpositie

De tijdelijke workaround in `page-header.css` (token-overrides voor padding-block) wordt verwijderd in de `feature/page-header` PR zodra deze fix gemerged is.

## Test plan

- [x] `pnpm test` — 1234 tests groen
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [x] Token cascade geverifieerd: `form-control` → `text-input` / `text-area` via de juiste lagen

🤖 Generated with [Claude Code](https://claude.com/claude-code)