### PR TITLE
feat(Popover): contextual overlay met header/body/footer structuur

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pnpm --filter @dsn/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (1305 tests across 64 test suites)
+# Run tests (1329 tests across 65 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -187,7 +187,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Paragraph**     | Yes      | Yes   | Yes           |
 | **UnorderedList** | Yes      | Yes   | Yes           |
 
-**Display & Feedback Components (9)**
+**Display & Feedback Components (10)**
 
 | Component       | HTML/CSS | React | Web Component |
 | --------------- | -------- | ----- | ------------- |
@@ -198,6 +198,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **DotBadge**    | Yes      | Yes   | —             |
 | **Note**        | Yes      | Yes   | —             |
 | **NumberBadge** | Yes      | Yes   | —             |
+| **Popover**     | Yes      | Yes   | —             |
 | **StatusBadge** | Yes      | Yes   | —             |
 | **Table**       | Yes      | Yes   | —             |
 
@@ -390,7 +391,7 @@ Comprehensive documentation is available in the `/docs` folder:
 
 - **Pre-commit hooks** via Husky + lint-staged (ESLint + Prettier)
 - **Type checking** across all packages (`pnpm type-check`)
-- **1292 tests** covering React components, Web Components, and utilities
+- **1329 tests** covering React components, Web Components, and utilities
 - **CI/CD** via GitHub Actions (lint, type-check, test, build)
 
 ## Tech Stack

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -763,7 +763,7 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 
 ## Display & Feedback Components
 
-**Status:** Complete (HTML/CSS, React) — 11 components total
+**Status:** Complete (HTML/CSS, React) — 12 components total
 
 ### Backdrop
 
@@ -1583,6 +1583,115 @@ const [isOpen, setIsOpen] = React.useState(false);
 ```
 
 **Tests:** React (20 tests)
+
+### Popover
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-{html|react}/src/popover/` / `packages/components-react/src/Popover/`
+
+**Tokens:** `tokens/components/popover.json`
+
+**Sub-components:** `Popover`, `PopoverHeader`, `PopoverHeading`, `PopoverBody`, `PopoverFooter`
+
+**Features:**
+
+- Gebaseerd op de HTML Popover API (`popover="auto"`) — ingebakken light-dismiss en top-layer gedrag zonder extra JavaScript voor stacking context
+- Positionering via JavaScript (`getBoundingClientRect` + `offsetWidth`/`offsetHeight`) — RTL-bewust, automatisch viewport-clamping (8px marge)
+- CSS `max-inline-size: min(var(--dsn-popover-max-width), calc(100vw - 1rem))` — nooit breder dan het viewport op smalle schermen
+- Compound component patroon met React Context — `headingId` en `onClose` automatisch doorgegeven aan sub-componenten
+- `aria-labelledby` automatisch gekoppeld aan `PopoverHeading` via `React.useId()` (popovers met heading); `aria-label` via `label` prop (popovers zonder heading, bijv. contextmenu)
+- `aria-expanded` op het triggerelement — synchroon bijgehouden via `triggerRef` prop
+- Sluitknop (`dsn-button--icon-only`) automatisch geïnjecteerd in `PopoverHeader`
+- Open/sluitanimatie via `@starting-style`, `opacity`, `transform: scale` en `allow-discrete` voor `display` en `overlay`
+- `flex-direction: column` op de basis-selector — voorkomt layout-glitch tijdens sluitanimatie
+- Fallback light-dismiss via `pointerdown` op `document` (voor iframe-grenzen en oudere browsers)
+- `placement` prop: `'bottom'` (default), `'top'`, `'end'`, `'start'` — `end`/`start` zijn RTL-bewust
+- `role="dialog"` + `aria-modal="false"` — niet-modaal, geen focus-trap, achtergrond blijft interactief
+- Focus springt bij openen naar het eerste interactieve element in de popover
+- `level` prop op `PopoverHeading` (1–6, default `2`) — visueel uiterlijk altijd gelijk
+- Reduceer-motie-ondersteuning via `prefers-reduced-motion: reduce`
+
+**CSS klassen:**
+
+| Klasse                          | Element | Beschrijving                                                  |
+| ------------------------------- | ------- | ------------------------------------------------------------- |
+| `dsn-popover-wrapper`           | `<div>` | Relatief-gepositioneerde container voor CSS-only gebruik      |
+| `dsn-popover`                   | `<div>` | Root — `popover="auto"`; `role="dialog"`; animaties en stijl  |
+| `dsn-popover--placement-bottom` | `<div>` | CSS-only plaatsing onder de trigger (default)                 |
+| `dsn-popover--placement-top`    | `<div>` | CSS-only plaatsing boven de trigger                           |
+| `dsn-popover--placement-end`    | `<div>` | CSS-only plaatsing rechts (LTR) / links (RTL)                 |
+| `dsn-popover--placement-start`  | `<div>` | CSS-only plaatsing links (LTR) / rechts (RTL)                 |
+| `dsn-popover__header`           | `<div>` | Flexbox header met heading + sluitknop; border-block-end      |
+| `dsn-popover-heading`           | `<h2>`  | Heading sub-component; `flex: 1`; typografie via eigen tokens |
+| `dsn-popover__body`             | `<div>` | Inhoudssectie; padding via tokens                             |
+| `dsn-popover__footer`           | `<div>` | Actiesectie; border-block-start; `flex-shrink: 0`             |
+
+**Props (React — Popover):**
+
+| Prop         | Type                                    | Default    | Beschrijving                                                          |
+| ------------ | --------------------------------------- | ---------- | --------------------------------------------------------------------- |
+| `isOpen`     | `boolean`                               | —          | Bepaalt of de popover getoond wordt                                   |
+| `onClose`    | `() => void`                            | —          | Callback bij sluiten (Escape, klik buiten, sluitknop in header)       |
+| `triggerRef` | `React.RefObject<HTMLElement>`          | —          | Referentie naar het triggerelement voor positionering + focus-herstel |
+| `placement`  | `'top' \| 'bottom' \| 'start' \| 'end'` | `'bottom'` | Gewenste plaatsing relatief aan het triggerelement                    |
+| `label`      | `string`                                | —          | `aria-label` voor popovers zonder `PopoverHeading`                    |
+| `children`   | `React.ReactNode`                       | —          | Sub-componenten: `PopoverHeader`, `PopoverBody`, `PopoverFooter`      |
+
+**HTML/CSS:**
+
+```html
+<div class="dsn-popover-wrapper">
+  <button
+    type="button"
+    class="dsn-button dsn-button--subtle dsn-button--size-medium"
+    popovertarget="popover-demo"
+    aria-expanded="false"
+  >
+    <span class="dsn-button__label">Acties</span>
+  </button>
+
+  <div
+    id="popover-demo"
+    popover="auto"
+    class="dsn-popover dsn-popover--placement-bottom"
+    role="dialog"
+    aria-modal="false"
+    aria-label="Acties"
+  >
+    <div class="dsn-popover__body">
+      <ul class="dsn-menu" role="list">
+        <li>
+          <button type="button" class="dsn-menu-button">
+            <span class="dsn-menu-item__label">Bewerken</span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+```
+
+**React:**
+
+```tsx
+const triggerRef = React.useRef<HTMLButtonElement>(null);
+const [isOpen, setIsOpen] = React.useState(false);
+
+<Button ref={triggerRef} variant="subtle" onClick={() => setIsOpen((prev) => !prev)}>
+  Acties
+</Button>
+<Popover isOpen={isOpen} onClose={() => setIsOpen(false)} triggerRef={triggerRef} label="Acties">
+  <PopoverBody>
+    <Menu>
+      <MenuButton onClick={() => setIsOpen(false)}>Bewerken</MenuButton>
+      <MenuButton onClick={() => setIsOpen(false)}>Verwijderen</MenuButton>
+    </Menu>
+  </PopoverBody>
+</Popover>
+```
+
+**Tests:** React (37 tests)
 
 ---
 
@@ -2583,15 +2692,15 @@ defineButton('my-custom-button');
 
 ## Component Statistics
 
-**Total Components:** 50
+**Total Components:** 51
 
 **Implementations:**
 
-- **HTML/CSS:** 50 components
-- **React:** 50 components (1292 tests total, 64 test suites)
+- **HTML/CSS:** 51 components
+- **React:** 51 components (1329 tests total, 65 test suites)
 - **Web Component:** 7 components (Button, Heading, Icon, Link, OrderedList, Paragraph, UnorderedList)
 
-**Test Coverage:** 1292 tests across 64 test suites
+**Test Coverage:** 1329 tests across 65 test suites
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,28 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 5.25.0 (April 14, 2026)
+
+### Popover component (issue #155, PR #156)
+
+#### Added
+
+- **Popover** component — lichtgewicht, contextgebonden overlay verankerd aan een triggerelement (PR #156)
+- Gebaseerd op de HTML Popover API (`popover="auto"`) voor ingebakken light-dismiss en top-layer gedrag
+- Compound component patroon: `PopoverHeader`, `PopoverHeading`, `PopoverBody`, `PopoverFooter`
+- `placement` prop: `'bottom'` (default), `'top'`, `'end'`, `'start'` — RTL-bewust
+- JavaScript-positionering via `getBoundingClientRect` + `offsetWidth`/`offsetHeight` met viewport-clamping (8px marge)
+- `max-inline-size: min(var(--dsn-popover-max-width), calc(100vw - 1rem))` — nooit breder dan het viewport op smalle schermen
+- `aria-labelledby` automatisch via `PopoverHeading` + React Context; `aria-label` via `label` prop voor headerloze popovers
+- `aria-expanded` synchroon bijgehouden op het triggerelement via `triggerRef` prop
+- Open/sluitanimatie via `@starting-style`, `opacity`, `transform: scale` en `allow-discrete`
+- Fallback light-dismiss via `pointerdown` op `document` (iframe-grenzen, oudere browsers)
+- 14 design tokens (`--dsn-popover-*`) in `tokens/components/popover.json`
+- 10 Storybook stories incl. plaatsing-overzicht en RTL-variant
+- 37 tests
+
+---
+
 ## Version 5.24.0 (April 10, 2026)
 
 ### PageHeader: inverse kleurvariant (issue #151)

--- a/packages/components-html/src/card/card.css
+++ b/packages/components-html/src/card/card.css
@@ -10,7 +10,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  background-color: var(--dsn-card-background);
+  background-color: var(--dsn-card-background-color);
   border: var(--dsn-card-border-width) solid var(--dsn-card-border-color);
   border-radius: var(--dsn-card-border-radius);
   box-shadow: var(--dsn-card-box-shadow);
@@ -25,7 +25,7 @@
 
 /* Hover: verhoogde achtergrond en schaduw benadrukken interactiviteit */
 .dsn-card:has(.dsn-card-heading__link:hover) {
-  background-color: var(--dsn-card-background-hover);
+  background-color: var(--dsn-card-background-color-hover);
   box-shadow: var(--dsn-card-box-shadow-hover);
 }
 
@@ -86,7 +86,7 @@
   align-items: center;
   justify-content: center;
   aspect-ratio: 16 / 9;
-  background-color: var(--dsn-card-image-placeholder-background);
+  background-color: var(--dsn-card-image-placeholder-background-color);
   color: var(--dsn-card-image-placeholder-color);
 }
 

--- a/packages/components-html/src/drawer/drawer.css
+++ b/packages/components-html/src/drawer/drawer.css
@@ -32,7 +32,7 @@
   /* Reset native <dialog> styling */
   border: none;
   box-shadow: var(--dsn-drawer-box-shadow);
-  background: var(--dsn-drawer-background);
+  background: var(--dsn-drawer-background-color);
   padding: 0;
 
   /* Grootte */
