### PR TITLE
fix(PageHeader): vervang verborgen h2-headings door aria-label op nav

### DIFF
--- a/packages/components-react/src/PageHeader/PageHeader.test.tsx
+++ b/packages/components-react/src/PageHeader/PageHeader.test.tsx
@@ -223,7 +223,7 @@ describe('PageHeader', () => {
     expect(container.querySelector('.dsn-page-header__searchbox')).toBeNull();
   });
 
-  it('masthead heeft uniek aria-labelledby voor servicemenu', () => {
+  it('masthead nav heeft aria-label="Servicemenu"', () => {
     const { container } = render(
       <PageHeader
         logoSlot={defaultLogo}
@@ -231,19 +231,15 @@ describe('PageHeader', () => {
       />
     );
     const nav = container.querySelector('.dsn-page-header__masthead nav');
-    const headingId = nav?.getAttribute('aria-labelledby');
-    expect(headingId).toBeTruthy();
-    expect(container.querySelector(`#${CSS.escape(headingId!)}`)).toBeTruthy();
+    expect(nav).toHaveAttribute('aria-label', 'Servicemenu');
   });
 
-  it('navbar heeft uniek aria-labelledby voor hoofdmenu', () => {
+  it('navbar nav heeft aria-label="Hoofdmenu"', () => {
     const { container } = render(
       <PageHeader logoSlot={defaultLogo} primaryNavigation={<span>nav</span>} />
     );
     const nav = container.querySelector('.dsn-page-header__navbar nav');
-    const headingId = nav?.getAttribute('aria-labelledby');
-    expect(headingId).toBeTruthy();
-    expect(container.querySelector(`#${CSS.escape(headingId!)}`)).toBeTruthy();
+    expect(nav).toHaveAttribute('aria-label', 'Hoofdmenu');
   });
 
   // ---------------------------------------------------------------------------
@@ -398,7 +394,7 @@ describe('PageHeader', () => {
     expect(compactLayout?.textContent).toContain('Contact');
   });
 
-  it('compact layout heeft aria-labelledby op primaire navigatie', () => {
+  it('compact layout primaire nav heeft aria-label="Hoofdmenu"', () => {
     const { container } = render(
       <PageHeader
         logoSlot={defaultLogo}
@@ -409,12 +405,10 @@ describe('PageHeader', () => {
     const nav = container.querySelector(
       '.dsn-page-header__compact-primary-nav nav'
     );
-    const headingId = nav?.getAttribute('aria-labelledby');
-    expect(headingId).toBeTruthy();
-    expect(container.querySelector(`#${CSS.escape(headingId!)}`)).toBeTruthy();
+    expect(nav).toHaveAttribute('aria-label', 'Hoofdmenu');
   });
 
-  it('compact layout heeft aria-labelledby op servicemenu', () => {
+  it('compact layout servicemenu nav heeft aria-label="Servicemenu"', () => {
     const { container } = render(
       <PageHeader
         logoSlot={defaultLogo}
@@ -425,9 +419,7 @@ describe('PageHeader', () => {
     const nav = container.querySelector(
       '.dsn-page-header__compact-secondary nav'
     );
-    const headingId = nav?.getAttribute('aria-labelledby');
-    expect(headingId).toBeTruthy();
-    expect(container.querySelector(`#${CSS.escape(headingId!)}`)).toBeTruthy();
+    expect(nav).toHaveAttribute('aria-label', 'Servicemenu');
   });
 
   it('compact layout heeft een zoekpaneel', () => {

--- a/packages/components-react/src/PageHeader/PageHeader.tsx
+++ b/packages/components-react/src/PageHeader/PageHeader.tsx
@@ -182,11 +182,7 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
     const searchPanelId = React.useId();
     const primaryNavId = React.useId();
     const serviceNavId = React.useId();
-    const primaryNavLargeId = React.useId();
-    const serviceNavLargeId = React.useId();
     const compactSearchPanelId = React.useId();
-    const compactPrimaryNavId = React.useId();
-    const compactServiceNavId = React.useId();
 
     // Auto-hide: detecteer scrollrichting en toggle data-hidden attribuut
     React.useEffect(() => {
@@ -344,13 +340,7 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
 
                   <div className="dsn-page-header__secondary-nav">
                     {(secondaryNavigationLarge ?? secondaryNavigation) && (
-                      <nav aria-labelledby={serviceNavLargeId}>
-                        <h2
-                          id={serviceNavLargeId}
-                          className="dsn-visually-hidden"
-                        >
-                          Servicemenu
-                        </h2>
+                      <nav aria-label="Servicemenu">
                         {secondaryNavigationLarge ?? secondaryNavigation}
                       </nav>
                     )}
@@ -367,13 +357,7 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
               <div className="dsn-page-header__navbar">
                 <div className="dsn-page-header__navbar-inner">
                   {(primaryNavigationLarge ?? primaryNavigation) && (
-                    <nav aria-labelledby={primaryNavLargeId}>
-                      <h2
-                        id={primaryNavLargeId}
-                        className="dsn-visually-hidden"
-                      >
-                        Hoofdmenu
-                      </h2>
+                    <nav aria-label="Hoofdmenu">
                       {primaryNavigationLarge ?? primaryNavigation}
                     </nav>
                   )}
@@ -397,13 +381,7 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
                     Dit garandeert dat de Drawer altijd de verticale variant ontvangt. */}
                 <div className="dsn-page-header__compact-primary-nav">
                   {(primaryNavigationLarge ?? primaryNavigation) && (
-                    <nav aria-labelledby={compactPrimaryNavId}>
-                      <h2
-                        id={compactPrimaryNavId}
-                        className="dsn-visually-hidden"
-                      >
-                        Hoofdmenu
-                      </h2>
+                    <nav aria-label="Hoofdmenu">
                       {primaryNavigationLarge ?? primaryNavigation}
                     </nav>
                   )}
@@ -412,13 +390,7 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
                 {/* Servicemenu + zoekknop (icon-only) — inline-end (derde gridkolom) */}
                 <div className="dsn-page-header__compact-secondary">
                   {(secondaryNavigationLarge ?? secondaryNavigation) && (
-                    <nav aria-labelledby={compactServiceNavId}>
-                      <h2
-                        id={compactServiceNavId}
-                        className="dsn-visually-hidden"
-                      >
-                        Servicemenu
-                      </h2>
+                    <nav aria-label="Servicemenu">
                       {secondaryNavigationLarge ?? secondaryNavigation}
                     </nav>
                   )}

--- a/packages/storybook/src/PageHeader.docs.md
+++ b/packages/storybook/src/PageHeader.docs.md
@@ -98,10 +98,7 @@ De mobile layout (hamburger + drawer) valt via `display: none` volledig uit de a
           <a href="/"><!-- Logo --></a>
         </div>
         <div class="dsn-page-header__secondary-nav">
-          <nav aria-labelledby="service-menu-id">
-            <h2 id="service-menu-id" class="dsn-visually-hidden">
-              Servicemenu
-            </h2>
+          <nav aria-label="Servicemenu">
             <ul class="dsn-menu dsn-menu--horizontal">
               <li><a class="dsn-menu-link" href="/contact">Contact</a></li>
             </ul>
@@ -114,8 +111,7 @@ De mobile layout (hamburger + drawer) valt via `display: none` volledig uit de a
     </div>
     <div class="dsn-page-header__navbar">
       <div class="dsn-page-header__navbar-inner">
-        <nav aria-labelledby="primary-nav-id">
-          <h2 id="primary-nav-id" class="dsn-visually-hidden">Hoofdmenu</h2>
+        <nav aria-label="Hoofdmenu">
           <ul class="dsn-menu dsn-menu--horizontal">
             <li><a class="dsn-menu-link" href="/home">Home</a></li>
           </ul>
@@ -181,8 +177,7 @@ De `layout="compact"` variant plaatst logo, primaire navigatie en servicemenu in
         <a href="/"><!-- Logo --></a>
       </div>
       <div class="dsn-page-header__compact-primary-nav">
-        <nav aria-labelledby="primary-nav-id">
-          <h2 id="primary-nav-id" class="dsn-visually-hidden">Hoofdmenu</h2>
+        <nav aria-label="Hoofdmenu">
           <!-- horizontale Menu met MenuLink items -->
         </nav>
       </div>
@@ -319,4 +314,4 @@ Het zoekpaneel verschijnt direct onder de header-binnenbalk. Het paneel bevat ee
 - Elke `<nav>` in de Drawer heeft een unieke toegankelijke naam via `aria-labelledby` + visueel verborgen `<h3>`.
 - Drawer-focusbeheer wordt verzorgd door het bestaande `Drawer`-component.
 - Op large viewport: `dsn-page-header__small-layout` en `dsn-page-header__large-layout` worden geswitcht met `display: none` — de inactieve sectie valt automatisch uit de accessibility tree.
-- Op large viewport: beide `<nav>` elementen gebruiken `<h2>` met `aria-labelledby` ("Servicemenu", "Hoofdmenu") — unieke IDs gegenereerd via `useId()`.
+- Op large viewport: beide `<nav>` elementen gebruiken `aria-label` ("Servicemenu", "Hoofdmenu") — geen verborgen headings, zodat de heading-hiërarchie van de pagina niet vervuild wordt vóór de `<h1>`.


### PR DESCRIPTION
## Summary

- Vier verborgen `<h2>` elementen die `<nav>` landmarks labelden via `aria-labelledby` stonden in de DOM vóór de `<h1>` van de pagina — screen reader-gebruikers navigerend via heading-toets kregen daardoor H2's te zien vóór de eigenlijke paginatitel
- Opgelost door `aria-label` direct op elk `<nav>` element te zetten — geen verborgen headings meer, heading-hiërarchie van de pagina blijft intact
- 4 overtollige `useId()` variabelen verwijderd (`primaryNavLargeId`, `serviceNavLargeId`, `compactPrimaryNavId`, `compactServiceNavId`)
- Tests en docs bijgewerkt

Sluit aan bij toegankelijkheidsreview sessie april 2026. Tab-volgorde issue gevolgd in #153.

## Test plan

- [x] Alle 47 PageHeader-tests groen
- [x] TypeScript schoon
- [x] Lint schoon

🤖 Generated with [Claude Code](https://claude.com/claude-code)