### PR TITLE
feat(PageHeader): compact layout variant voor large viewport

### DIFF
--- a/packages/components-html/src/page-header/page-header.css
+++ b/packages/components-html/src/page-header/page-header.css
@@ -41,7 +41,8 @@
    display: none verwijdert de sectie uit de accessibility tree.
    ============================================================================= */
 
-.dsn-page-header__large-layout {
+.dsn-page-header__large-layout,
+.dsn-page-header__compact-layout {
   display: none;
 }
 
@@ -58,6 +59,22 @@
      een accent-1 achtergrond die het visuele scheidingswerk overneemt */
   .dsn-page-header {
     border-block-end: none;
+  }
+
+  /* Compact variant: verberg default large layout, toon compact layout */
+  .dsn-page-header--compact .dsn-page-header__large-layout {
+    display: none;
+  }
+
+  .dsn-page-header--compact .dsn-page-header__compact-layout {
+    display: block;
+  }
+
+  /* Compact: border-block-end herstellen — geen accent-1 navbar als visueel
+     scheidingsmiddel, dus dezelfde border als op small viewport */
+  .dsn-page-header--compact {
+    border-block-end: var(--dsn-page-header-border-block-end-width) solid
+      var(--dsn-page-header-border-block-end-color);
   }
 }
 
@@ -111,6 +128,41 @@
 }
 
 /* =============================================================================
+   Compact layout (large viewport) — één rij: logo | primaire nav | servicemenu
+   CSS-grid 1fr auto 1fr centreert de primaire navigatie optisch tussen
+   logo (inline-start) en servicemenu + zoekknop (inline-end).
+   ============================================================================= */
+
+.dsn-page-header__compact-inner {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  background-color: var(--dsn-page-header-compact-background-color);
+  padding-block: var(--dsn-page-header-compact-padding-block);
+  padding-inline: var(--dsn-page-header-compact-padding-inline);
+}
+
+/* Logo in compact context links uitlijnen — niet centreren zoals in de mobile bar.
+   Scoped op de compact-inner zodat geen media query override nodig is. */
+.dsn-page-header__compact-inner .dsn-page-header__logo {
+  justify-content: flex-start;
+}
+
+/* Primaire navigatie in de middelste gridkolom */
+.dsn-page-header__compact-primary-nav {
+  display: flex;
+  justify-content: center;
+}
+
+/* Servicemenu + zoekknop uitgelijnd naar inline-end */
+.dsn-page-header__compact-secondary {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--dsn-page-header-secondary-nav-gap);
+}
+
+/* =============================================================================
    Navbar (large viewport) — accent-1 achtergrond, primaire navigatie
    ============================================================================= */
 
@@ -133,6 +185,8 @@
   position: sticky;
   inset-block-start: 0;
   z-index: var(--dsn-page-header-z-index);
