### PR TITLE
feat(PageHeader): inverse kleurvariant

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pnpm --filter @dsn/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (1292 tests across 64 test suites)
+# Run tests (1305 tests across 64 test suites)
 pnpm test
 
 # Run tests in watch mode

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1908,14 +1908,16 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 **Tokens:** `tokens/components/page-header.json`
 
-**Props:** `logoSlot`, `sticky` (`'none'` | `'sticky'` | `'auto-hide'`), `primaryNavigation`, `primaryNavigationLarge`, `secondaryNavigation`, `secondaryNavigationLarge`, `searchSlot`, `onMenuOpen`, `onMenuClose`, `onSearchOpen`, `onSearchClose`, `className`
+**Props:** `logoSlot`, `sticky` (`'none'` | `'sticky'` | `'auto-hide'`), `layout` (`'default'` | `'compact'`), `colorScheme` (`'default'` | `'inverse'`), `initialSearchOpen`, `primaryNavigation`, `primaryNavigationLarge`, `secondaryNavigation`, `secondaryNavigationLarge`, `searchSlot`, `onMenuOpen`, `onMenuClose`, `onSearchOpen`, `onSearchClose`, `className`
 
 **Features:**
 
 - Mobile-first: hamburgerknop (inline-start) opent een `Drawer`, gecentreerd logo (CSS-grid `1fr auto 1fr`), zoekknop (inline-end) ontvouwt zoekpaneel direct onder de header
-- Boven `64em` (~1024px): tweebandig large viewport layout via `display: none` switch
+- Boven `64em` (~1024px): tweebandig large viewport layout via `display: none` switch (`layout="default"`, standaard)
   - **Masthead** — neutrale achtergrond met logo (inline-start), servicemenu en inline zoekveld (inline-end)
   - **Navigatiebalk** — accent-1 achtergrond met primaire navigatie; MenuLink-items krijgen `min-block-size: 4rem` en `padding-inline: var(--dsn-space-inline-xl)` via token-overschrijving op de container
+- `layout="compact"` — één rij op large viewport: logo (inline-start) | primaire navigatie (gecentreerd, CSS-grid `1fr auto 1fr`) | servicemenu + icon-only zoekknop (inline-end)
+- `colorScheme="inverse"` — accent-1-inverse achtergrond op navbar, compact balk en zoekpaneel; masthead blijft neutraal; logo en menu-items passen kleuren automatisch aan via CSS custom property overrides
 - `primaryNavigationLarge` / `secondaryNavigationLarge` — aparte slots voor large viewport; valt terug op de mobile variant wanneer weggelaten
 - `sticky='sticky'`: `position: sticky; inset-block-start: 0`
 - `sticky='auto-hide'`: sticky + verbergt bij scroll-down via JS `scroll`-eventlistener (`data-hidden` attribuut), CSS-transitie animeert de beweging
@@ -1925,24 +1927,30 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 **CSS-klassen:**
 