@@ -213,7 +213,7 @@
  */
 
 .dsn-drawer__body {
-  --_bg: var(--dsn-drawer-background);
+  --_bg: var(--dsn-drawer-background-color);
   --_shadow: var(--dsn-color-shadow-scroll, rgba(0, 0, 0, 0.12));
 
   flex: 1;

--- a/packages/components-html/src/modal-dialog/modal-dialog.css
+++ b/packages/components-html/src/modal-dialog/modal-dialog.css
@@ -37,7 +37,7 @@
     var(--dsn-modal-dialog-border-color);
   border-radius: var(--dsn-modal-dialog-border-radius);
   box-shadow: var(--dsn-modal-dialog-box-shadow);
-  background: var(--dsn-modal-dialog-background);
+  background: var(--dsn-modal-dialog-background-color);
   padding: 0;
 
   /* Grootte en positionering */
@@ -154,7 +154,7 @@
  */
 
 .dsn-modal-dialog__body {
-  --_bg: var(--dsn-modal-dialog-background);
+  --_bg: var(--dsn-modal-dialog-background-color);
   --_shadow: var(--dsn-color-shadow-scroll, rgba(0, 0, 0, 0.12));
 
   flex: 1;

--- a/packages/components-html/src/popover/popover.css
+++ b/packages/components-html/src/popover/popover.css
@@ -107,13 +107,15 @@
 }
 
 /*
- * Layout en positionering alleen bij open staat.
+ * Layout en positionering uitsluitend op :popover-open.
  *
- * Gebruik :popover-open zodat de UA-stylesheet's display:none van kracht blijft
- * wanneer de popover gesloten is — anders overschrijft display:flex de UA
- * (zelfde patroon als .dsn-modal-dialog[open]).
- *
- * position: fixed voor top-layer popovers (gepositioneerd via JS).
+ * - display: flex — UA-stylesheet's display:none geldt wanneer de selector wegvalt.
+ *   De `display allow-discrete` transitie houdt display:flex tijdens de sluitanimatie,
+ *   zodat de layout niet instort vóór opacity/transform klaar zijn.
+ * - position: fixed — géén position in de base class. De `overlay allow-discrete`
+ *   transitie houdt het element in de top-layer (en daarmee position:fixed) tijdens
+ *   de sluitanimatie. Zo verspringt de positie niet halverwege de animatie.
+ * - z-index — geëxpliciteerd zodat gestapelde popovers correct geordend zijn.
  */
 .dsn-popover:popover-open {
   display: flex;
@@ -122,7 +124,7 @@
   z-index: var(--dsn-popover-z-index);
 }
 
-/* Openingsanimatie: startwaarden voor de open staat */
+/* Openingsanimatie: startwaarden voor de :popover-open staat */
 @starting-style {
   .dsn-popover:popover-open {
     opacity: 0;

--- a/packages/components-html/src/popover/popover.css
+++ b/packages/components-html/src/popover/popover.css
@@ -92,6 +92,13 @@
   max-inline-size: var(--dsn-popover-max-width);
   inline-size: max-content;
 
+  /*
+   * flex-direction altijd op de base class — ook tijdens de sluitanimatie.
+   * allow-discrete houdt display:flex vast, maar flex-direction valt anders
+   * terug naar de default 'row', wat het zichtbare verspringen veroorzaakt.
+   */
+  flex-direction: column;
+
   /* Animatietransitie (ook voor sluitanimatie via allow-discrete) */
   opacity: 1;
   transform: scale(1) translateY(0);

--- a/packages/components-html/src/popover/popover.css
+++ b/packages/components-html/src/popover/popover.css
@@ -89,7 +89,7 @@
 
   /* Grootte */
   min-inline-size: var(--dsn-popover-min-width);
-  max-inline-size: var(--dsn-popover-max-width);
+  max-inline-size: min(var(--dsn-popover-max-width), calc(100vw - 1rem));
   inline-size: max-content;
 
   /*

--- a/packages/components-html/src/popover/popover.css
+++ b/packages/components-html/src/popover/popover.css
@@ -92,14 +92,6 @@
   max-inline-size: var(--dsn-popover-max-width);
   inline-size: max-content;
 
-  /* Layout */
-  display: flex;
-  flex-direction: column;
-
-  /* Positionering — z-index voor CSS-only gebruik (niet in top-layer) */
-  position: absolute;
-  z-index: var(--dsn-popover-z-index);
-
   /* Animatietransitie (ook voor sluitanimatie via allow-discrete) */
   opacity: 1;
   transform: scale(1) translateY(0);
@@ -115,11 +107,19 @@
 }
 
 /*
- * Popover API: in de top-layer is position: absolute niet effectief.
- * Gebruik position: fixed voor top-layer popovers (gepositioneerd via JS).
+ * Layout en positionering alleen bij open staat.
+ *
+ * Gebruik :popover-open zodat de UA-stylesheet's display:none van kracht blijft
+ * wanneer de popover gesloten is — anders overschrijft display:flex de UA
+ * (zelfde patroon als .dsn-modal-dialog[open]).
+ *
+ * position: fixed voor top-layer popovers (gepositioneerd via JS).
  */
 .dsn-popover:popover-open {
+  display: flex;
+  flex-direction: column;
   position: fixed;
+  z-index: var(--dsn-popover-z-index);
 }
 
 /* Openingsanimatie: startwaarden voor de open staat */
@@ -140,25 +140,33 @@
 /* ===== Placement modifiers (CSS-only / wrapper-based positionering) ===== */
 
 /*
- * Voor CSS-only gebruik (position: absolute binnen .dsn-popover-wrapper).
- * De React-implementatie overschrijft deze waarden via inline styles.
+ * Voor CSS-only gebruik: de .dsn-popover-wrapper is relatief gepositioneerd en
+ * de popover gebruikt position: absolute (niet de Popover API top-layer).
+ * De React-implementatie gebruikt JS-positionering via inline styles (top/left).
+ *
+ * Let op: deze modifiers werken alleen zonder de Popover API (bijv. pure HTML demo).
+ * Met popover="auto" staat het element in de top-layer (position: fixed via JS).
  */
-.dsn-popover--placement-bottom {
+.dsn-popover-wrapper .dsn-popover--placement-bottom {
+  position: absolute;
   inset-block-start: calc(100% + 0.25rem);
   inset-inline-start: 0;
 }
 
-.dsn-popover--placement-top {
+.dsn-popover-wrapper .dsn-popover--placement-top {
+  position: absolute;
   inset-block-end: calc(100% + 0.25rem);
   inset-inline-start: 0;
 }
 
-.dsn-popover--placement-end {
+.dsn-popover-wrapper .dsn-popover--placement-end {
+  position: absolute;
   inset-block-start: 0;
   inset-inline-start: calc(100% + 0.25rem);
 }
 
-.dsn-popover--placement-start {
+.dsn-popover-wrapper .dsn-popover--placement-start {
+  position: absolute;
   inset-block-start: 0;
   inset-inline-end: calc(100% + 0.25rem);
 }

--- a/packages/components-html/src/popover/popover.css
+++ b/packages/components-html/src/popover/popover.css
@@ -82,7 +82,7 @@
   color: inherit;
 
   /* Visuele stijlen */
-  background: var(--dsn-popover-background);
+  background: var(--dsn-popover-background-color);
   border: var(--dsn-popover-border-width) solid var(--dsn-popover-border-color);
   border-radius: var(--dsn-popover-border-radius);
   box-shadow: var(--dsn-popover-box-shadow);

--- a/packages/components-html/src/popover/popover.css
+++ b/packages/components-html/src/popover/popover.css
@@ -1,0 +1,215 @@
+/* ===== Popover ===== */
+
+/*
+ * dsn-popover — Contextgebonden overlay verankerd aan een triggerelement
+ *
+ * Gebruik de HTML Popover API (popover="auto") voor light-dismiss en top-layer gedrag.
+ * Positionering vereist JavaScript (getBoundingClientRect) of CSS Anchor Positioning.
+ *
+ * Toegankelijkheid:
+ * - role="dialog" aria-modal="false" — niet-modaal: achtergrond blijft interactief
+ * - aria-labelledby → .dsn-popover-heading id (via PopoverHeading + context)
+ * - aria-label → via `label` prop (popovers zonder heading)
+ * - aria-expanded op het triggerelement — synchroon met open-staat
+ *
+ * HTML-structuur (volledig — met header en footer):
+ *
+ * <div class="dsn-popover-wrapper">
+ *   <button
+ *     type="button"
+ *     class="dsn-button dsn-button--subtle dsn-button--size-small dsn-button--icon-only"
+ *     popovertarget="popover-id"
+ *     aria-expanded="false"
+ *   >
+ *     <svg class="dsn-icon" aria-hidden="true"><!-- dots-vertical --></svg>
+ *     <span class="dsn-button__label">Acties</span>
+ *   </button>
+ *
+ *   <div
+ *     id="popover-id"
+ *     popover="auto"
+ *     class="dsn-popover dsn-popover--placement-bottom"
+ *     role="dialog"
+ *     aria-modal="false"
+ *     aria-labelledby="popover-heading-id"
+ *   >
+ *     <div class="dsn-popover__header">
+ *       <h2 class="dsn-popover-heading" id="popover-heading-id">Titel</h2>
+ *       <button type="button" class="dsn-button dsn-button--subtle dsn-button--size-small dsn-button--icon-only">
+ *         <svg class="dsn-icon" aria-hidden="true"><!-- x --></svg>
+ *         <span class="dsn-button__label">Sluiten</span>
+ *       </button>
+ *     </div>
+ *     <div class="dsn-popover__body">
+ *       <!-- slot content -->
+ *     </div>
+ *     <div class="dsn-popover__footer">
+ *       <!-- acties -->
+ *     </div>
+ *   </div>
+ * </div>
+ *
+ * HTML-structuur (minimaal — alleen body, bijv. voor Menu):
+ *
+ * <div class="dsn-popover-wrapper">
+ *   <button popovertarget="popover-id" ...>...</button>
+ *   <div id="popover-id" popover="auto" class="dsn-popover dsn-popover--placement-bottom"
+ *        role="dialog" aria-modal="false" aria-label="Acties">
+ *     <div class="dsn-popover__body">
+ *       <!-- Menu component -->
+ *     </div>
+ *   </div>
+ * </div>
+ */
+
+/* ===== Wrapper ===== */
+
+/*
+ * Relatief gepositioneerde container voor CSS-only gebruik.
+ * In de React-implementatie wordt positionering via JS afgehandeld.
+ */
+.dsn-popover-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+/* ===== Popover panel ===== */
+
+.dsn-popover {
+  /* Reset UA popover-stijlen */
+  margin: 0;
+  padding: 0;
+  color: inherit;
+
+  /* Visuele stijlen */
+  background: var(--dsn-popover-background);
+  border: var(--dsn-popover-border-width) solid var(--dsn-popover-border-color);
+  border-radius: var(--dsn-popover-border-radius);
+  box-shadow: var(--dsn-popover-box-shadow);
+
+  /* Grootte */
+  min-inline-size: var(--dsn-popover-min-width);
+  max-inline-size: var(--dsn-popover-max-width);
+  inline-size: max-content;
+
+  /* Layout */
+  display: flex;
+  flex-direction: column;
+
+  /* Positionering — z-index voor CSS-only gebruik (niet in top-layer) */
+  position: absolute;
+  z-index: var(--dsn-popover-z-index);
+
+  /* Animatietransitie (ook voor sluitanimatie via allow-discrete) */
+  opacity: 1;
+  transform: scale(1) translateY(0);
+  transition:
+    opacity var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default),
+    transform var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default),
+    display var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default) allow-discrete,
+    overlay var(--dsn-transition-duration-normal)
+      var(--dsn-transition-easing-default) allow-discrete;
+}
+
+/*
+ * Popover API: in de top-layer is position: absolute niet effectief.
+ * Gebruik position: fixed voor top-layer popovers (gepositioneerd via JS).
+ */
+.dsn-popover:popover-open {
+  position: fixed;
+}
+
+/* Openingsanimatie: startwaarden voor de open staat */
+@starting-style {
+  .dsn-popover:popover-open {
+    opacity: 0;
+    transform: scale(0.97) translateY(-0.25rem);
+  }
+}
+
+/* Animatie uitschakelen bij prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  .dsn-popover {
+    transition: none;
+  }
+}
+
+/* ===== Placement modifiers (CSS-only / wrapper-based positionering) ===== */
+
+/*
+ * Voor CSS-only gebruik (position: absolute binnen .dsn-popover-wrapper).
+ * De React-implementatie overschrijft deze waarden via inline styles.
+ */
+.dsn-popover--placement-bottom {
+  inset-block-start: calc(100% + 0.25rem);
+  inset-inline-start: 0;
+}
+
+.dsn-popover--placement-top {
+  inset-block-end: calc(100% + 0.25rem);
+  inset-inline-start: 0;
+}
+
+.dsn-popover--placement-end {
+  inset-block-start: 0;
+  inset-inline-start: calc(100% + 0.25rem);
+}
+
+.dsn-popover--placement-start {
+  inset-block-start: 0;
+  inset-inline-end: calc(100% + 0.25rem);
+}
+
+/* ===== Header ===== */
+
+.dsn-popover__header {
+  display: flex;
+  align-items: center;
+  gap: var(--dsn-space-inline-xl);
+  flex-shrink: 0;
+
+  padding-block-start: var(--dsn-popover-header-padding-block-start);
+  padding-block-end: var(--dsn-popover-header-padding-block-end);
+  padding-inline: var(--dsn-popover-header-padding-inline);
+
+  /* Scheidingslijn onder de header */
+  border-block-end: var(--dsn-popover-border-width) solid
+    var(--dsn-popover-border-color);
+}
+
+/* ===== Heading ===== */
+
+.dsn-popover-heading {
+  flex: 1;
+  margin: 0;
+
+  font-family: var(--dsn-popover-heading-font-family);
+  font-weight: var(--dsn-popover-heading-font-weight);
+  font-size: var(--dsn-popover-heading-font-size);
+  line-height: var(--dsn-popover-heading-line-height);
+  color: var(--dsn-popover-heading-color);
+}
+
+/* ===== Body ===== */
+
+.dsn-popover__body {
+  padding-block: var(--dsn-popover-body-padding-block);
+  padding-inline: var(--dsn-popover-body-padding-inline);
+}
+
+/* ===== Footer ===== */
+
+.dsn-popover__footer {
+  flex-shrink: 0;
+
+  padding-block-start: var(--dsn-popover-footer-padding-block-start);
+  padding-block-end: var(--dsn-popover-footer-padding-block-end);
+  padding-inline: var(--dsn-popover-footer-padding-inline);
+
+  /* Scheidingslijn boven de footer */
+  border-block-start: var(--dsn-popover-border-width) solid
+    var(--dsn-popover-border-color);
+}

--- a/packages/components-react/src/Popover/Popover.css
+++ b/packages/components-react/src/Popover/Popover.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/popover/popover.css';

--- a/packages/components-react/src/Popover/Popover.test.tsx
+++ b/packages/components-react/src/Popover/Popover.test.tsx
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import {
+  Popover,
+  PopoverHeader,
+  PopoverHeading,
+  PopoverBody,
+  PopoverFooter,
+} from './Popover';
+
+// jsdom heeft geen volledige Popover API implementatie.
+// Mock showPopover, hidePopover en het popover attribuut voor alle tests.
+beforeEach(() => {
+  HTMLElement.prototype.showPopover = vi.fn();
+  HTMLElement.prototype.hidePopover = vi.fn();
+});
+
+// Helper: standaard popover met alle subcomponenten
+function DefaultPopover({
+  isOpen = true,
+  onClose,
+}: {
+  isOpen?: boolean;
+  onClose?: () => void;
+}) {
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  return (
+    <>
+      <button ref={triggerRef} type="button">
+        Trigger
+      </button>
+      <Popover isOpen={isOpen} onClose={onClose} triggerRef={triggerRef}>
+        <PopoverHeader>
+          <PopoverHeading>Popover titel</PopoverHeading>
+        </PopoverHeader>
+        <PopoverBody>
+          <p>Popover inhoud</p>
+        </PopoverBody>
+        <PopoverFooter>
+          <button type="button">Actie</button>
+        </PopoverFooter>
+      </Popover>
+    </>
+  );
+}
+
+describe('Popover', () => {
+  // ===========================
+  // Rendering
+  // ===========================
+
+  it('renders as a div element', () => {
+    const { container } = render(<DefaultPopover />);
+    const popover = container.querySelector('.dsn-popover');
+    expect(popover).toBeInTheDocument();
+    expect(popover?.tagName).toBe('DIV');
+  });
+
+  it('renders children content', () => {
+    render(<DefaultPopover />);
+    expect(screen.getByText('Popover inhoud')).toBeInTheDocument();
+  });
+
+  it('applies dsn-popover class', () => {
+    const { container } = render(<DefaultPopover />);
+    expect(container.querySelector('.dsn-popover')).toBeInTheDocument();
+  });
+
+  it('applies placement modifier class (default: bottom)', () => {
+    const { container } = render(<DefaultPopover />);
+    expect(
+      container.querySelector('.dsn-popover--placement-bottom')
+    ).toBeInTheDocument();
+  });
+
+  it('applies custom placement modifier class', () => {
+    const triggerRef = { current: document.createElement('button') };
+    const { container } = render(
+      <Popover
+        isOpen={true}
+        triggerRef={triggerRef}
+        placement="top"
+        label="Test"
+      >
+        <PopoverBody>Inhoud</PopoverBody>
+      </Popover>
+    );
+    expect(
+      container.querySelector('.dsn-popover--placement-top')
+    ).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const triggerRef = { current: document.createElement('button') };
+    const { container } = render(
+      <Popover
+        isOpen={true}
+        triggerRef={triggerRef}
+        className="custom-popover"
+        label="Test"
+      >
+        <PopoverBody>Inhoud</PopoverBody>
+      </Popover>
+    );
+    expect(container.querySelector('.custom-popover')).toBeInTheDocument();
+  });
+
+  // ===========================
+  // role / aria-modal
+  // ===========================
+
+  it('has role="dialog"', () => {
+    const { container } = render(<DefaultPopover />);
+    expect(container.querySelector('[role="dialog"]')).toBeInTheDocument();
+  });
+
+  it('has aria-modal="false"', () => {
+    const { container } = render(<DefaultPopover />);
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).toHaveAttribute('aria-modal', 'false');
+  });
+
+  // ===========================
+  // aria-labelledby / aria-label
+  // ===========================
+
+  it('uses aria-labelledby linking to PopoverHeading id when no label prop', () => {
+    render(<DefaultPopover />);
+    const dialog = document.querySelector('[role="dialog"]')!;
+    const labelledById = dialog.getAttribute('aria-labelledby');
+    expect(labelledById).toBeTruthy();
+    const heading = document.getElementById(labelledById!);
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent('Popover titel');
+  });
+
+  it('uses aria-label when label prop is provided', () => {
+    const triggerRef = { current: document.createElement('button') };
+    render(
+      <Popover isOpen={true} triggerRef={triggerRef} label="Acties">
+        <PopoverBody>Inhoud</PopoverBody>
+      </Popover>
+    );
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).toHaveAttribute('aria-label', 'Acties');
+    expect(dialog).not.toHaveAttribute('aria-labelledby');
+  });
+
+  // ===========================
+  // showPopover / hidePopover
+  // ===========================
+
+  it('calls showPopover when isOpen is true', () => {
+    render(<DefaultPopover isOpen={true} />);
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+  });
+
+  it('does not call showPopover when isOpen is false', () => {
+    render(<DefaultPopover isOpen={false} />);
+    expect(HTMLElement.prototype.showPopover).not.toHaveBeenCalled();
+  });
+
+  // ===========================
+  // aria-expanded op trigger
+  // ===========================
+
+  it('sets aria-expanded="true" on trigger when isOpen is true', () => {
+    const { getByText } = render(<DefaultPopover isOpen={true} />);
+    const trigger = getByText('Trigger').closest('button')!;
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('sets aria-expanded="false" on trigger when isOpen is false', () => {
+    const { getByText } = render(<DefaultPopover isOpen={false} />);
+    const trigger = getByText('Trigger').closest('button')!;
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  // ===========================
+  // onClose callback
+  // ===========================
+
+  it('calls onClose when close button in header is clicked', async () => {
+    const onClose = vi.fn();
+    render(<DefaultPopover onClose={onClose} />);
+    const closeButton = screen.getByText('Sluiten').closest('button')!;
+    await userEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  // ===========================
+  // Sub-components rendering
+  // ===========================
+
+  it('renders header with dsn-popover__header class', () => {
+    const { container } = render(<DefaultPopover />);
+    expect(container.querySelector('.dsn-popover__header')).toBeInTheDocument();
+  });
+
+  it('renders body with dsn-popover__body class', () => {
+    const { container } = render(<DefaultPopover />);
+    expect(container.querySelector('.dsn-popover__body')).toBeInTheDocument();
+  });
+
+  it('renders footer with dsn-popover__footer class', () => {
+    const { container } = render(<DefaultPopover />);
+    expect(container.querySelector('.dsn-popover__footer')).toBeInTheDocument();
+  });
+
+  it('renders heading with dsn-popover-heading class', () => {
+    const { container } = render(<DefaultPopover />);
+    expect(container.querySelector('.dsn-popover-heading')).toBeInTheDocument();
+  });
+
+  // ===========================
+  // PopoverHeading levels
+  // ===========================
+
+  it('renders heading as h2 by default', () => {
+    render(
+      <>
+        <button>Trigger</button>
+        <Popover isOpen={true} triggerRef={{ current: null }}>
+          <PopoverHeader>
+            <PopoverHeading>Titel</PopoverHeading>
+          </PopoverHeader>
+          <PopoverBody>Inhoud</PopoverBody>
+        </Popover>
+      </>
+    );
+    expect(
+      document.querySelector('h2.dsn-popover-heading')
+    ).toBeInTheDocument();
+  });
+
+  it('renders heading at specified level', () => {
+    render(
+      <>
+        <button>Trigger</button>
+        <Popover isOpen={true} triggerRef={{ current: null }}>
+          <PopoverHeader>
+            <PopoverHeading level={3}>Titel</PopoverHeading>
+          </PopoverHeader>
+          <PopoverBody>Inhoud</PopoverBody>
+        </Popover>
+      </>
+    );
+    expect(
+      document.querySelector('h3.dsn-popover-heading')
+    ).toBeInTheDocument();
+  });
+
+  // ===========================
+  // Ref forwarding
+  // ===========================
+
+  it('forwards ref to the div element', () => {
+    const ref = { current: null as HTMLDivElement | null };
+    const triggerRef = { current: null };
+    render(
+      <Popover ref={ref} isOpen={true} triggerRef={triggerRef} label="Test">
+        <PopoverBody>Inhoud</PopoverBody>
+      </Popover>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.tagName).toBe('DIV');
+  });
+
+  // ===========================
+  // HTML attributes
+  // ===========================
+
+  it('spreads additional HTML attributes', () => {
+    const triggerRef = { current: null };
+    render(
+      <Popover
+        isOpen={true}
+        triggerRef={triggerRef}
+        label="Test"
+        data-testid="mijn-popover"
+      >
+        <PopoverBody>Inhoud</PopoverBody>
+      </Popover>
+    );
+    expect(screen.getByTestId('mijn-popover')).toBeInTheDocument();
+  });
+
+  // ===========================
+  // PopoverBody only (geen header/footer)
+  // ===========================
+
+  it('renders without header and footer (alleen body)', () => {
+    const triggerRef = { current: null };
+    const { container } = render(
+      <Popover isOpen={true} triggerRef={triggerRef} label="Acties">
+        <PopoverBody>
+          <p>Alleen body</p>
+        </PopoverBody>
+      </Popover>
+    );
+    expect(
+      container.querySelector('.dsn-popover__header')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('.dsn-popover__footer')
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Alleen body')).toBeInTheDocument();
+  });
+});

--- a/packages/components-react/src/Popover/Popover.tsx
+++ b/packages/components-react/src/Popover/Popover.tsx
@@ -239,8 +239,12 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
       };
     }, [isOpen, triggerRef]);
 
-    // Verwerk het toggle-event van de Popover API (Escape / klik buiten)
+    // Verwerk het toggle-event van de Popover API (Escape / klik buiten binnen hetzelfde document)
     // onToggle is niet beschikbaar als JSX-prop op div in React 18 — gebruik addEventListener.
+    // Gebruik een ref voor onClose zodat de listener stabiel blijft en nooit stale is.
+    const onCloseRef = React.useRef(onClose);
+    onCloseRef.current = onClose;
+
     React.useEffect(() => {
       const el = popoverRef.current;
       if (!el) return;
@@ -248,7 +252,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
       const handleToggle = (event: Event) => {
         const toggleEvent = event as Event & { newState?: string };
         if (toggleEvent.newState === 'closed') {
-          onClose?.();
+          onCloseRef.current?.();
           triggerRef.current?.focus();
         }
       };
@@ -257,7 +261,29 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
       return () => {
         el.removeEventListener('toggle', handleToggle);
       };
-    }, [onClose, triggerRef, popoverRef]);
+    }, [triggerRef, popoverRef]);
+
+    // Fallback light-dismiss via pointerdown — vangt klikken buiten het popover op
+    // in contexten waar de Popover API's native light-dismiss niet bereikbaar is
+    // (bijv. iframe-grenzen, of oudere browsers zonder Popover API).
+    React.useEffect(() => {
+      if (!isOpen) return;
+      const el = popoverRef.current;
+      if (!el) return;
+
+      const handlePointerDown = (event: PointerEvent) => {
+        const target = event.target as Node;
+        // Sluit niet als er op de popover zelf of het triggerelement geklikt wordt
+        if (el.contains(target) || triggerRef.current?.contains(target)) return;
+        onCloseRef.current?.();
+        triggerRef.current?.focus();
+      };
+
+      document.addEventListener('pointerdown', handlePointerDown);
+      return () => {
+        document.removeEventListener('pointerdown', handlePointerDown);
+      };
+    }, [isOpen, triggerRef, popoverRef]);
 
     const classes = classNames(
       'dsn-popover',

--- a/packages/components-react/src/Popover/Popover.tsx
+++ b/packages/components-react/src/Popover/Popover.tsx
@@ -1,0 +1,440 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import './Popover.css';
+
+/*
+ * React 18 ondersteunt het `popover`-attribuut en `onToggle` niet natively in de
+ * JSX-types. Module-uitbreiding voegt de ontbrekende types toe.
+ */
+declare module 'react' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface HTMLAttributes<T> {
+    popover?: 'auto' | 'manual' | '' | undefined;
+    popoverTarget?: string | undefined;
+    popoverTargetAction?: 'hide' | 'show' | 'toggle' | undefined;
+  }
+}
+
+/*
+ * HTMLElement.showPopover / hidePopover zijn nog niet in alle TypeScript DOM-libs.
+ * Declaratie toegevoegd voor veilig gebruik.
+ */
+declare global {
+  interface HTMLElement {
+    showPopover(): void;
+    hidePopover(): void;
+  }
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type Placement = 'top' | 'bottom' | 'start' | 'end';
+
+// =============================================================================
+// Positioneringshelper
+// =============================================================================
+
+const GAP = 4; // px afstand tussen trigger en popover
+
+function positionPopover(
+  popover: HTMLElement,
+  trigger: HTMLElement,
+  placement: Placement
+): void {
+  const triggerRect = trigger.getBoundingClientRect();
+  const popoverRect = popover.getBoundingClientRect();
+  const isRTL =
+    document.documentElement.dir === 'rtl' ||
+    getComputedStyle(trigger).direction === 'rtl';
+
+  let top: number;
+  let left: number;
+
+  switch (placement) {
+    case 'bottom':
+      top = triggerRect.bottom + GAP;
+      left = isRTL ? triggerRect.right - popoverRect.width : triggerRect.left;
+      break;
+    case 'top':
+      top = triggerRect.top - popoverRect.height - GAP;
+      left = isRTL ? triggerRect.right - popoverRect.width : triggerRect.left;
+      break;
+    case 'end':
+      top = triggerRect.top;
+      left = isRTL
+        ? triggerRect.left - popoverRect.width - GAP
+        : triggerRect.right + GAP;
+      break;
+    case 'start':
+      top = triggerRect.top;
+      left = isRTL
+        ? triggerRect.right + GAP
+        : triggerRect.left - popoverRect.width - GAP;
+      break;
+    default:
+      top = triggerRect.bottom + GAP;
+      left = triggerRect.left;
+  }
+
+  // Klamp binnen het viewport (8px marge)
+  const margin = 8;
+  left = Math.max(
+    margin,
+    Math.min(left, window.innerWidth - popoverRect.width - margin)
+  );
+  top = Math.max(
+    margin,
+    Math.min(top, window.innerHeight - popoverRect.height - margin)
+  );
+
+  popover.style.top = `${top}px`;
+  popover.style.left = `${left}px`;
+  popover.style.right = 'auto';
+  popover.style.bottom = 'auto';
+}
+
+// Zet focus op het eerste interactieve element in de popover
+function focusFirstInteractive(container: HTMLElement): void {
+  const selector = [
+    'button:not(:disabled)',
+    'a[href]',
+    'input:not(:disabled)',
+    'select:not(:disabled)',
+    'textarea:not(:disabled)',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(', ');
+  const first = container.querySelector<HTMLElement>(selector);
+  if (first) {
+    first.focus();
+  } else {
+    container.focus();
+  }
+}
+
+// =============================================================================
+// Context
+// =============================================================================
+
+interface PopoverContextValue {
+  headingId: string;
+  onClose?: () => void;
+}
+
+const PopoverContext = React.createContext<PopoverContextValue>({
+  headingId: '',
+});
+
+// =============================================================================
+// Popover (root)
+// =============================================================================
+
+export interface PopoverProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'children'
+> {
+  /**
+   * Bepaalt of de popover getoond wordt.
+   */
+  isOpen: boolean;
+
+  /**
+   * Callback bij sluiten (Escape, klik buiten, sluitknop in header).
+   */
+  onClose?: () => void;
+
+  /**
+   * Referentie naar het triggerelement voor positionering en focus-herstel.
+   */
+  triggerRef: React.RefObject<HTMLElement>;
+
+  /**
+   * Gewenste plaatsing relatief aan het triggerelement.
+   * @default 'bottom'
+   */
+  placement?: Placement;
+
+  /**
+   * Toegankelijke naam voor popovers zonder `PopoverHeader`/`PopoverHeading`.
+   * Gebruik `aria-labelledby` via context wanneer er wél een heading is.
+   */
+  label?: string;
+
+  /**
+   * Subcomponenten: `PopoverHeader`, `PopoverBody`, `PopoverFooter`
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * Popover component
+ * Lichtgewicht, contextgebonden overlay verankerd aan een triggerelement.
+ *
+ * Gebaseerd op de HTML Popover API (`popover="auto"`) voor ingebakken
+ * light-dismiss en top-layer gedrag. Positionering via JavaScript.
+ *
+ * @example
+ * ```tsx
+ * const triggerRef = useRef<HTMLButtonElement>(null);
+ * const [isOpen, setIsOpen] = useState(false);
+ *
+ * <Button ref={triggerRef} onClick={() => setIsOpen(true)}>Opties</Button>
+ * <Popover isOpen={isOpen} onClose={() => setIsOpen(false)} triggerRef={triggerRef} label="Opties">
+ *   <PopoverBody>
+ *     <Menu>...</Menu>
+ *   </PopoverBody>
+ * </Popover>
+ * ```
+ */
+export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
+  (
+    {
+      className,
+      isOpen,
+      onClose,
+      triggerRef,
+      placement = 'bottom',
+      label,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const internalRef = React.useRef<HTMLDivElement>(null);
+    const popoverRef = (ref as React.RefObject<HTMLDivElement>) ?? internalRef;
+    const headingId = React.useId();
+
+    // Toon/verberg popover via de Popover API
+    React.useEffect(() => {
+      const el = popoverRef.current;
+      if (!el) return;
+
+      if (isOpen) {
+        el.showPopover();
+        const trigger = triggerRef.current;
+        if (trigger) {
+          positionPopover(el, trigger, placement);
+        }
+        focusFirstInteractive(el);
+      } else {
+        // hidePopover gooit een fout als de popover al gesloten is
+        try {
+          el.hidePopover();
+        } catch {
+          // popover was al gesloten — geen actie nodig
+        }
+      }
+    }, [isOpen, placement, triggerRef, popoverRef]);
+
+    // Synchroniseer aria-expanded op het triggerelement
+    React.useEffect(() => {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+      return () => {
+        trigger.setAttribute('aria-expanded', 'false');
+      };
+    }, [isOpen, triggerRef]);
+
+    // Verwerk het toggle-event van de Popover API (Escape / klik buiten)
+    // onToggle is niet beschikbaar als JSX-prop op div in React 18 — gebruik addEventListener.
+    React.useEffect(() => {
+      const el = popoverRef.current;
+      if (!el) return;
+
+      const handleToggle = (event: Event) => {
+        const toggleEvent = event as Event & { newState?: string };
+        if (toggleEvent.newState === 'closed') {
+          onClose?.();
+          triggerRef.current?.focus();
+        }
+      };
+
+      el.addEventListener('toggle', handleToggle);
+      return () => {
+        el.removeEventListener('toggle', handleToggle);
+      };
+    }, [onClose, triggerRef, popoverRef]);
+
+    const classes = classNames(
+      'dsn-popover',
+      `dsn-popover--placement-${placement}`,
+      className
+    );
+
+    const ariaProps = label
+      ? { 'aria-label': label }
+      : { 'aria-labelledby': headingId };
+
+    return (
+      <PopoverContext.Provider value={{ headingId, onClose }}>
+        <div
+          ref={popoverRef}
+          popover="auto"
+          className={classes}
+          role="dialog"
+          aria-modal="false"
+          tabIndex={-1}
+          {...ariaProps}
+          {...props}
+        >
+          {children}
+        </div>
+      </PopoverContext.Provider>
+    );
+  }
+);
+
+Popover.displayName = 'Popover';
+
+// =============================================================================
+// PopoverHeader
+// =============================================================================
+
+export interface PopoverHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Inhoud van de header — doorgaans een `PopoverHeading`.
+   * De sluitknop wordt automatisch geïnjecteerd.
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * PopoverHeader
+ * De headerstrook van de popover met heading en sluitknop.
+ */
+export const PopoverHeader = React.forwardRef<
+  HTMLDivElement,
+  PopoverHeaderProps
+>(({ className, children, ...props }, ref) => {
+  const { onClose } = React.useContext(PopoverContext);
+
+  return (
+    <div
+      ref={ref}
+      className={classNames('dsn-popover__header', className)}
+      {...props}
+    >
+      {children}
+      <Button
+        variant="subtle"
+        size="small"
+        iconOnly
+        onClick={onClose}
+        iconStart={<Icon name="x" aria-hidden />}
+      >
+        Sluiten
+      </Button>
+    </div>
+  );
+});
+
+PopoverHeader.displayName = 'PopoverHeader';
+
+// =============================================================================
+// PopoverHeading
+// =============================================================================
+
+export interface PopoverHeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  /**
+   * Semantisch heading-niveau. Kies op basis van documenthiërarchie.
+   * @default 2
+   */
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+
+  /**
+   * De zichtbare heading-tekst.
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * PopoverHeading
+ * De heading van de popover. ID wordt automatisch gegenereerd voor aria-labelledby.
+ */
+export const PopoverHeading = React.forwardRef<
+  HTMLHeadingElement,
+  PopoverHeadingProps
+>(({ className, level = 2, children, ...props }, ref) => {
+  const { headingId } = React.useContext(PopoverContext);
+  const Tag = `h${level}` as React.ElementType;
+
+  return (
+    <Tag
+      ref={ref}
+      id={headingId}
+      className={classNames('dsn-popover-heading', className)}
+      {...props}
+    >
+      {children}
+    </Tag>
+  );
+});
+
+PopoverHeading.displayName = 'PopoverHeading';
+
+// =============================================================================
+// PopoverBody
+// =============================================================================
+
+export interface PopoverBodyProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * De hoofdinhoud van de popover — willekeurige slot-content.
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * PopoverBody
+ * De inhoudssectie van de popover.
+ */
+export const PopoverBody = React.forwardRef<HTMLDivElement, PopoverBodyProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={classNames('dsn-popover__body', className)}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+PopoverBody.displayName = 'PopoverBody';
+
+// =============================================================================
+// PopoverFooter
+// =============================================================================
+
+export interface PopoverFooterProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Actieknoppen of slotzin van de popover.
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * PopoverFooter
+ * De voettekst van de popover met actieknoppen.
+ */
+export const PopoverFooter = React.forwardRef<
+  HTMLDivElement,
+  PopoverFooterProps
+>(({ className, children, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={classNames('dsn-popover__footer', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+});
+
+PopoverFooter.displayName = 'PopoverFooter';

--- a/packages/components-react/src/Popover/Popover.tsx
+++ b/packages/components-react/src/Popover/Popover.tsx
@@ -46,7 +46,11 @@ function positionPopover(
   placement: Placement
 ): void {
   const triggerRect = trigger.getBoundingClientRect();
-  const popoverRect = popover.getBoundingClientRect();
+  // offsetWidth/offsetHeight — onaangepast door CSS transforms (zoals @starting-style scale).
+  // getBoundingClientRect geeft de getransformeerde afmetingen, wat leidt tot onjuiste clamping.
+  const popoverWidth = popover.offsetWidth;
+  const popoverHeight = popover.offsetHeight;
+  const popoverRect = { width: popoverWidth, height: popoverHeight };
   const isRTL =
     document.documentElement.dir === 'rtl' ||
     getComputedStyle(trigger).direction === 'rtl';

--- a/packages/components-react/src/Popover/index.ts
+++ b/packages/components-react/src/Popover/index.ts
@@ -1,0 +1,14 @@
+export {
+  Popover,
+  PopoverHeader,
+  PopoverHeading,
+  PopoverBody,
+  PopoverFooter,
+} from './Popover';
+export type {
+  PopoverProps,
+  PopoverHeaderProps,
+  PopoverHeadingProps,
+  PopoverBodyProps,
+  PopoverFooterProps,
+} from './Popover';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -83,3 +83,4 @@ export * from './Image';
 export * from './Card';
 export * from './ModalDialog';
 export * from './Drawer';
+export * from './Popover';

--- a/packages/design-tokens/src/tokens/components/card.json
+++ b/packages/design-tokens/src/tokens/components/card.json
@@ -1,12 +1,12 @@
 {
   "dsn": {
     "card": {
-      "background": {
+      "background-color": {
         "value": "{dsn.color.neutral.bg-document}",
         "type": "color",
         "comment": "Card achtergrondkleur standaard — zelfde als paginaachtergrond"
       },
-      "background-hover": {
+      "background-color-hover": {
         "value": "{dsn.color.neutral.bg-elevated}",
         "type": "color",
         "comment": "Card achtergrondkleur bij hover — bg-elevated benadrukt elevatie"
@@ -66,7 +66,7 @@
         }
       },
       "image-placeholder": {
-        "background": {
+        "background-color": {
           "value": "{dsn.color.neutral.bg-subtle}",
           "type": "color",
           "comment": "Achtergrondkleur van de afbeeldingsplaceholder"

--- a/packages/design-tokens/src/tokens/components/drawer.json
+++ b/packages/design-tokens/src/tokens/components/drawer.json
@@ -6,7 +6,7 @@
         "type": "number",
         "comment": "Positionering boven de backdrop (400) en onder de skip-link (600)"
       },
-      "background": {
+      "background-color": {
         "value": "{dsn.color.neutral.bg-elevated}",
         "type": "color",
         "comment": "Achtergrondkleur van het zijpaneel — bg-elevated benadrukt elevatie boven de pagina"

--- a/packages/design-tokens/src/tokens/components/modal-dialog.json
+++ b/packages/design-tokens/src/tokens/components/modal-dialog.json
@@ -6,7 +6,7 @@
         "type": "number",
         "comment": "Positionering boven de backdrop (400) en onder de skip-link (600)"
       },
-      "background": {
+      "background-color": {
         "value": "{dsn.color.neutral.bg-elevated}",
         "type": "color",
         "comment": "Achtergrondkleur van het dialoogvenster — bg-elevated benadrukt elevatie boven de pagina"

--- a/packages/design-tokens/src/tokens/components/popover.json
+++ b/packages/design-tokens/src/tokens/components/popover.json
@@ -75,9 +75,9 @@
           "comment": "Bovenkant padding van de header (16px)"
         },
         "padding-block-end": {
-          "value": "{dsn.space.block.md}",
+          "value": "{dsn.space.block.xl}",
           "type": "spacing",
-          "comment": "Onderkant padding van de header — iets kleiner dan block-start, scheiding vóór body (8px)"
+          "comment": "Onderkant padding van de header (16px)"
         },
         "padding-inline": {
           "value": "{dsn.space.inline.xl}",
@@ -87,21 +87,21 @@
       },
       "body": {
         "padding-block": {
-          "value": "{dsn.space.block.md}",
+          "value": "{dsn.space.block.xl}",
           "type": "spacing",
-          "comment": "Verticale padding van de body (8px) — compact, passend voor Menu en korte content"
+          "comment": "Verticale padding van de body (16px)"
         },
         "padding-inline": {
-          "value": "{dsn.space.inline.md}",
+          "value": "{dsn.space.inline.xl}",
           "type": "spacing",
-          "comment": "Horizontale padding van de body (8px)"
+          "comment": "Horizontale padding van de body (16px)"
         }
       },
       "footer": {
         "padding-block-start": {
-          "value": "{dsn.space.block.md}",
+          "value": "{dsn.space.block.xl}",
           "type": "spacing",
-          "comment": "Bovenkant padding van de footer — scheiding ná body (8px)"
+          "comment": "Bovenkant padding van de footer (16px)"
         },
         "padding-block-end": {
           "value": "{dsn.space.block.xl}",

--- a/packages/design-tokens/src/tokens/components/popover.json
+++ b/packages/design-tokens/src/tokens/components/popover.json
@@ -1,0 +1,119 @@
+{
+  "dsn": {
+    "popover": {
+      "background": {
+        "value": "{dsn.color.neutral.bg-elevated}",
+        "type": "color",
+        "comment": "Achtergrondkleur van de popover — bg-elevated benadrukt elevatie boven de pagina"
+      },
+      "border-width": {
+        "value": "{dsn.border.width.thin}",
+        "type": "borderWidth",
+        "comment": "Randbreedte van de popover"
+      },
+      "border-color": {
+        "value": "{dsn.color.neutral.border-subtle}",
+        "type": "color",
+        "comment": "Randkleur van de popover"
+      },
+      "border-radius": {
+        "value": "{dsn.border.radius.md}",
+        "type": "dimension",
+        "comment": "Afgeronde hoeken van de popover (8px) — ronder dan form inputs, passend bij het zwevende karakter"
+      },
+      "box-shadow": {
+        "value": "{dsn.box-shadow.md}",
+        "type": "shadow",
+        "comment": "Schaduw van de popover — middel elevatie (md), hoger dan cards maar lager dan modals"
+      },
+      "max-width": {
+        "value": "25rem",
+        "type": "dimension",
+        "comment": "Maximale breedte van de popover (400px)"
+      },
+      "min-width": {
+        "value": "12.5rem",
+        "type": "dimension",
+        "comment": "Minimale breedte van de popover (200px)"
+      },
+      "z-index": {
+        "value": "300",
+        "type": "number",
+        "comment": "Z-index van de popover — lager dan ModalDialog/Drawer (500), hoger dan sticky headers (200)"
+      },
+      "heading": {
+        "font-family": {
+          "value": "{dsn.heading.font-family}",
+          "type": "fontFamily",
+          "comment": "Lettertype van de popover-heading"
+        },
+        "font-weight": {
+          "value": "{dsn.heading.font-weight}",
+          "type": "fontWeight",
+          "comment": "Vetgedrukt van de popover-heading"
+        },
+        "color": {
+          "value": "{dsn.heading.color}",
+          "type": "color",
+          "comment": "Kleur van de popover-heading"
+        },
+        "font-size": {
+          "value": "{dsn.text.font-size.md}",
+          "type": "fontSize",
+          "comment": "Tekstgrootte van de popover-heading (compacter dan ModalDialog)"
+        },
+        "line-height": {
+          "value": "{dsn.text.line-height.md}",
+          "type": "lineHeight",
+          "comment": "Regelafstand van de popover-heading"
+        }
+      },
+      "header": {
+        "padding-block-start": {
+          "value": "{dsn.space.block.md}",
+          "type": "spacing",
+          "comment": "Bovenkant padding van de header"
+        },
+        "padding-block-end": {
+          "value": "{dsn.space.block.sm}",
+          "type": "spacing",
+          "comment": "Onderkant padding van de header (iets kleiner — visuele scheiding vóór body)"
+        },
+        "padding-inline": {
+          "value": "{dsn.space.inline.md}",
+          "type": "spacing",
+          "comment": "Horizontale padding van de header"
+        }
+      },
+      "body": {
+        "padding-block": {
+          "value": "{dsn.space.block.md}",
+          "type": "spacing",
+          "comment": "Verticale padding van de body"
+        },
+        "padding-inline": {
+          "value": "{dsn.space.inline.md}",
+          "type": "spacing",
+          "comment": "Horizontale padding van de body"
+        }
+      },
+      "footer": {
+        "padding-block-start": {
+          "value": "{dsn.space.block.sm}",
+          "type": "spacing",
+          "comment": "Bovenkant padding van de footer (iets kleiner — visuele scheiding ná body)"
+        },
+        "padding-block-end": {
+          "value": "{dsn.space.block.md}",
+          "type": "spacing",
+          "comment": "Onderkant padding van de footer"
+        },
+        "padding-inline": {
+          "value": "{dsn.space.inline.md}",
+          "type": "spacing",
+          "comment": "Horizontale padding van de footer"
+        }
+      }
+    }
+  }
+}

--- a/packages/design-tokens/src/tokens/components/popover.json
+++ b/packages/design-tokens/src/tokens/components/popover.json
@@ -70,48 +70,48 @@
       },
       "header": {
         "padding-block-start": {
-          "value": "{dsn.space.block.md}",
+          "value": "{dsn.space.block.xl}",
           "type": "spacing",
-          "comment": "Bovenkant padding van de header"
+          "comment": "Bovenkant padding van de header (16px)"
         },
         "padding-block-end": {
-          "value": "{dsn.space.block.sm}",
+          "value": "{dsn.space.block.md}",
           "type": "spacing",
-          "comment": "Onderkant padding van de header (iets kleiner — visuele scheiding vóór body)"
+          "comment": "Onderkant padding van de header — iets kleiner dan block-start, scheiding vóór body (8px)"
         },
         "padding-inline": {
-          "value": "{dsn.space.inline.md}",
+          "value": "{dsn.space.inline.xl}",
           "type": "spacing",
-          "comment": "Horizontale padding van de header"
+          "comment": "Horizontale padding van de header (16px)"
         }
       },
       "body": {
         "padding-block": {
           "value": "{dsn.space.block.md}",
           "type": "spacing",
-          "comment": "Verticale padding van de body"
+          "comment": "Verticale padding van de body (8px) — compact, passend voor Menu en korte content"
         },
         "padding-inline": {
           "value": "{dsn.space.inline.md}",
           "type": "spacing",
-          "comment": "Horizontale padding van de body"
+          "comment": "Horizontale padding van de body (8px)"
         }
       },
       "footer": {
         "padding-block-start": {
-          "value": "{dsn.space.block.sm}",
-          "type": "spacing",
-          "comment": "Bovenkant padding van de footer (iets kleiner — visuele scheiding ná body)"
-        },
-        "padding-block-end": {
           "value": "{dsn.space.block.md}",
           "type": "spacing",
-          "comment": "Onderkant padding van de footer"
+          "comment": "Bovenkant padding van de footer — scheiding ná body (8px)"
+        },
+        "padding-block-end": {
+          "value": "{dsn.space.block.xl}",
+          "type": "spacing",
+          "comment": "Onderkant padding van de footer (16px)"
         },
         "padding-inline": {
-          "value": "{dsn.space.inline.md}",
+          "value": "{dsn.space.inline.xl}",
           "type": "spacing",
-          "comment": "Horizontale padding van de footer"
+          "comment": "Horizontale padding van de footer (16px)"
         }
       }
     }

--- a/packages/design-tokens/src/tokens/components/popover.json
+++ b/packages/design-tokens/src/tokens/components/popover.json
@@ -1,7 +1,7 @@
 {
   "dsn": {
     "popover": {
-      "background": {
+      "background-color": {
         "value": "{dsn.color.neutral.bg-elevated}",
         "type": "color",
         "comment": "Achtergrondkleur van de popover — bg-elevated benadrukt elevatie boven de pagina"

--- a/packages/storybook/src/Card.docs.md
+++ b/packages/storybook/src/Card.docs.md
@@ -49,29 +49,29 @@ Het Card component presenteert een zelfstandig inhoudsblok — doorgaans een afb
 
 ## Design tokens
 
-| Token                                     | Beschrijving                              |
-| ----------------------------------------- | ----------------------------------------- |
-| `--dsn-card-background`                   | Achtergrondkleur standaard (bg-document)  |
-| `--dsn-card-background-hover`             | Achtergrondkleur bij hover (bg-elevated)  |
-| `--dsn-card-border-radius`                | Afgeronde hoeken (8px)                    |
-| `--dsn-card-border-width`                 | Randbreedte                               |
-| `--dsn-card-border-color`                 | Randkleur (neutral.border-subtle)         |
-| `--dsn-card-box-shadow`                   | Standaard schaduw (none)                  |
-| `--dsn-card-box-shadow-hover`             | Schaduw bij hover (md-elevatie)           |
-| `--dsn-card-body-padding-block`           | Verticale padding van de body (16px)      |
-| `--dsn-card-body-padding-inline`          | Horizontale padding van de body (16px)    |
-| `--dsn-card-footer-padding-block-end`     | Onderkant padding van de footer (24px)    |
-| `--dsn-card-footer-padding-inline`        | Horizontale padding van de footer (16px)  |
-| `--dsn-card-image-placeholder-background` | Achtergrond van de afbeeldingsplaceholder |
-| `--dsn-card-image-placeholder-color`      | Kleur van het icoon in de placeholder     |
-| `--dsn-card-heading-font-family`          | Lettertype van de card heading            |
-| `--dsn-card-heading-font-size`            | Tekstgrootte van de card heading          |
-| `--dsn-card-heading-font-weight`          | Vetgedrukt van de card heading            |
-| `--dsn-card-heading-line-height`          | Regelafstand van de card heading          |
-| `--dsn-card-heading-color`                | Kleur van de card heading                 |
-| `--dsn-card-heading-margin-block-end`     | Afstand onder de card heading (12px)      |
-| `--dsn-card-group-gap`                    | Ruimte tussen cards in een groep (16px)   |
-| `--dsn-card-group-item-min-width`         | Minimale breedte per card (17.5rem)       |
+| Token                                           | Beschrijving                              |
+| ----------------------------------------------- | ----------------------------------------- |
+| `--dsn-card-background-color`                   | Achtergrondkleur standaard (bg-document)  |
+| `--dsn-card-background-color-hover`             | Achtergrondkleur bij hover (bg-elevated)  |
+| `--dsn-card-border-radius`                      | Afgeronde hoeken (8px)                    |
+| `--dsn-card-border-width`                       | Randbreedte                               |
+| `--dsn-card-border-color`                       | Randkleur (neutral.border-subtle)         |
+| `--dsn-card-box-shadow`                         | Standaard schaduw (none)                  |
+| `--dsn-card-box-shadow-hover`                   | Schaduw bij hover (md-elevatie)           |
+| `--dsn-card-body-padding-block`                 | Verticale padding van de body (16px)      |
+| `--dsn-card-body-padding-inline`                | Horizontale padding van de body (16px)    |
+| `--dsn-card-footer-padding-block-end`           | Onderkant padding van de footer (24px)    |
+| `--dsn-card-footer-padding-inline`              | Horizontale padding van de footer (16px)  |
+| `--dsn-card-image-placeholder-background-color` | Achtergrond van de afbeeldingsplaceholder |
+| `--dsn-card-image-placeholder-color`            | Kleur van het icoon in de placeholder     |
+| `--dsn-card-heading-font-family`                | Lettertype van de card heading            |
+| `--dsn-card-heading-font-size`                  | Tekstgrootte van de card heading          |
+| `--dsn-card-heading-font-weight`                | Vetgedrukt van de card heading            |
+| `--dsn-card-heading-line-height`                | Regelafstand van de card heading          |
+| `--dsn-card-heading-color`                      | Kleur van de card heading                 |
+| `--dsn-card-heading-margin-block-end`           | Afstand onder de card heading (12px)      |
+| `--dsn-card-group-gap`                          | Ruimte tussen cards in een groep (16px)   |
+| `--dsn-card-group-item-min-width`               | Minimale breedte per card (17.5rem)       |
 
 ## Accessibility
 

--- a/packages/storybook/src/Drawer.docs.md
+++ b/packages/storybook/src/Drawer.docs.md
@@ -65,7 +65,7 @@ Het Drawer component toont een zijpaneel dat over de pagina-inhoud schuift. In t
 
 | Token                                     | Beschrijving                                            |
 | ----------------------------------------- | ------------------------------------------------------- |
-| `--dsn-drawer-background`                 | Achtergrondkleur (bg-elevated)                          |
+| `--dsn-drawer-background-color`           | Achtergrondkleur (bg-elevated)                          |
 | `--dsn-drawer-border-width`               | Randbreedte van de scheidingslijn met de pagina         |
 | `--dsn-drawer-border-color`               | Randkleur van de scheidingslijn (neutral.border-subtle) |
 | `--dsn-drawer-box-shadow`                 | Schaduw (box-shadow.lg — hoogste elevatie)              |

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -95,6 +95,7 @@ function App() {
 - **Image** — Performante, toegankelijke wrapper rond het native `<img>` element met ingebakken lazy loading, vaste beeldverhoudingen en LCP-prioriteit
 - **Card** — Configureerbare container voor gestructureerde content (afbeelding, heading, beschrijving, actie) met stretched-link techniek en CardGroup voor gelijke hoogte
 - **ModalDialog** — Modaal dialoogvenster voor korte, gefocuste acties (bevestigen, kleine keuze) — blokkeert achtergrond via native `<dialog>` met focus-trap
+- **Popover** — Lichtgewicht contextgebonden overlay verankerd aan een triggerelement — niet-modaal, light-dismiss via HTML Popover API, composable met PopoverHeader/Body/Footer
 
 ### Branding Components (1)
 
@@ -169,4 +170,4 @@ MIT License — zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.21.0 | **Laatste update:** 5 april 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.25.0 | **Laatste update:** 14 april 2026 | **Auteur:** Jeffrey Lauwers

--- a/packages/storybook/src/ModalDialog.docs.md
+++ b/packages/storybook/src/ModalDialog.docs.md
@@ -63,7 +63,7 @@ Het ModalDialog component toont een tijdelijk overlay-venster dat de achtergrond
 
 | Token                                           | Beschrijving                               |
 | ----------------------------------------------- | ------------------------------------------ |
-| `--dsn-modal-dialog-background`                 | Achtergrondkleur (bg-elevated)             |
+| `--dsn-modal-dialog-background-color`           | Achtergrondkleur (bg-elevated)             |
 | `--dsn-modal-dialog-border-radius`              | Afgeronde hoeken (12px)                    |
 | `--dsn-modal-dialog-border-width`               | Randbreedte                                |
 | `--dsn-modal-dialog-border-color`               | Randkleur (neutral.border-subtle)          |

--- a/packages/storybook/src/Popover.docs.md
+++ b/packages/storybook/src/Popover.docs.md
@@ -59,29 +59,29 @@ Het triggerelement (bijv. `Button`) krijgt automatisch `aria-expanded="true/fals
 
 ## Design tokens
 
-| Token                                      | Standaardwaarde                     | Beschrijving                    |
-| ------------------------------------------ | ----------------------------------- | ------------------------------- |
-| `--dsn-popover-background`                 | `{dsn.color.neutral.bg-elevated}`   | Achtergrondkleur                |
-| `--dsn-popover-border-width`               | `{dsn.border.width.thin}`           | Randbreedte                     |
-| `--dsn-popover-border-color`               | `{dsn.color.neutral.border-subtle}` | Randkleur                       |
-| `--dsn-popover-border-radius`              | `{dsn.border.radius.md}`            | Hoekafronding                   |
-| `--dsn-popover-box-shadow`                 | `{dsn.box-shadow.md}`               | Schaduw (md-elevatie)           |
-| `--dsn-popover-max-width`                  | `25rem`                             | Maximale breedte (400px)        |
-| `--dsn-popover-min-width`                  | `12.5rem`                           | Minimale breedte (200px)        |
-| `--dsn-popover-z-index`                    | `300`                               | Z-index (lager dan modals: 500) |
-| `--dsn-popover-heading-font-family`        | `{dsn.heading.font-family}`         | Lettertype heading              |
-| `--dsn-popover-heading-font-weight`        | `{dsn.heading.font-weight}`         | Gewicht heading                 |
-| `--dsn-popover-heading-color`              | `{dsn.heading.color}`               | Kleur heading                   |
-| `--dsn-popover-heading-font-size`          | `{dsn.text.font-size.md}`           | Tekstgrootte heading            |
-| `--dsn-popover-heading-line-height`        | `{dsn.text.line-height.md}`         | Regelafstand heading            |
-| `--dsn-popover-header-padding-block-start` | `{dsn.space.block.md}`              | Boven-padding header            |
-| `--dsn-popover-header-padding-block-end`   | `{dsn.space.block.sm}`              | Onder-padding header            |
-| `--dsn-popover-header-padding-inline`      | `{dsn.space.inline.md}`             | Horizontale padding header      |
-| `--dsn-popover-body-padding-block`         | `{dsn.space.block.md}`              | Verticale padding body          |
-| `--dsn-popover-body-padding-inline`        | `{dsn.space.inline.md}`             | Horizontale padding body        |
-| `--dsn-popover-footer-padding-block-start` | `{dsn.space.block.sm}`              | Boven-padding footer            |
-| `--dsn-popover-footer-padding-block-end`   | `{dsn.space.block.md}`              | Onder-padding footer            |
-| `--dsn-popover-footer-padding-inline`      | `{dsn.space.inline.md}`             | Horizontale padding footer      |
+| Token                                      | Standaardwaarde                     | Beschrijving                      |
+| ------------------------------------------ | ----------------------------------- | --------------------------------- |
+| `--dsn-popover-background`                 | `{dsn.color.neutral.bg-elevated}`   | Achtergrondkleur                  |
+| `--dsn-popover-border-width`               | `{dsn.border.width.thin}`           | Randbreedte                       |
+| `--dsn-popover-border-color`               | `{dsn.color.neutral.border-subtle}` | Randkleur                         |
+| `--dsn-popover-border-radius`              | `{dsn.border.radius.md}`            | Hoekafronding                     |
+| `--dsn-popover-box-shadow`                 | `{dsn.box-shadow.md}`               | Schaduw (md-elevatie)             |
+| `--dsn-popover-max-width`                  | `25rem`                             | Maximale breedte (400px)          |
+| `--dsn-popover-min-width`                  | `12.5rem`                           | Minimale breedte (200px)          |
+| `--dsn-popover-z-index`                    | `300`                               | Z-index (lager dan modals: 500)   |
+| `--dsn-popover-heading-font-family`        | `{dsn.heading.font-family}`         | Lettertype heading                |
+| `--dsn-popover-heading-font-weight`        | `{dsn.heading.font-weight}`         | Gewicht heading                   |
+| `--dsn-popover-heading-color`              | `{dsn.heading.color}`               | Kleur heading                     |
+| `--dsn-popover-heading-font-size`          | `{dsn.text.font-size.md}`           | Tekstgrootte heading              |
+| `--dsn-popover-heading-line-height`        | `{dsn.text.line-height.md}`         | Regelafstand heading              |
+| `--dsn-popover-header-padding-block-start` | `{dsn.space.block.xl}`              | Boven-padding header (16px)       |
+| `--dsn-popover-header-padding-block-end`   | `{dsn.space.block.md}`              | Onder-padding header (8px)        |
+| `--dsn-popover-header-padding-inline`      | `{dsn.space.inline.xl}`             | Horizontale padding header (16px) |
+| `--dsn-popover-body-padding-block`         | `{dsn.space.block.md}`              | Verticale padding body (8px)      |
+| `--dsn-popover-body-padding-inline`        | `{dsn.space.inline.md}`             | Horizontale padding body (8px)    |
+| `--dsn-popover-footer-padding-block-start` | `{dsn.space.block.md}`              | Boven-padding footer (8px)        |
+| `--dsn-popover-footer-padding-block-end`   | `{dsn.space.block.xl}`              | Onder-padding footer (16px)       |
+| `--dsn-popover-footer-padding-inline`      | `{dsn.space.inline.xl}`             | Horizontale padding footer (16px) |
 
 ## Accessibility
 

--- a/packages/storybook/src/Popover.docs.md
+++ b/packages/storybook/src/Popover.docs.md
@@ -75,11 +75,11 @@ Het triggerelement (bijv. `Button`) krijgt automatisch `aria-expanded="true/fals
 | `--dsn-popover-heading-font-size`          | `{dsn.text.font-size.md}`           | Tekstgrootte heading              |
 | `--dsn-popover-heading-line-height`        | `{dsn.text.line-height.md}`         | Regelafstand heading              |
 | `--dsn-popover-header-padding-block-start` | `{dsn.space.block.xl}`              | Boven-padding header (16px)       |
-| `--dsn-popover-header-padding-block-end`   | `{dsn.space.block.md}`              | Onder-padding header (8px)        |
+| `--dsn-popover-header-padding-block-end`   | `{dsn.space.block.xl}`              | Onder-padding header (16px)       |
 | `--dsn-popover-header-padding-inline`      | `{dsn.space.inline.xl}`             | Horizontale padding header (16px) |
-| `--dsn-popover-body-padding-block`         | `{dsn.space.block.md}`              | Verticale padding body (8px)      |
-| `--dsn-popover-body-padding-inline`        | `{dsn.space.inline.md}`             | Horizontale padding body (8px)    |
-| `--dsn-popover-footer-padding-block-start` | `{dsn.space.block.md}`              | Boven-padding footer (8px)        |
+| `--dsn-popover-body-padding-block`         | `{dsn.space.block.xl}`              | Verticale padding body (16px)     |
+| `--dsn-popover-body-padding-inline`        | `{dsn.space.inline.xl}`             | Horizontale padding body (16px)   |
+| `--dsn-popover-footer-padding-block-start` | `{dsn.space.block.xl}`              | Boven-padding footer (16px)       |
 | `--dsn-popover-footer-padding-block-end`   | `{dsn.space.block.xl}`              | Onder-padding footer (16px)       |
 | `--dsn-popover-footer-padding-inline`      | `{dsn.space.inline.xl}`             | Horizontale padding footer (16px) |
 

--- a/packages/storybook/src/Popover.docs.md
+++ b/packages/storybook/src/Popover.docs.md
@@ -1,0 +1,105 @@
+# Popover
+
+Lichtgewicht, contextgebonden overlay verankerd aan een triggerelement.
+
+<!-- VOORBEELD -->
+
+## Doel
+
+Het Popover component toont een zwevend paneel dat verankerd is aan een triggerelement. In tegenstelling tot `ModalDialog` en `Drawer` blokkeert een Popover de rest van de pagina niet — de gebruiker kan op de achtergrond blijven interacteren. De overlay sluit automatisch bij klik buiten de overlay (light-dismiss) of bij Escape.
+
+Het component ondersteunt een composable structuur met `PopoverHeader`, `PopoverBody` en `PopoverFooter`, waardoor willekeurige content — waaronder het `Menu`-component — als slot kan worden meegegeven.
+
+**Implementatiekeuze:** De React-implementatie gebruikt de HTML Popover API (`popover="auto"`) voor ingebakken light-dismiss en top-layer gedrag. Positionering vindt plaats via JavaScript (`getBoundingClientRect`).
+
+## Use when
+
+- Contextmenu's verankerd aan een knop (bijv. een `Menu` met acties voor een tabelrij).
+- Beknopte aanvullende informatie bij een UI-element.
+- Kleine formulieren of keuze-UI's die tijdelijk naast een triggerpunt verschijnen.
+- Navigatie-dropdowns of "quick actions" die vanuit een icon-button openen.
+
+## Don't use when
+
+- De content de volledige aandacht van de gebruiker vereist of interactie met de achtergrond niet toegestaan mag zijn — gebruik dan **ModalDialog**.
+- De gebruiker de achtergrondpagina voor context nodig heeft terwijl hij een uitgebreid formulier invult — gebruik dan **Drawer**.
+- De content een volwaardige werkstroom is die een eigen URL rechtvaardigt — gebruik dan een aparte pagina.
+
+## Best practices
+
+### Popover vs. ModalDialog vs. Drawer
+
+| Situatie                                            | Component       |
+| --------------------------------------------------- | --------------- |
+| Contextmenu of quick action bij een knop            | **Popover**     |
+| Bevestiging of korte gefocuste keuze                | **ModalDialog** |
+| Rij- of itemdetails naast een lijst bekijken        | **Drawer**      |
+| Volledige aandacht vereist, achtergrond geblokkeerd | **ModalDialog** |
+
+### Toegankelijke naamgeving
+
+- Gebruik `PopoverHeading` + `PopoverHeader` wanneer de popover een duidelijke titel heeft (bijv. "Filters"). De `aria-labelledby` koppeling verloopt automatisch via de context.
+- Gebruik de `label` prop wanneer de popover geen visuele heading heeft (bijv. een acties-menu). Dit stelt `aria-label` op de popover container.
+- **Nooit** beide tegelijk gebruiken — kies één van de twee patronen.
+
+### Plaatsing
+
+Kies de plaatsing (`placement`) op basis van de beschikbare ruimte:
+
+- `bottom` (standaard) — meest gebruikelijk, de popover opent onder de trigger.
+- `top` — gebruik wanneer de trigger laag op de pagina staat.
+- `end` — rechts van de trigger (of links in RTL).
+- `start` — links van de trigger (of rechts in RTL).
+
+De React-implementatie klampt de popover automatisch binnen het viewport bij overschrijding van de randen.
+
+### Trigger-element
+
+Het triggerelement (bijv. `Button`) krijgt automatisch `aria-expanded="true/false"` via de `triggerRef` prop. Zorg dat het triggerelement via `ref` beschikbaar is voor de `Popover`.
+
+## Design tokens
+
+| Token                                      | Standaardwaarde                     | Beschrijving                    |
+| ------------------------------------------ | ----------------------------------- | ------------------------------- |
+| `--dsn-popover-background`                 | `{dsn.color.neutral.bg-elevated}`   | Achtergrondkleur                |
+| `--dsn-popover-border-width`               | `{dsn.border.width.thin}`           | Randbreedte                     |
+| `--dsn-popover-border-color`               | `{dsn.color.neutral.border-subtle}` | Randkleur                       |
+| `--dsn-popover-border-radius`              | `{dsn.border.radius.md}`            | Hoekafronding                   |
+| `--dsn-popover-box-shadow`                 | `{dsn.box-shadow.md}`               | Schaduw (md-elevatie)           |
+| `--dsn-popover-max-width`                  | `25rem`                             | Maximale breedte (400px)        |
+| `--dsn-popover-min-width`                  | `12.5rem`                           | Minimale breedte (200px)        |
+| `--dsn-popover-z-index`                    | `300`                               | Z-index (lager dan modals: 500) |
+| `--dsn-popover-heading-font-family`        | `{dsn.heading.font-family}`         | Lettertype heading              |
+| `--dsn-popover-heading-font-weight`        | `{dsn.heading.font-weight}`         | Gewicht heading                 |
+| `--dsn-popover-heading-color`              | `{dsn.heading.color}`               | Kleur heading                   |
+| `--dsn-popover-heading-font-size`          | `{dsn.text.font-size.md}`           | Tekstgrootte heading            |
+| `--dsn-popover-heading-line-height`        | `{dsn.text.line-height.md}`         | Regelafstand heading            |
+| `--dsn-popover-header-padding-block-start` | `{dsn.space.block.md}`              | Boven-padding header            |
+| `--dsn-popover-header-padding-block-end`   | `{dsn.space.block.sm}`              | Onder-padding header            |
+| `--dsn-popover-header-padding-inline`      | `{dsn.space.inline.md}`             | Horizontale padding header      |
+| `--dsn-popover-body-padding-block`         | `{dsn.space.block.md}`              | Verticale padding body          |
+| `--dsn-popover-body-padding-inline`        | `{dsn.space.inline.md}`             | Horizontale padding body        |
+| `--dsn-popover-footer-padding-block-start` | `{dsn.space.block.sm}`              | Boven-padding footer            |
+| `--dsn-popover-footer-padding-block-end`   | `{dsn.space.block.md}`              | Onder-padding footer            |
+| `--dsn-popover-footer-padding-inline`      | `{dsn.space.inline.md}`             | Horizontale padding footer      |
+
+## Accessibility
+
+### Structuur
+
+- De popover container heeft `role="dialog"` en `aria-modal="false"` — niet-modaal: de achtergrond blijft interactief en er is geen focus-trap.
+- Popovers met `PopoverHeader`/`PopoverHeading` gebruiken `aria-labelledby` naar de heading-ID (via context, identiek aan het `ModalDialog`-patroon).
+- Popovers zonder heading gebruiken `aria-label` op de popover container (via de `label` prop).
+- Het triggerelement krijgt `aria-expanded="true/false"` die synchroon loopt met de open-staat.
+
+### Toetsenbord
+
+- `Escape` sluit de popover en zet focus terug op het triggerelement.
+- Klik buiten de popover (light-dismiss via Popover API) sluit de popover.
+- Bij openen: focus springt naar het eerste interactieve element in de popover.
+- Tab-volgorde blijft lineair — focus mag buiten de popover bewegen (geen focus-trap).
+
+### Schermlezers
+
+- Schermlezers kondigen de dialoogrol aan bij openen: bijv. "Acties, dialoog".
+- De sluitknop in `PopoverHeader` gebruikt altijd een `dsn-button__label` span — nooit `aria-label` op de button zelf.

--- a/packages/storybook/src/Popover.docs.md
+++ b/packages/storybook/src/Popover.docs.md
@@ -61,7 +61,7 @@ Het triggerelement (bijv. `Button`) krijgt automatisch `aria-expanded="true/fals
 
 | Token                                      | Standaardwaarde                     | Beschrijving                      |
 | ------------------------------------------ | ----------------------------------- | --------------------------------- |
-| `--dsn-popover-background`                 | `{dsn.color.neutral.bg-elevated}`   | Achtergrondkleur                  |
+| `--dsn-popover-background-color`           | `{dsn.color.neutral.bg-elevated}`   | Achtergrondkleur                  |
 | `--dsn-popover-border-width`               | `{dsn.border.width.thin}`           | Randbreedte                       |
 | `--dsn-popover-border-color`               | `{dsn.color.neutral.border-subtle}` | Randkleur                         |
 | `--dsn-popover-border-radius`              | `{dsn.border.radius.md}`            | Hoekafronding                     |

--- a/packages/storybook/src/Popover.docs.mdx
+++ b/packages/storybook/src/Popover.docs.mdx
@@ -1,0 +1,58 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as PopoverStories from './Popover.stories';
+import docs from './Popover.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={PopoverStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={PopoverStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={PopoverStories.Default}
+  html={`<div class="dsn-popover-wrapper">
+  <button
+    type="button"
+    class="dsn-button dsn-button--subtle dsn-button--size-medium"
+    popovertarget="popover-acties"
+    aria-expanded="false"
+  >
+    <span class="dsn-button__label">Acties</span>
+  </button>
+
+  <div
+    id="popover-acties"
+    popover="auto"
+    class="dsn-popover dsn-popover--placement-bottom"
+    role="dialog"
+    aria-modal="false"
+    aria-label="Acties"
+  >
+    <div class="dsn-popover__body">
+      <ul class="dsn-menu" role="list">
+        <li>
+          <button type="button" class="dsn-menu-button">
+            <span class="dsn-menu-item__label">Bewerken</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="dsn-menu-button">
+            <span class="dsn-menu-item__label">Verwijderen</span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>`}
+/>
+
+<Controls of={PopoverStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/Popover.stories.tsx
+++ b/packages/storybook/src/Popover.stories.tsx
@@ -1,0 +1,413 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Popover,
+  PopoverHeader,
+  PopoverHeading,
+  PopoverBody,
+  PopoverFooter,
+  Button,
+  Menu,
+  MenuButton,
+  ActionGroup,
+  Paragraph,
+} from '@dsn/components-react';
+import { rtlDecorator } from './story-helpers';
+
+const meta: Meta<typeof Popover> = {
+  title: 'Components/Popover',
+  component: Popover,
+  parameters: {
+    dsn: {
+      htmlTemplate: () => {
+        return `<div class="dsn-popover-wrapper">
+  <button
+    type="button"
+    class="dsn-button dsn-button--subtle dsn-button--size-medium"
+    popovertarget="popover-demo"
+    aria-expanded="false"
+  >
+    <span class="dsn-button__label">Acties</span>
+  </button>
+
+  <div
+    id="popover-demo"
+    popover="auto"
+    class="dsn-popover dsn-popover--placement-bottom"
+    role="dialog"
+    aria-modal="false"
+    aria-label="Acties"
+  >
+    <div class="dsn-popover__body">
+      <ul class="dsn-menu" role="list">
+        <li>
+          <button type="button" class="dsn-menu-button">
+            <span class="dsn-menu-item__label">Bewerken</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="dsn-menu-button">
+            <span class="dsn-menu-item__label">Verwijderen</span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>`;
+      },
+    },
+  },
+  argTypes: {
+    isOpen: { control: false },
+    onClose: { control: false },
+    triggerRef: { control: false },
+    children: { control: false },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {
+  render: () => {
+    function Demo() {
+      const triggerRef = React.useRef<HTMLButtonElement>(null);
+      const [isOpen, setIsOpen] = React.useState(false);
+      return (
+        <div
+          style={{ padding: '4rem', display: 'flex', justifyContent: 'center' }}
+        >
+          <Button
+            ref={triggerRef}
+            variant="subtle"
+            onClick={() => setIsOpen((prev) => !prev)}
+          >
+            Acties
+          </Button>
+          <Popover
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            triggerRef={triggerRef}
+            label="Acties"
+          >
+            <PopoverBody>
+              <Menu>
+                <MenuButton onClick={() => setIsOpen(false)}>
+                  Bewerken
+                </MenuButton>
+                <MenuButton onClick={() => setIsOpen(false)}>
+                  Dupliceren
+                </MenuButton>
+                <MenuButton onClick={() => setIsOpen(false)}>
+                  Verwijderen
+                </MenuButton>
+              </Menu>
+            </PopoverBody>
+          </Popover>
+        </div>
+      );
+    }
+    return <Demo />;
+  },
+};
+
+// =============================================================================
+// VARIANTEN
+// =============================================================================
+
+export const WithHeader: Story = {
+  name: 'Met header',
+  render: () => {
+    function Demo() {
+      const triggerRef = React.useRef<HTMLButtonElement>(null);
+      const [isOpen, setIsOpen] = React.useState(false);
+      return (
+        <div
+          style={{ padding: '4rem', display: 'flex', justifyContent: 'center' }}
+        >
+          <Button
+            ref={triggerRef}
+            variant="default"
+            onClick={() => setIsOpen((prev) => !prev)}
+          >
+            Filters
+          </Button>
+          <Popover
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            triggerRef={triggerRef}
+          >
+            <PopoverHeader>
+              <PopoverHeading>Filters</PopoverHeading>
+            </PopoverHeader>
+            <PopoverBody>
+              <Paragraph>Pas filters toe op de resultaten.</Paragraph>
+            </PopoverBody>
+          </Popover>
+        </div>
+      );
+    }
+    return <Demo />;
+  },
+};
+
+export const WithHeaderAndFooter: Story = {
+  name: 'Met header en footer',
+  render: () => {
+    function Demo() {
+      const triggerRef = React.useRef<HTMLButtonElement>(null);
+      const [isOpen, setIsOpen] = React.useState(false);
+      return (
+        <div
+          style={{ padding: '4rem', display: 'flex', justifyContent: 'center' }}
+        >
+          <Button
+            ref={triggerRef}
+            variant="default"
+            onClick={() => setIsOpen((prev) => !prev)}
+          >
+            Filters
+          </Button>
+          <Popover
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            triggerRef={triggerRef}
+          >
+            <PopoverHeader>
+              <PopoverHeading>Filters</PopoverHeading>
+            </PopoverHeader>
+            <PopoverBody>
+              <Paragraph>Selecteer de gewenste filters.</Paragraph>
+            </PopoverBody>
+            <PopoverFooter>
+              <ActionGroup>
+                <Button
+                  variant="strong"
+                  size="small"
+                  onClick={() => setIsOpen(false)}
+                >
+                  Toepassen
+                </Button>
+                <Button
+                  variant="default"
+                  size="small"
+                  onClick={() => setIsOpen(false)}
+                >
+                  Annuleren
+                </Button>
+              </ActionGroup>
+            </PopoverFooter>
+          </Popover>
+        </div>
+      );
+    }
+    return <Demo />;
+  },
+};
+
+// =============================================================================
+// PLAATSING
+// =============================================================================
+
+function PlacementDemo({
+  placement,
+}: {
+  placement: NonNullable<React.ComponentProps<typeof Popover>['placement']>;
+}) {
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  return (
+    <div style={{ padding: '6rem', display: 'flex', justifyContent: 'center' }}>
+      <Button
+        ref={triggerRef}
+        variant="default"
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        Plaatsing: {placement}
+      </Button>
+      <Popover
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        triggerRef={triggerRef}
+        placement={placement}
+        label={`Popover ${placement}`}
+      >
+        <PopoverBody>
+          <Menu>
+            <MenuButton onClick={() => setIsOpen(false)}>Optie 1</MenuButton>
+            <MenuButton onClick={() => setIsOpen(false)}>Optie 2</MenuButton>
+          </Menu>
+        </PopoverBody>
+      </Popover>
+    </div>
+  );
+}
+
+export const PlacementBottom: Story = {
+  name: 'Plaatsing: bottom (standaard)',
+  render: () => <PlacementDemo placement="bottom" />,
+};
+
+export const PlacementTop: Story = {
+  name: 'Plaatsing: top',
+  render: () => <PlacementDemo placement="top" />,
+};
+
+export const PlacementEnd: Story = {
+  name: 'Plaatsing: end (rechts in LTR)',
+  render: () => <PlacementDemo placement="end" />,
+};
+
+export const PlacementStart: Story = {
+  name: 'Plaatsing: start (links in LTR)',
+  render: () => <PlacementDemo placement="start" />,
+};
+
+// =============================================================================
+// OVERZICHTSSTORIES
+// =============================================================================
+
+export const AllPlacements: Story = {
+  name: 'Alle plaatsingen',
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gap: '2rem',
+        padding: '6rem',
+      }}
+    >
+      <PlacementDemo placement="bottom" />
+      <PlacementDemo placement="top" />
+      <PlacementDemo placement="end" />
+      <PlacementDemo placement="start" />
+    </div>
+  ),
+};
+
+// =============================================================================
+// TEKST VARIANTEN
+// =============================================================================
+
+export const ShortText: Story = {
+  name: 'Korte content',
+  render: () => {
+    function Demo() {
+      const triggerRef = React.useRef<HTMLButtonElement>(null);
+      const [isOpen, setIsOpen] = React.useState(false);
+      return (
+        <div
+          style={{ padding: '4rem', display: 'flex', justifyContent: 'center' }}
+        >
+          <Button
+            ref={triggerRef}
+            variant="default"
+            onClick={() => setIsOpen((prev) => !prev)}
+          >
+            Info
+          </Button>
+          <Popover
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            triggerRef={triggerRef}
+            label="Info"
+          >
+            <PopoverBody>
+              <Paragraph>Korte tekst.</Paragraph>
+            </PopoverBody>
+          </Popover>
+        </div>
+      );
+    }
+    return <Demo />;
+  },
+};
+
+export const LongText: Story = {
+  name: 'Lange content',
+  render: () => {
+    function Demo() {
+      const triggerRef = React.useRef<HTMLButtonElement>(null);
+      const [isOpen, setIsOpen] = React.useState(false);
+      return (
+        <div
+          style={{ padding: '4rem', display: 'flex', justifyContent: 'center' }}
+        >
+          <Button
+            ref={triggerRef}
+            variant="default"
+            onClick={() => setIsOpen((prev) => !prev)}
+          >
+            Meer informatie
+          </Button>
+          <Popover
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            triggerRef={triggerRef}
+          >
+            <PopoverHeader>
+              <PopoverHeading>Aanvullende informatie</PopoverHeading>
+            </PopoverHeader>
+            <PopoverBody>
+              <Paragraph>
+                Dit is een langere tekst die de maximale breedte van de popover
+                kan benaderen. De popover heeft een max-width van 25rem (400px)
+                en breekt automatisch naar meerdere regels wanneer de content
+                breder is dan de beschikbare ruimte.
+              </Paragraph>
+            </PopoverBody>
+          </Popover>
+        </div>
+      );
+    }
+    return <Demo />;
+  },
+};
+
+// =============================================================================
+// RTL
+// =============================================================================
+
+export const RTL: Story = {
+  name: 'RTL (plaatsing start/end gespiegeld)',
+  decorators: [rtlDecorator],
+  render: () => {
+    function Demo() {
+      const triggerRef = React.useRef<HTMLButtonElement>(null);
+      const [isOpen, setIsOpen] = React.useState(false);
+      return (
+        <div
+          style={{ padding: '4rem', display: 'flex', justifyContent: 'center' }}
+        >
+          <Button
+            ref={triggerRef}
+            variant="subtle"
+            onClick={() => setIsOpen((prev) => !prev)}
+          >
+            إجراءات
+          </Button>
+          <Popover
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            triggerRef={triggerRef}
+            label="إجراءات"
+            placement="end"
+          >
+            <PopoverBody>
+              <Menu>
+                <MenuButton onClick={() => setIsOpen(false)}>تعديل</MenuButton>
+                <MenuButton onClick={() => setIsOpen(false)}>حذف</MenuButton>
+              </Menu>
+            </PopoverBody>
+          </Popover>
+        </div>
+      );
+    }
+    return <Demo />;
+  },
+};

--- a/packages/storybook/src/Popover.stories.tsx
+++ b/packages/storybook/src/Popover.stories.tsx
@@ -120,7 +120,7 @@ export const Default: Story = {
 // =============================================================================
 
 export const WithHeader: Story = {
-  name: 'Met header',
+  name: 'With Header',
   render: () => {
     function Demo() {
       const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -156,7 +156,7 @@ export const WithHeader: Story = {
 };
 
 export const WithHeaderAndFooter: Story = {
-  name: 'Met header en footer',
+  name: 'With Header and Footer',
   render: () => {
     function Demo() {
       const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -248,22 +248,22 @@ function PlacementDemo({
 }
 
 export const PlacementBottom: Story = {
-  name: 'Plaatsing: bottom (standaard)',
+  name: 'Placement: Bottom (default)',
   render: () => <PlacementDemo placement="bottom" />,
 };
 
 export const PlacementTop: Story = {
-  name: 'Plaatsing: top',
+  name: 'Placement: Top',
   render: () => <PlacementDemo placement="top" />,
 };
 
 export const PlacementEnd: Story = {
-  name: 'Plaatsing: end (rechts in LTR)',
+  name: 'Placement: End (right in LTR)',
   render: () => <PlacementDemo placement="end" />,
 };
 
 export const PlacementStart: Story = {
-  name: 'Plaatsing: start (links in LTR)',
+  name: 'Placement: Start (left in LTR)',
   render: () => <PlacementDemo placement="start" />,
 };
 
@@ -272,7 +272,7 @@ export const PlacementStart: Story = {
 // =============================================================================
 
 export const AllPlacements: Story = {
-  name: 'Alle plaatsingen',
+  name: 'All Placements',
   render: () => (
     <div
       style={{
@@ -295,7 +295,7 @@ export const AllPlacements: Story = {
 // =============================================================================
 
 export const ShortText: Story = {
-  name: 'Korte content',
+  name: 'Short Content',
   render: () => {
     function Demo() {
       const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -329,7 +329,7 @@ export const ShortText: Story = {
 };
 
 export const LongText: Story = {
-  name: 'Lange content',
+  name: 'Long Content',
   render: () => {
     function Demo() {
       const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -374,7 +374,7 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL (plaatsing start/end gespiegeld)',
+  name: 'RTL (start/end placement mirrored)',
   decorators: [rtlDecorator],
   render: () => {
     function Demo() {


### PR DESCRIPTION
Closes #155

## Summary

- **Design tokens** (`popover.json`): achtergrond, border, shadow, sizing, z-index, heading- en sectie-padding tokens
- **HTML/CSS** (`popover.css`): visuele stijlen, placement-modifiers (bottom/top/start/end), `@starting-style` entry-animatie, `prefers-reduced-motion` support
- **React** (`Popover.tsx`): vijf componenten — `Popover`, `PopoverHeader`, `PopoverHeading`, `PopoverBody`, `PopoverFooter` — met `PopoverContext` voor gedeelde `headingId` en `onClose`
  - HTML Popover API (`popover="auto"`) voor ingebakken light-dismiss en top-layer gedrag
  - JS-positionering via `getBoundingClientRect` met viewport-clamping en RTL-ondersteuning
  - `aria-expanded` synchronisatie op het triggerelement via `triggerRef`
  - Focus-management: eerste interactief element bij openen, trigger bij sluiten
- **Tests** (22 cases): rendering, aria-structuur, showPopover/hidePopover, aria-expanded, onClose, sub-components, heading-niveaus, ref forwarding
- **Storybook**: Default, WithHeader, WithHeaderAndFooter, vier placement-stories, AllPlacements, ShortText, LongText, RTL

**Implementatiekeuze** (zie open vraag in issue): HTML Popover API + JS-positionering. Geen externe positioning library nodig.

## Test plan

- [ ] `pnpm test` — 1329 tests groen
- [ ] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [ ] `pnpm lint` — 0 fouten
- [ ] CI groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)