+  transition: box-shadow var(--dsn-transition-duration-normal)
+    var(--dsn-transition-easing-default);
 }
 
 /* =============================================================================
@@ -144,12 +198,22 @@
   position: sticky;
   inset-block-start: 0;
   z-index: var(--dsn-page-header-z-index);
-  transition: transform var(--dsn-transition-duration-normal)
-    var(--dsn-transition-easing-default);
+  transition:
+    transform var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default),
+    box-shadow var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default);
 }
 
 .dsn-page-header--auto-hide[data-hidden='true'] {
   transform: translateY(-100%);
+}
+
+/* Drop-shadow zodra content onder de sticky/auto-hide header schuift.
+   JS zet data-scrolled="true" bij scrollY > 0, "false" aan de bovenkant. */
+.dsn-page-header--sticky[data-scrolled='true'],
+.dsn-page-header--auto-hide[data-scrolled='true'] {
+  box-shadow: var(--dsn-box-shadow-sm);
 }
 
 /* =============================================================================

--- a/packages/components-react/src/PageHeader/PageHeader.test.tsx
+++ b/packages/components-react/src/PageHeader/PageHeader.test.tsx
@@ -307,6 +307,165 @@ describe('PageHeader', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // initialSearchOpen
+  // ---------------------------------------------------------------------------
+
+  it('zoekpaneel is open bij initialSearchOpen={true}', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} initialSearchOpen={true} />
+    );
+    const panel = container.querySelector('.dsn-page-header__search-panel');
+    expect(panel).not.toHaveAttribute('hidden');
+  });
+
+  it('zoekknop heeft aria-expanded="true" bij initialSearchOpen={true}', () => {
+    render(<PageHeader logoSlot={defaultLogo} initialSearchOpen={true} />);
+    const searchButton = screen.getByRole('button', { name: /sluiten/i });
+    expect(searchButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Compact layout
+  // ---------------------------------------------------------------------------
+
+  it('heeft geen dsn-page-header--compact bij layout="default"', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} layout="default" />
+    );
+    expect(container.querySelector('header')).not.toHaveClass(
+      'dsn-page-header--compact'
+    );
+  });
+
+  it('heeft dsn-page-header--compact bij layout="compact"', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} layout="compact" />
+    );
+    expect(container.querySelector('header')).toHaveClass(
+      'dsn-page-header--compact'
+    );
+  });
+
+  it('rendert dsn-page-header__compact-layout bij layout="compact"', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} layout="compact" />
+    );
+    expect(
+      container.querySelector('.dsn-page-header__compact-layout')
+    ).toBeTruthy();
+  });
+
+  it('rendert geen dsn-page-header__compact-layout bij layout="default"', () => {
+    const { container } = render(<PageHeader logoSlot={defaultLogo} />);
+    expect(
+      container.querySelector('.dsn-page-header__compact-layout')
+    ).toBeNull();
+  });
+
+  it('compact layout rendert primaire navigatie', () => {
+    const { container } = render(
+      <PageHeader
+        logoSlot={defaultLogo}
+        layout="compact"
+        primaryNavigation={
+          <ul>
+            <li>Home</li>
+          </ul>
+        }
+      />
+    );
+    const compactLayout = container.querySelector(
+      '.dsn-page-header__compact-layout'
+    );
+    expect(compactLayout?.textContent).toContain('Home');
+  });
+
+  it('compact layout rendert servicemenu', () => {
+    const { container } = render(
+      <PageHeader
+        logoSlot={defaultLogo}
+        layout="compact"
+        secondaryNavigation={
+          <ul>
+            <li>Contact</li>
+          </ul>
+        }
+      />
+    );
+    const compactLayout = container.querySelector(
+      '.dsn-page-header__compact-layout'
+    );
+    expect(compactLayout?.textContent).toContain('Contact');
+  });
+
+  it('compact layout heeft aria-labelledby op primaire navigatie', () => {
+    const { container } = render(
+      <PageHeader
+        logoSlot={defaultLogo}
+        layout="compact"
+        primaryNavigation={<span>nav</span>}
+      />
+    );
+    const nav = container.querySelector(
+      '.dsn-page-header__compact-primary-nav nav'
+    );
+    const headingId = nav?.getAttribute('aria-labelledby');
+    expect(headingId).toBeTruthy();
+    expect(container.querySelector(`#${CSS.escape(headingId!)}`)).toBeTruthy();
+  });
+
+  it('compact layout heeft aria-labelledby op servicemenu', () => {
+    const { container } = render(
+      <PageHeader
+        logoSlot={defaultLogo}
+        layout="compact"
+        secondaryNavigation={<span>nav</span>}
+      />
+    );
+    const nav = container.querySelector(
+      '.dsn-page-header__compact-secondary nav'
+    );
+    const headingId = nav?.getAttribute('aria-labelledby');
+    expect(headingId).toBeTruthy();
+    expect(container.querySelector(`#${CSS.escape(headingId!)}`)).toBeTruthy();
+  });
+
+  it('compact layout heeft een zoekpaneel', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} layout="compact" />
+    );
+    const compactLayout = container.querySelector(
+      '.dsn-page-header__compact-layout'
+    );
+    expect(
+      compactLayout?.querySelector('.dsn-page-header__search-panel')
+    ).toBeTruthy();
+  });
+
+  it('compact zoekpaneel is standaard verborgen', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} layout="compact" />
+    );
+    const compactLayout = container.querySelector(
+      '.dsn-page-header__compact-layout'
+    );
+    const panel = compactLayout?.querySelector(
+      '.dsn-page-header__search-panel'
+    );
+    expect(panel).toHaveAttribute('hidden');
+  });
+
+  it('compact layout rendert het logo', () => {
+    const { container } = render(
+      <PageHeader logoSlot={defaultLogo} layout="compact" />
+    );
+    const compactLayout = container.querySelector(
+      '.dsn-page-header__compact-layout'
+    );
+    expect(compactLayout?.querySelector('.dsn-page-header__logo')).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
   // className en ref
   // ---------------------------------------------------------------------------
 

--- a/packages/components-react/src/PageHeader/PageHeader.tsx
+++ b/packages/components-react/src/PageHeader/PageHeader.tsx
@@ -8,6 +8,7 @@ import { Stack } from '../Stack';
 import './PageHeader.css';
 
 export type PageHeaderSticky = 'none' | 'sticky' | 'auto-hide';
+export type PageHeaderLayout = 'default' | 'compact';
 
 export interface PageHeaderProps extends Omit<
   React.HTMLAttributes<HTMLElement>,
@@ -27,6 +28,26 @@ export interface PageHeaderProps extends Omit<
    * @default 'none'
    */
   sticky?: PageHeaderSticky;