-| Klasse                            | Element    | Beschrijving                                          |
-| --------------------------------- | ---------- | ----------------------------------------------------- |
-| `dsn-page-header`                 | `<header>` | Basiscomponent                                        |
-| `dsn-page-header--sticky`         | `<header>` | Sticky gedrag: `position: sticky`                     |
-| `dsn-page-header--auto-hide`      | `<header>` | Auto-hide sticky: CSS-transitie op `data-hidden`      |
-| `dsn-page-header__small-layout`   | `<div>`    | Zichtbaar op small viewport (`< 64em`)                |
-| `dsn-page-header__large-layout`   | `<div>`    | Zichtbaar op large viewport (`≥ 64em`)                |
-| `dsn-page-header__inner`          | `<div>`    | CSS-grid (`1fr auto 1fr`) voor gecentreerd logo       |
-| `dsn-page-header__start`          | `<div>`    | Inline-start slot (hamburgerknop)                     |
-| `dsn-page-header__logo`           | `<div>`    | Logo-slot; `max-block-size` op directe child          |
-| `dsn-page-header__end`            | `<div>`    | Inline-end slot (zoekknop)                            |
-| `dsn-page-header__search-panel`   | `<div>`    | Zoekpaneel (small viewport); verborgen via `[hidden]` |
-| `dsn-page-header__search-inner`   | `<div>`    | Flex-container: zoekveld + zoekknop                   |
-| `dsn-page-header__masthead`       | `<div>`    | Bovenste band large viewport (neutrale achtergrond)   |
-| `dsn-page-header__masthead-inner` | `<div>`    | Flex-container: logo ↔ secondary-nav                  |
-| `dsn-page-header__secondary-nav`  | `<div>`    | Servicemenu + zoekveld naast elkaar (inline-end)      |
-| `dsn-page-header__searchbox`      | `<div>`    | Inline zoekveld + zoekknop in masthead                |
-| `dsn-page-header__navbar`         | `<div>`    | Onderste band large viewport (accent-1 achtergrond)   |
+| Klasse                                 | Element    | Beschrijving                                                    |
+| -------------------------------------- | ---------- | --------------------------------------------------------------- |
+| `dsn-page-header`                      | `<header>` | Basiscomponent                                                  |
+| `dsn-page-header--sticky`              | `<header>` | Sticky gedrag: `position: sticky`                               |
+| `dsn-page-header--auto-hide`           | `<header>` | Auto-hide sticky: CSS-transitie op `data-hidden`                |
+| `dsn-page-header--compact`             | `<header>` | Compact layout: één rij op large viewport                       |
+| `dsn-page-header--inverse`             | `<header>` | Inverse kleurvariant: accent-1-inverse achtergronden            |
+| `dsn-page-header__small-layout`        | `<div>`    | Zichtbaar op small viewport (`< 64em`)                          |
+| `dsn-page-header__large-layout`        | `<div>`    | Zichtbaar op large viewport (`≥ 64em`, default layout)          |
+| `dsn-page-header__compact-layout`      | `<div>`    | Zichtbaar op large viewport (`≥ 64em`, compact layout)          |
+| `dsn-page-header__inner`               | `<div>`    | CSS-grid (`1fr auto 1fr`) voor gecentreerd logo                 |
+| `dsn-page-header__start`               | `<div>`    | Inline-start slot (hamburgerknop)                               |
+| `dsn-page-header__logo`                | `<div>`    | Logo-slot; `max-block-size` op directe child                    |
+| `dsn-page-header__end`                 | `<div>`    | Inline-end slot (zoekknop)                                      |
+| `dsn-page-header__search-panel`        | `<div>`    | Zoekpaneel (small + compact viewport); verborgen via `[hidden]` |
+| `dsn-page-header__search-inner`        | `<div>`    | Flex-container: zoekveld + zoekknop                             |
+| `dsn-page-header__masthead`            | `<div>`    | Bovenste band large viewport (neutrale achtergrond)             |
+| `dsn-page-header__masthead-inner`      | `<div>`    | Flex-container: logo ↔ secondary-nav                            |
+| `dsn-page-header__secondary-nav`       | `<div>`    | Servicemenu + zoekveld naast elkaar (inline-end)                |
+| `dsn-page-header__searchbox`           | `<div>`    | Inline zoekveld + zoekknop in masthead                          |
+| `dsn-page-header__navbar`              | `<div>`    | Onderste band large viewport (accent-1 achtergrond)             |
+| `dsn-page-header__compact-inner`       | `<div>`    | CSS-grid (`1fr auto 1fr`) compact balk                          |
+| `dsn-page-header__compact-primary-nav` | `<div>`    | Primaire nav gecentreerd in compact balk                        |
+| `dsn-page-header__compact-secondary`   | `<div>`    | Servicemenu + zoekknop (inline-end) in compact balk             |
 
 **Design tokens:**
 
@@ -1964,6 +1972,9 @@ const [isOpen, setIsOpen] = React.useState(false);
 | `--dsn-page-header-navbar-background-color`       | `{dsn.color.accent-1.bg-default}`    | Navigatiebalk achtergrond                   |
 | `--dsn-page-header-navbar-padding-inline`         | `{dsn.space.inline.xl}`              | Horizontale padding navigatiebalk           |
 | `--dsn-page-header-secondary-nav-gap`             | `{dsn.space.column.3xl}`             | Gap servicemenu ↔ zoekveld in masthead      |
+| `--dsn-page-header-compact-background-color`      | `{dsn.color.neutral.bg-document}`    | Achtergrond compact balk (large viewport)   |
+| `--dsn-page-header-compact-padding-block`         | `{dsn.space.block.xl}`               | Verticale padding compact balk              |
+| `--dsn-page-header-compact-padding-inline`        | `{dsn.space.inline.xl}`              | Horizontale padding compact balk            |
 
 **Usage:**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,45 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 5.24.0 (April 10, 2026)
+
+### PageHeader: inverse kleurvariant (issue #151)
+
+#### Added
+
+- **`colorScheme` prop** op `PageHeader` — `'default'` (standaard) | `'inverse'` — activeert de `dsn-page-header--inverse` modifier
+- **Inverse kleurvariant** (`colorScheme="inverse"`): accent-1-inverse achtergronden op navbar en compact balk voor prominente branding
+  - Navbar (large default layout): `accent-1-inverse.bg-default`
+  - Compact balk (large compact layout): `accent-1-inverse.bg-default`
+  - Zoekpaneel: `accent-1-inverse.bg-document` (iets donkerder voor visuele scheiding)
+  - Small viewport header-balk: `accent-1-inverse.bg-default`
+  - Masthead blijft ongewijzigd op `neutral.bg-document`
+- **Logo-kleuren passen zich automatisch aan** via CSS custom property overrides op `.dsn-page-header--inverse`: `--dsn-logo-color-primary` en `--dsn-logo-color-label` omgedraaid voor donkere achtergrond; reset in masthead-context
+- **Menu-items en buttons zichtbaar** op inverse achtergrond via context-gebonden token-overrides: `--dsn-menu-item-color`, `--dsn-menu-link-current-*` en `--dsn-button-subtle-color` → wit (`accent-1-inverse.color-default`) op alle inverse vlakken
+- Orthogonaal modifier — combineerbaar met alle andere props: `layout="compact" colorScheme="inverse"` werkt correct
+- 2 nieuwe Storybook stories: `Inverse color scheme` en `Inverse compact layout`
+
+---
+
+## Version 5.23.0 (April 9, 2026)
+
+### PageHeader: compact layout (issue #147, PR #147)
+
+#### Added
+
+- **`layout` prop** op `PageHeader` — `'default'` (standaard) | `'compact'` — activeert de `dsn-page-header--compact` modifier
+- **Compact layout** (large viewport ≥ 64em): één enkele rij via CSS-grid `1fr auto 1fr`:
+  - Logo (inline-start, eerste kolom)
+  - Primaire navigatie (optisch gecentreerd, middelste kolom)
+  - Servicemenu + icon-only zoekknop (inline-end, derde kolom)
+- `primaryNavigationLarge` / `secondaryNavigationLarge` worden ook in de compacte balk gebruikt (Drawer ontvangt altijd de verticale variant)
+- Zoekpaneel (`dsn-page-header__search-panel`) ook beschikbaar in compact layout, getriggerd via icon-only zoekknop
+- CSS-klassen: `dsn-page-header--compact`, `dsn-page-header__compact-layout`, `dsn-page-header__compact-inner`, `dsn-page-header__compact-primary-nav`, `dsn-page-header__compact-secondary`
+- 3 nieuwe design tokens: `compact.background-color` (`{dsn.color.neutral.bg-document}`), `compact.padding-block` (`{dsn.space.block.xl}`), `compact.padding-inline` (`{dsn.space.inline.xl}`)
+- 3 nieuwe Storybook stories: `Compact layout`, `RTL compact layout` en `AllStates`
+
+---
+
 ## Version 5.22.0 (April 9, 2026)
 
 ### SkipLink component (issue #148, PR #149)