+
+  /**
+   * Lay-out van de header op large viewport (≥ 64em).
+   * - `default`: twee horizontale banden — Masthead (logo + servicemenu + zoekveld)
+   *   en Navigatiebalk (primaire navigatie op accent-1 achtergrond)
+   * - `compact`: één enkele rij — logo (inline-start), primaire navigatie (gecentreerd),
+   *   servicemenu + zoekknop (inline-end). Geeft `primaryNavigationLarge` voorrang
+   *   boven `primaryNavigation` (en idem voor secondary) zodat de Drawer altijd
+   *   de verticale variant ontvangt.
+   * @default 'default'
+   */
+  layout?: PageHeaderLayout;
+
+  /**
+   * Initiële open-staat van het zoekpaneel (small viewport).
+   * Handig voor Storybook en tests — het paneel kan daarna nog steeds
+   * worden geopend/gesloten via de knop.
+   * @default false
+   */
+  initialSearchOpen?: boolean;
 
   /**
    * Primaire navigatie-inhoud in de Drawer (small viewport) — doorgaans een verticale `<Menu>` met
@@ -119,6 +140,8 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
       className,
       logoSlot,
       sticky = 'none',
+      layout = 'default',
+      initialSearchOpen = false,
       primaryNavigation,
       primaryNavigationLarge,
       secondaryNavigation,
@@ -133,7 +156,7 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
     ref
   ) => {
     const [isMenuOpen, setIsMenuOpen] = React.useState(false);
-    const [isSearchOpen, setIsSearchOpen] = React.useState(false);
+    const [isSearchOpen, setIsSearchOpen] = React.useState(initialSearchOpen);
 
     const headerRef = React.useRef<HTMLElement>(null);
     const combinedRef = (ref as React.RefObject<HTMLElement>) ?? headerRef;
@@ -141,12 +164,17 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
     const menuButtonRef = React.useRef<HTMLButtonElement>(null);
     const searchButtonRef = React.useRef<HTMLButtonElement>(null);
     const searchInputRef = React.useRef<HTMLInputElement>(null);
+    const compactSearchButtonRef = React.useRef<HTMLButtonElement>(null);
+    const compactSearchInputRef = React.useRef<HTMLInputElement>(null);
 
     const searchPanelId = React.useId();
     const primaryNavId = React.useId();
     const serviceNavId = React.useId();
     const primaryNavLargeId = React.useId();
     const serviceNavLargeId = React.useId();
+    const compactSearchPanelId = React.useId();
+    const compactPrimaryNavId = React.useId();
+    const compactServiceNavId = React.useId();
 
     // Auto-hide: detecteer scrollrichting en toggle data-hidden attribuut
     React.useEffect(() => {
@@ -169,10 +197,30 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
       return () => window.removeEventListener('scroll', handleScroll);
     }, [sticky, combinedRef]);
 
-    // Focus management: bij openen zoekpaneel → focus naar input
+    // Drop-shadow: zet data-scrolled op "true" zodra de pagina gescrolled is.
+    // Werkt voor zowel sticky als auto-hide — ongeacht scrollrichting.
+    React.useEffect(() => {
+      if (sticky === 'none') return;
+
+      const updateScrolled = () => {
+        combinedRef.current?.setAttribute(
+          'data-scrolled',
+          String(window.scrollY > 0)
+        );
+      };
+
+      // Direct bij mount instellen (pagina kan al gescrolled zijn)
+      updateScrolled();
+
+      window.addEventListener('scroll', updateScrolled, { passive: true });
+      return () => window.removeEventListener('scroll', updateScrolled);
+    }, [sticky, combinedRef]);
+
+    // Focus management: bij openen zoekpaneel → focus naar input (klein of compact)
     React.useEffect(() => {
       if (isSearchOpen) {
         searchInputRef.current?.focus();
+        compactSearchInputRef.current?.focus();
       }
     }, [isSearchOpen]);
 
@@ -195,8 +243,9 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
         onSearchOpen?.();
       } else {
         onSearchClose?.();
-        // Focus terug naar zoek/sluit-knop (na state-update, via useEffect werkt ook)
+        // Focus terug naar zoek/sluit-knop — afhankelijk van actieve layout
         searchButtonRef.current?.focus();
+        compactSearchButtonRef.current?.focus();
       }
     };
 
@@ -204,6 +253,7 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
       'dsn-page-header',
       sticky === 'sticky' && 'dsn-page-header--sticky',
       sticky === 'auto-hide' && 'dsn-page-header--auto-hide',
+      layout === 'compact' && 'dsn-page-header--compact',
       className
     );
 
@@ -270,19 +320,88 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
           </div>
 
           {/* ----------------------------------------------------------------
-              Large viewport layout (zichtbaar boven 64em via CSS display:block)
+              Large viewport layout (zichtbaar boven 64em, alleen bij layout="default")
               ---------------------------------------------------------------- */}
-          <div className="dsn-page-header__large-layout">
-            {/* Masthead: neutrale achtergrond — logo + servicemenu + zoek */}
-            <div className="dsn-page-header__masthead">
-              <div className="dsn-page-header__masthead-inner">
+          {layout === 'default' && (
+            <div className="dsn-page-header__large-layout">
+              {/* Masthead: neutrale achtergrond — logo + servicemenu + zoek */}
+              <div className="dsn-page-header__masthead">
+                <div className="dsn-page-header__masthead-inner">
+                  <div className="dsn-page-header__logo">{logoSlot}</div>
+
+                  <div className="dsn-page-header__secondary-nav">
+                    {(secondaryNavigationLarge ?? secondaryNavigation) && (
+                      <nav aria-labelledby={serviceNavLargeId}>
+                        <h2
+                          id={serviceNavLargeId}
+                          className="dsn-visually-hidden"
+                        >
+                          Servicemenu
+                        </h2>
+                        {secondaryNavigationLarge ?? secondaryNavigation}
+                      </nav>
+                    )}
+                    {searchSlot && (
+                      <div className="dsn-page-header__searchbox">
+                        {searchSlot}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Navigatiebalk: accent-1 achtergrond — primaire navigatie (large viewport) */}
+              <div className="dsn-page-header__navbar">
+                <div className="dsn-page-header__navbar-inner">
+                  {(primaryNavigationLarge ?? primaryNavigation) && (
+                    <nav aria-labelledby={primaryNavLargeId}>
+                      <h2
+                        id={primaryNavLargeId}
+                        className="dsn-visually-hidden"
+                      >
+                        Hoofdmenu
+                      </h2>
+                      {primaryNavigationLarge ?? primaryNavigation}
+                    </nav>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* ----------------------------------------------------------------
+              Compact layout (zichtbaar boven 64em wanneer layout="compact")
+              Eén rij: logo (1fr) | primaire navigatie (auto) | servicemenu + zoek (1fr)
+              ---------------------------------------------------------------- */}
+          {layout === 'compact' && (
+            <div className="dsn-page-header__compact-layout">
+              <div className="dsn-page-header__compact-inner">
+                {/* Logo — inline-start (eerste gridkolom) */}
                 <div className="dsn-page-header__logo">{logoSlot}</div>
 
-                <div className="dsn-page-header__secondary-nav">
-                  {(secondaryNavigationLarge ?? secondaryNavigation) && (
-                    <nav aria-labelledby={serviceNavLargeId}>
+                {/* Primaire navigatie — gecentreerd (middelste gridkolom)
+                    Gebruikt primaryNavigationLarge als aanwezig, anders primaryNavigation.
+                    Dit garandeert dat de Drawer altijd de verticale variant ontvangt. */}
+                <div className="dsn-page-header__compact-primary-nav">
+                  {(primaryNavigationLarge ?? primaryNavigation) && (
+                    <nav aria-labelledby={compactPrimaryNavId}>
                       <h2
-                        id={serviceNavLargeId}
+                        id={compactPrimaryNavId}
+                        className="dsn-visually-hidden"
+                      >
+                        Hoofdmenu
+                      </h2>
+                      {primaryNavigationLarge ?? primaryNavigation}
+                    </nav>
+                  )}
+                </div>
+
+                {/* Servicemenu + zoekknop (icon-only) — inline-end (derde gridkolom) */}
+                <div className="dsn-page-header__compact-secondary">
+                  {(secondaryNavigationLarge ?? secondaryNavigation) && (
+                    <nav aria-labelledby={compactServiceNavId}>
+                      <h2
+                        id={compactServiceNavId}
                         className="dsn-visually-hidden"
                       >
                         Servicemenu
@@ -290,29 +409,39 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
                       {secondaryNavigationLarge ?? secondaryNavigation}
                     </nav>
                   )}
-                  {searchSlot && (
-                    <div className="dsn-page-header__searchbox">
-                      {searchSlot}
-                    </div>
-                  )}
+                  <Button
+                    ref={compactSearchButtonRef}
+                    variant="subtle"
+                    iconOnly
+                    aria-expanded={isSearchOpen}
+                    aria-controls={compactSearchPanelId}
+                    onClick={handleSearchToggle}
+                    iconStart={
+                      <Icon name={isSearchOpen ? 'x' : 'search'} aria-hidden />
+                    }
+                  >
+                    {isSearchOpen ? 'Sluiten' : 'Zoeken'}
+                  </Button>
+                </div>
+              </div>
+
+              {/* Zoekpaneel compact layout */}
+              <div
+                id={compactSearchPanelId}
+                className="dsn-page-header__search-panel"
+                hidden={!isSearchOpen}
+              >
+                <div className="dsn-page-header__search-inner">
+                  <SearchInput
+                    ref={compactSearchInputRef}
+                    placeholder="Zoeken…"
+                    aria-label="Zoekopdracht"
+                  />
+                  <Button variant="strong">Zoeken</Button>
                 </div>
               </div>
             </div>
-
-            {/* Navigatiebalk: accent-1 achtergrond — primaire navigatie (large viewport) */}
-            <div className="dsn-page-header__navbar">
-              <div className="dsn-page-header__navbar-inner">
-                {(primaryNavigationLarge ?? primaryNavigation) && (
-                  <nav aria-labelledby={primaryNavLargeId}>
-                    <h2 id={primaryNavLargeId} className="dsn-visually-hidden">
-                      Hoofdmenu
-                    </h2>
-                    {primaryNavigationLarge ?? primaryNavigation}
-                  </nav>
-                )}
-              </div>
-            </div>
-          </div>
+          )}
         </header>
 
         {/* Navigatielade (sibling aan PageHeader, altijd in DOM) */}

--- a/packages/design-tokens/src/tokens/components/page-header.json
+++ b/packages/design-tokens/src/tokens/components/page-header.json
@@ -90,6 +90,23 @@
           "type": "spacing",
           "comment": "Horizontale padding van het zoekpaneel"
         }
+      },
+      "compact": {
+        "background-color": {
+          "value": "{dsn.color.neutral.bg-document}",
+          "type": "color",
+          "comment": "Achtergrond van de compacte balk — zelfde neutrale kleur als masthead; de primaire navigatie staat hier direct naast het logo zonder aparte navbar"
+        },
+        "padding-block": {
+          "value": "{dsn.space.block.xl}",
+          "type": "spacing",
+          "comment": "Verticale ademruimte in de compacte balk — zelfde schaal als masthead"
+        },
+        "padding-inline": {
+          "value": "{dsn.space.inline.xl}",
+          "type": "spacing",
+          "comment": "Horizontale padding van de compacte balk — zelfde schaal als masthead en navbar"
+        }
       }
     }
   }

--- a/packages/storybook/src/PageHeader.stories.tsx
+++ b/packages/storybook/src/PageHeader.stories.tsx
@@ -8,6 +8,7 @@ import {
   PageHeader,
   SearchInput,
 } from '@dsn/components-react';
+import { rtlDecorator } from './story-helpers';
 
 // =============================================================================
 // META
@@ -133,9 +134,6 @@ function PrimaryNavigation() {
 
 const secondaryNavigation = (
   <Menu orientation="vertical">
-    <MenuLink href="/contact" level={1}>
-      Contact
-    </MenuLink>
     <MenuLink href="/english" level={1}>
       English
     </MenuLink>
@@ -148,9 +146,6 @@ const secondaryNavigation = (
 /** Large viewport: horizontale servicemenu zonder verticale hiërarchie */
 const secondaryNavigationLarge = (
   <Menu orientation="horizontal">
-    <MenuLink href="/contact" level={1}>
-      Contact
-    </MenuLink>
     <MenuLink href="/english" level={1}>
       English
     </MenuLink>
@@ -182,6 +177,82 @@ const searchSlot = (
   <>
     <SearchInput placeholder="Zoeken…" aria-label="Zoekopdracht" />
     <Button variant="strong">Zoeken</Button>
+  </>
+);
+
+// =============================================================================
+// ARABISCHE CONTENT (voor RTL stories)
+// =============================================================================
+
+const logoSlotAR = (
+  <a href="/">
+    <Logo aria-hidden={true} />
+    <span className="dsn-visually-hidden">
+      Starter Kit — العودة إلى الصفحة الرئيسية
+    </span>
+  </a>
+);
+
+const primaryNavigationAR = (
+  <Menu orientation="vertical">
+    <MenuLink href="/home" level={1} current>
+      الرئيسية
+    </MenuLink>
+    <MenuLink href="/about" level={1}>
+      عن الشركة
+    </MenuLink>
+    <MenuLink href="/services" level={1}>
+      الخدمات
+    </MenuLink>
+    <MenuLink href="/news" level={1}>
+      أخبار
+    </MenuLink>
+  </Menu>
+);
+
+const primaryNavigationLargeAR = (
+  <Menu orientation="horizontal">
+    <MenuLink href="/home" level={1} current>
+      الرئيسية
+    </MenuLink>
+    <MenuLink href="/about" level={1}>
+      عن الشركة
+    </MenuLink>
+    <MenuLink href="/services" level={1}>
+      الخدمات
+    </MenuLink>
+    <MenuLink href="/news" level={1}>
+      أخبار
+    </MenuLink>
+  </Menu>
+);
+
+const secondaryNavigationAR = (
+  <Menu orientation="vertical">
+    <MenuLink href="/english" level={1}>
+      English
+    </MenuLink>
+    <MenuLink href="/my-env" level={1}>
+      بيئتي
+    </MenuLink>
+  </Menu>
+);
+
+const secondaryNavigationLargeAR = (
+  <Menu orientation="horizontal">
+    <MenuLink href="/english" level={1}>
+      English
+    </MenuLink>
+    <MenuLink href="/my-env" level={1}>
+      بيئتي
+    </MenuLink>
+  </Menu>
+);
+
+const searchSlotAR = (
+  <>
+    <SearchInput placeholder="بحث…" aria-label="مصطلح البحث" />
+    <Button variant="strong">بحث</Button>
   </>
 );
 
@@ -233,6 +304,15 @@ const meta: Meta<typeof PageHeader> = {
     sticky: {
       control: 'select',
       options: ['none', 'sticky', 'auto-hide'],
+      table: { category: 'Gedrag' },
+    },
+    layout: {
+      control: 'select',
+      options: ['default', 'compact'],
+      table: { category: 'Gedrag' },
+    },
+    initialSearchOpen: {
+      control: 'boolean',
       table: { category: 'Gedrag' },
     },
     // ── Slots — ReactNode, niet bewerkbaar via controls ──────────────────────
@@ -292,6 +372,24 @@ const meta: Meta<typeof PageHeader> = {
 export default meta;
 type Story = StoryObj<typeof PageHeader>;
 
+// Helper: wat paginacontent zodat scroll-gedrag testbaar is
+function PageContent() {
+  return (
+    <main style={{ padding: '2rem', maxWidth: '60rem', margin: '0 auto' }}>
+      {Array.from({ length: 8 }, (_, i) => (
+        <p key={i} style={{ marginBlockEnd: '1rem', lineHeight: '1.6' }}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur.
+        </p>
+      ))}
+    </main>
+  );
+}
+
 // =============================================================================
 // DEFAULT
 // =============================================================================
@@ -307,6 +405,12 @@ export const WithStickyHeader: Story = {
   args: {
     sticky: 'sticky',
   },
+  render: (args) => (
+    <>
+      <PageHeader {...args} />
+      <PageContent />
+    </>
+  ),
   parameters: {
     docs: {
       description: {
@@ -322,11 +426,17 @@ export const WithAutoHide: Story = {
   args: {
     sticky: 'auto-hide',
   },
+  render: (args) => (
+    <>
+      <PageHeader {...args} />
+      <PageContent />
+    </>
+  ),
   parameters: {
     docs: {
       description: {
         story:
-          'Sticky header die verbergt bij scroll-down en terugkomt bij scroll-up. JS beheert `data-hidden` attribuut; CSS-transitie verzorgt de animatie.',
+          'Sticky header die verbergt bij scroll-down en terugkomt bij scroll-up. Scroll omlaag om de header te verbergen; scroll omhoog om hem terug te brengen.',
       },
     },
   },
@@ -334,21 +444,14 @@ export const WithAutoHide: Story = {
 
 export const WithSearchOpen: Story = {
   name: 'With search open',
-  render: (args) => {
-    return (
-      <PageHeader
-        {...args}
-        onSearchOpen={() => {
-          /* search panel opens via internal state */
-        }}
-      />
-    );
+  args: {
+    initialSearchOpen: true,
   },
   parameters: {
     docs: {
       description: {
         story:
-          'Klik op de zoekknop om het zoekpaneel te openen. Focus verplaatst automatisch naar het zoekveld.',
+          'Het zoekpaneel is standaard open (`initialSearchOpen={true}`). Focus verplaatst automatisch naar het zoekveld.',
       },
     },
   },
@@ -369,6 +472,91 @@ export const WithMenuOpen: Story = {
 // =============================================================================
 // OVERZICHTSSTORIES
 // =============================================================================
+
+export const CompactLayout: Story = {
+  name: 'Compact layout',
+  args: {
+    layout: 'compact',
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'Op viewports ≥ 64em toont de compact variant één enkele rij: logo (inline-start), primaire navigatie (optisch gecentreerd via CSS-grid `1fr auto 1fr`), en servicemenu + zoek-iconknop (inline-end). Gebruikt `primaryNavigationLarge` voor de compacte balk en `primaryNavigation` (verticaal) voor de Drawer op small viewport.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// RTL
+// =============================================================================
+
+export const RTL: Story = {
+  name: 'RTL',
+  decorators: [rtlDecorator],
+  args: {
+    logoSlot: logoSlotAR,
+    primaryNavigation: primaryNavigationAR,
+    primaryNavigationLarge: primaryNavigationLargeAR,
+    secondaryNavigation: secondaryNavigationAR,
+    secondaryNavigationLarge: secondaryNavigationLargeAR,
+    searchSlot: searchSlotAR,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Right-to-left layout (Arabisch) op small viewport. Logo staat inline-end, menuknop inline-start. CSS logische eigenschappen spiegelen automatisch.',
+      },
+    },
+  },
+};
+
+export const RTLLargeViewport: Story = {
+  name: 'RTL large viewport',
+  decorators: [rtlDecorator],
+  args: {
+    logoSlot: logoSlotAR,
+    primaryNavigation: primaryNavigationAR,
+    primaryNavigationLarge: primaryNavigationLargeAR,
+    secondaryNavigation: secondaryNavigationAR,
+    secondaryNavigationLarge: secondaryNavigationLargeAR,
+    searchSlot: searchSlotAR,
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'RTL op large viewport — masthead (logo rechts, servicemenu links) en navbar gespiegeld.',
+      },
+    },
+  },
+};
+
+export const RTLCompact: Story = {
+  name: 'RTL compact layout',
+  decorators: [rtlDecorator],
+  args: {
+    layout: 'compact',
+    logoSlot: logoSlotAR,
+    primaryNavigation: primaryNavigationAR,
+    primaryNavigationLarge: primaryNavigationLargeAR,
+    secondaryNavigation: secondaryNavigationAR,
+    secondaryNavigationLarge: secondaryNavigationLargeAR,
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'RTL compact layout — logo inline-end, primaire navigatie gecentreerd, servicemenu + zoekknop inline-start.',
+      },
+    },
+  },
+};
 
 export const LargeViewport: Story = {
   name: 'Large viewport',


### PR DESCRIPTION
## Summary

- Voegt `layout="compact"` toe aan PageHeader: één enkele rij met logo (inline-start), primaire navigatie (optisch gecentreerd via CSS-grid `1fr auto 1fr`) en servicemenu + icon-only zoekknop (inline-end) op viewports ≥ 64em
- Drop-shadow op sticky/auto-hide header zodra content eronder schuift (`data-scrolled` attribuut + CSS box-shadow transitie)
- `initialSearchOpen` prop voor initiële open-staat van het zoekpaneel
- RTL stories bijgewerkt met Arabische navigatieteksten via `rtlDecorator`

## Wijzigingen

**Design tokens** (`page-header.json`): `compact.background-color`, `compact.padding-block`, `compact.padding-inline`

**CSS** (`page-header.css`):
- `.dsn-page-header--compact` modifier + `.dsn-page-header__compact-layout` / `__compact-inner` / `__compact-primary-nav` / `__compact-secondary`
- Logo links uitgelijnd in compact context (`.dsn-page-header__compact-inner .dsn-page-header__logo`)
- `border-block-end` hersteld op large viewport voor compact variant
- `box-shadow` transitie op `--sticky` en `--auto-hide`; actief via `[data-scrolled='true']`

**Component** (`PageHeader.tsx`):
- `layout?: 'default' | 'compact'` prop
- `initialSearchOpen?: boolean` prop
- Compact layout gebruikt `primaryNavigationLarge ?? primaryNavigation` zodat Drawer altijd de verticale variant ontvangt
- Scroll listener zet `data-scrolled` voor sticky én auto-hide

**Stories** (`PageHeader.stories.tsx`):
- `CompactLayout`, `WithStickyHeader` (+ content), `WithAutoHide` (+ content), `WithSearchOpen` (direct open)
- RTL stories: `rtlDecorator` + Arabische navigatieteksten
- Contact verwijderd uit secondary navigation

## Test plan

- [ ] Compact layout op large viewport: logo links, nav gecentreerd, servicemenu + zoekicon rechts
- [ ] Compact layout op small viewport: identiek aan default (menu + logo + zoeken)
- [ ] Sticky header: drop-shadow verschijnt bij scrollen, verdwijnt bovenaan
- [ ] Auto-hide header: drop-shadow + verberg/toon animatie werken samen
- [ ] RTL stories: Arabisch + gespiegelde layout
- [ ] `initialSearchOpen={true}`: paneel direct open
- [ ] 1305 tests groen, TypeScript schoon, lint schoon

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)