--- a/packages/components-html/src/page-header/page-header.css
+++ b/packages/components-html/src/page-header/page-header.css
@@ -307,3 +307,111 @@
   --dsn-text-input-padding-block-start: var(--dsn-space-block-md);
   --dsn-text-input-padding-block-end: var(--dsn-space-block-md);
 }
+
+/* =============================================================================
+   Inverse kleurvariant — accent-1-inverse achtergrond voor prominente branding
+   Navbar + compact bar: accent-1-inverse.bg-default
+   Zoekpaneel: accent-1-inverse.bg-document (iets donkerder voor visuele scheiding)
+   Masthead: ongewijzigd (neutral.bg-document)
+   Logo-kleuren passen zich automatisch aan via CSS custom property overrides.
+   ============================================================================= */
+
+.dsn-page-header--inverse {
+  /* Small viewport: header-balk en border krijgen de inverse achtergrondkleur */
+  --dsn-page-header-background-color: var(
+    --dsn-color-accent-1-inverse-bg-default
+  );
+  --dsn-page-header-border-block-end-color: var(
+    --dsn-color-accent-1-inverse-bg-default
+  );
+  /* Navbar (large default layout) */
+  --dsn-page-header-navbar-background-color: var(
+    --dsn-color-accent-1-inverse-bg-default
+  );
+  /* Zoekpaneel: bg-document is donkerder dan bg-default — visuele scheiding */
+  --dsn-page-header-search-panel-background-color: var(
+    --dsn-color-accent-1-inverse-bg-document
+  );
+  /* Compact layout balk */
+  --dsn-page-header-compact-background-color: var(
+    --dsn-color-accent-1-inverse-bg-default
+  );
+  /* Logo: primaire kleur en label omdraaien voor donkere achtergrond */
+  --dsn-logo-color-primary: var(--dsn-color-accent-1-inverse-color-default);
+  --dsn-logo-color-label: var(--dsn-color-accent-1-inverse-bg-default);
+}
+
+/* Masthead blijft op neutrale achtergrond — logo kleuren resetten naar standaard */
+.dsn-page-header--inverse .dsn-page-header__masthead {
+  --dsn-logo-color-primary: var(--dsn-color-accent-1-inverse-bg-default);
+  --dsn-logo-color-label: var(--dsn-color-neutral-bg-document);
+}
+
+/* Buttons in de header-balk (small viewport: menu + zoekknop) op inverse achtergrond */
+.dsn-page-header--inverse .dsn-page-header__small-layout {
+  --dsn-button-subtle-color: var(--dsn-color-accent-1-inverse-color-default);
+  --dsn-button-subtle-hover-background-color: var(
+    --dsn-color-accent-1-inverse-bg-hover
+  );
+  --dsn-button-subtle-hover-color: var(
+    --dsn-color-accent-1-inverse-color-hover
+  );
+  --dsn-button-subtle-active-background-color: var(
+    --dsn-color-accent-1-inverse-bg-active
+  );
+  --dsn-button-subtle-active-color: var(
+    --dsn-color-accent-1-inverse-color-active
+  );
+}
+
+/* Menu-items + expand-buttons + zoekknop in de inverse navbar en compacte navigatie */
+.dsn-page-header--inverse .dsn-page-header__navbar,
+.dsn-page-header--inverse .dsn-page-header__compact-primary-nav,
+.dsn-page-header--inverse .dsn-page-header__compact-secondary {
+  /* Menu-item kleuren: tekst en interactiestaten */
+  --dsn-menu-item-color: var(--dsn-color-accent-1-inverse-color-default);
+  --dsn-menu-item-hover-color: var(--dsn-color-accent-1-inverse-color-hover);
+  --dsn-menu-item-hover-background-color: var(
+    --dsn-color-accent-1-inverse-bg-hover
+  );
+  --dsn-menu-item-active-color: var(--dsn-color-accent-1-inverse-color-active);
+  --dsn-menu-item-active-background-color: var(
+    --dsn-color-accent-1-inverse-bg-active
+  );
+  /* MenuLink current (actieve pagina) */
+  --dsn-menu-link-current-color: var(
+    --dsn-color-accent-1-inverse-color-default
+  );
+  --dsn-menu-link-current-background-color: var(
+    --dsn-color-accent-1-inverse-bg-active
+  );
+  --dsn-menu-link-current-indicator-color: var(
+    --dsn-color-accent-1-inverse-color-default
+  );
+  --dsn-menu-link-current-hover-color: var(
+    --dsn-color-accent-1-inverse-color-hover
+  );
+  --dsn-menu-link-current-hover-background-color: var(
+    --dsn-color-accent-1-inverse-bg-active
+  );
+  --dsn-menu-link-current-active-color: var(
+    --dsn-color-accent-1-inverse-color-active
+  );
+  --dsn-menu-link-current-active-background-color: var(
+    --dsn-color-accent-1-inverse-bg-active
+  );
+  /* Subtle buttons: uitklapknop in MenuLink + icon-only zoekknop */
+  --dsn-button-subtle-color: var(--dsn-color-accent-1-inverse-color-default);
+  --dsn-button-subtle-hover-background-color: var(
+    --dsn-color-accent-1-inverse-bg-hover
+  );
+  --dsn-button-subtle-hover-color: var(
+    --dsn-color-accent-1-inverse-color-hover
+  );
+  --dsn-button-subtle-active-background-color: var(
+    --dsn-color-accent-1-inverse-bg-active
+  );
+  --dsn-button-subtle-active-color: var(
+    --dsn-color-accent-1-inverse-color-active
+  );
+}

--- a/packages/components-react/src/PageHeader/PageHeader.tsx
+++ b/packages/components-react/src/PageHeader/PageHeader.tsx
@@ -9,6 +9,7 @@ import './PageHeader.css';
 
 export type PageHeaderSticky = 'none' | 'sticky' | 'auto-hide';
 export type PageHeaderLayout = 'default' | 'compact';
+export type PageHeaderColorScheme = 'default' | 'inverse';
 
 export interface PageHeaderProps extends Omit<
   React.HTMLAttributes<HTMLElement>,
@@ -40,6 +41,16 @@ export interface PageHeaderProps extends Omit<
    * @default 'default'
    */
   layout?: PageHeaderLayout;
+
+  /**
+   * Kleurschema van de header.
+   * - `default`: neutrale achtergrond met accent-1 navbar
+   * - `inverse`: sterke accent-1-inverse achtergrond op navbar en compact balk
+   *   voor prominente branding. Het masthead blijft altijd neutraal.
+   *   Logo-kleuren passen zich automatisch aan via CSS context overrides.
+   * @default 'default'
+   */
+  colorScheme?: PageHeaderColorScheme;
 
   /**
    * Initiële open-staat van het zoekpaneel (small viewport).
@@ -141,6 +152,7 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
       logoSlot,
       sticky = 'none',
       layout = 'default',
+      colorScheme = 'default',
       initialSearchOpen = false,
       primaryNavigation,
       primaryNavigationLarge,
@@ -254,6 +266,7 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
       sticky === 'sticky' && 'dsn-page-header--sticky',
       sticky === 'auto-hide' && 'dsn-page-header--auto-hide',
       layout === 'compact' && 'dsn-page-header--compact',
+      colorScheme === 'inverse' && 'dsn-page-header--inverse',
       className
     );
 

--- a/packages/storybook/src/PageHeader.docs.md
+++ b/packages/storybook/src/PageHeader.docs.md
@@ -164,6 +164,105 @@ De mobile layout (hamburger + drawer) valt via `display: none` volledig uit de a
 3. Inline zoekveld + Zoeken-knop
 4. Primaire navigatie items
 
+### Compact layout (large viewport)
+
+De `layout="compact"` variant plaatst logo, primaire navigatie en servicemenu in één enkele rij via CSS-grid `1fr auto 1fr`. Gebruik dit wanneer de primaire navigatie maar één niveau heeft en de branding compacter mag:
+
+```html
+<!-- HTML/CSS — compact layout modifier -->
+<header class="dsn-page-header dsn-page-header--compact">
+  <!-- Small viewport layout (ongewijzigd) -->
+  <div class="dsn-page-header__small-layout">...</div>
+
+  <!-- Compact balk (zichtbaar boven 64em) -->
+  <div class="dsn-page-header__compact-layout">
+    <div class="dsn-page-header__compact-inner">
+      <div class="dsn-page-header__logo">
+        <a href="/"><!-- Logo --></a>
+      </div>
+      <div class="dsn-page-header__compact-primary-nav">
+        <nav aria-labelledby="primary-nav-id">
+          <h2 id="primary-nav-id" class="dsn-visually-hidden">Hoofdmenu</h2>
+          <!-- horizontale Menu met MenuLink items -->
+        </nav>
+      </div>
+      <div class="dsn-page-header__compact-secondary">
+        <!-- horizontale Menu met servicemenu items -->
+        <button
+          type="button"
+          class="dsn-button dsn-button--subtle dsn-button--icon-only"
+          aria-expanded="false"
+          aria-controls="compact-search-panel"
+        >
+          <svg class="dsn-icon" aria-hidden="true"><!-- search --></svg>
+          <span class="dsn-button__label">Zoeken</span>
+        </button>
+      </div>
+    </div>
+    <div class="dsn-page-header__search-panel" id="compact-search-panel" hidden>
+      <!-- zoekveld + zoekknop -->
+    </div>
+  </div>
+</header>
+```
+
+```tsx
+<PageHeader
+  layout="compact"
+  logoSlot={
+    <a href="/">
+      <Logo aria-hidden={true} />
+    </a>
+  }
+  primaryNavigationLarge={
+    <Menu orientation="horizontal">
+      <MenuLink href="/home" level={1} current>
+        Home
+      </MenuLink>
+    </Menu>
+  }
+  secondaryNavigationLarge={
+    <Menu orientation="horizontal">
+      <MenuLink href="/contact" level={1}>
+        Contact
+      </MenuLink>
+    </Menu>
+  }
+/>
+```
+
+### Inverse kleurvariant
+
+De `colorScheme="inverse"` variant gebruikt `accent-1-inverse` achtergronden op de navbar en compact balk voor prominente branding. Het masthead blijft altijd neutraal (`neutral.bg-document`). Logo-kleuren en menu-items passen zich automatisch aan via CSS context overrides — geen extra klassen nodig.
+
+```html
+<!-- HTML/CSS — inverse modifier (combineerbaar met andere modifiers) -->
+<header class="dsn-page-header dsn-page-header--inverse">...</header>
+
+<!-- Combinatie met compact layout -->
+<header
+  class="dsn-page-header dsn-page-header--compact dsn-page-header--inverse"
+>
+  ...
+</header>
+```
+
+```tsx
+<PageHeader colorScheme="inverse" logoSlot={...} ... />
+
+{/* Combinatie */}
+<PageHeader layout="compact" colorScheme="inverse" logoSlot={...} ... />
+```
+
+De inverse modifier overschrijft via CSS custom properties:
+
+- `--dsn-page-header-background-color` → `accent-1-inverse.bg-default` (small viewport balk)
+- `--dsn-page-header-navbar-background-color` → `accent-1-inverse.bg-default`
+- `--dsn-page-header-compact-background-color` → `accent-1-inverse.bg-default`
+- `--dsn-page-header-search-panel-background-color` → `accent-1-inverse.bg-document`
+- `--dsn-logo-color-primary` / `--dsn-logo-color-label` → wit / achtergrondkleur (reset in masthead)
+- `--dsn-menu-item-color` en `--dsn-button-subtle-color` → wit op alle inverse vlakken
+
 ### Zoekpaneel (small viewport)
 
 Het zoekpaneel verschijnt direct onder de header-binnenbalk. Het paneel bevat een `SearchInput` en een zoekknop:
@@ -206,6 +305,9 @@ Het zoekpaneel verschijnt direct onder de header-binnenbalk. Het paneel bevat ee
 | `--dsn-page-header-navbar-background-color`       | `{dsn.color.accent-1.bg-default}`    | Navigatiebalk achtergrond (large)          |
 | `--dsn-page-header-navbar-padding-inline`         | `{dsn.space.inline.xl}`              | Horizontale padding navigatiebalk (large)  |
 | `--dsn-page-header-secondary-nav-gap`             | `{dsn.space.column.3xl}`             | Gap servicemenu ↔ zoekveld (large)         |
+| `--dsn-page-header-compact-background-color`      | `{dsn.color.neutral.bg-document}`    | Compact balk achtergrond                   |
+| `--dsn-page-header-compact-padding-block`         | `{dsn.space.block.xl}`               | Verticale padding compact balk             |
+| `--dsn-page-header-compact-padding-inline`        | `{dsn.space.inline.xl}`              | Horizontale padding compact balk           |
 
 ## Accessibility
 

--- a/packages/storybook/src/PageHeader.stories.tsx
+++ b/packages/storybook/src/PageHeader.stories.tsx
@@ -311,6 +311,11 @@ const meta: Meta<typeof PageHeader> = {
       options: ['default', 'compact'],
       table: { category: 'Gedrag' },
     },
+    colorScheme: {
+      control: 'select',
+      options: ['default', 'inverse'],
+      table: { category: 'Gedrag' },
+    },
     initialSearchOpen: {
       control: 'boolean',
       table: { category: 'Gedrag' },
@@ -484,6 +489,43 @@ export const CompactLayout: Story = {
       description: {
         story:
           'Op viewports ≥ 64em toont de compact variant één enkele rij: logo (inline-start), primaire navigatie (optisch gecentreerd via CSS-grid `1fr auto 1fr`), en servicemenu + zoek-iconknop (inline-end). Gebruikt `primaryNavigationLarge` voor de compacte balk en `primaryNavigation` (verticaal) voor de Drawer op small viewport.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// INVERSE KLEURVARIANT
+// =============================================================================
+
+export const InverseColorScheme: Story = {
+  name: 'Inverse color scheme',
+  args: {
+    colorScheme: 'inverse',
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'De inverse kleurvariant (`colorScheme="inverse"`) gebruikt `accent-1-inverse` achtergronden op de navbar en het zoekpaneel voor prominente branding. Het masthead blijft neutraal. Het logo past zijn kleuren automatisch aan via CSS context overrides.',
+      },
+    },
+  },
+};
+
+export const InverseCompactLayout: Story = {
+  name: 'Inverse compact layout',
+  args: {
+    layout: 'compact',
+    colorScheme: 'inverse',
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'Combinatie van `layout="compact"` en `colorScheme="inverse"`: de compacte balk (logo, primaire navigatie, servicemenu) heeft een `accent-1-inverse` achtergrond. Het zoekpaneel gebruikt `accent-1-inverse.bg-document` voor visuele scheiding.',
       },
     },
   },


### PR DESCRIPTION
## Summary

- Nieuwe `colorScheme` prop op `PageHeader`: `'default'` | `'inverse'`
- `.dsn-page-header--inverse` modifier: accent-1-inverse achtergronden op navbar, compact balk en zoekpaneel; masthead blijft neutraal
- Logo-kleuren draaien automatisch om via CSS custom property overrides (geen extra klassen nodig)
- Menu-items en subtle buttons worden wit op inverse achtergrond via context-gebonden token-overrides
- Orthogonale modifier — combineerbaar met alle bestaande props (`layout`, `sticky`, etc.)
- 2 nieuwe Storybook stories: *Inverse color scheme* en *Inverse compact layout*

## Test plan

- [ ] `Inverse color scheme` story (large viewport): navbar donkerblauw, menu-items wit, masthead neutraal, logo wit op donkere achtergrond
- [ ] `Inverse compact layout` story (large viewport): compacte balk donkerblauw, navigatie en zoekknop wit zichtbaar
- [ ] Small viewport (beide inverse stories): header-balk donkerblauw, Menu- en Zoeken-knop wit zichtbaar
- [ ] Default story ongewijzigd — geen regressie
- [ ] TypeScript: `pnpm --filter storybook exec tsc --noEmit` geeft 0 fouten
- [ ] CI groen

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)