### PR TITLE
feat(PageHeader): Logged In en New Message stories + badge-positionering

### DIFF
--- a/packages/components-html/src/button/button.css
+++ b/packages/components-html/src/button/button.css
@@ -8,6 +8,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  position: relative; /* Ankerpunt voor DotBadge */
 
   /* Typography */
   font-family: var(--dsn-button-font-family);

--- a/packages/components-html/src/link/link.css
+++ b/packages/components-html/src/link/link.css
@@ -8,6 +8,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--dsn-link-gap);
+  position: relative; /* Ankerpunt voor DotBadge */
 
   /* Typography */
   color: var(--dsn-link-color);

--- a/packages/components-html/src/menu-button/menu-button.css
+++ b/packages/components-html/src/menu-button/menu-button.css
@@ -36,6 +36,7 @@
   background: none;
   border: 0;
   cursor: pointer;
+  position: relative; /* Ankerpunt voor DotBadge */
 
   /* Layout */
   display: inline-flex;
@@ -73,11 +74,9 @@
 
 .dsn-menu-button__label {
   /* De <button> zelf is full-width via width: 100%.
-     Het label vult de resterende ruimte zodat iconEnd rechts uitlijnt.
-     position: relative zodat de dotBadge zich absoluut rechtsboven de tekst positioneert. */
+     Het label vult de resterende ruimte zodat iconEnd rechts uitlijnt. */
   flex: 1;
   text-align: start;
-  position: relative;
 }
 
 /* =============================================================================

--- a/packages/components-react/src/PageHeader/PageHeader.tsx
+++ b/packages/components-react/src/PageHeader/PageHeader.tsx
@@ -91,6 +91,21 @@ export interface PageHeaderProps extends Omit<
   searchSlot?: React.ReactNode;
 
   /**
+   * Visuele badge-indicator bij de menuknop (small viewport), doorgaans een `<DotBadge>`.
+   * Gebruik dit om ongelezen meldingen te signaleren. De badge is altijd `aria-hidden` —
+   * geef de toegankelijke tekst mee via `menuButtonBadgeLabel`.
+   */
+  menuButtonBadge?: React.ReactNode;
+
+  /**
+   * Toegankelijke tekst die wordt toegevoegd aan het label van de menuknop als er een badge
+   * aanwezig is, bijvoorbeeld `"2 nieuwe berichten"`. Wordt visueel verborgen getoond zodat
+   * screenreadergebruikers de melding horen: "Menu, 2 nieuwe berichten".
+   * Vereist als `menuButtonBadge` is meegegeven.
+   */
+  menuButtonBadgeLabel?: string;
+
+  /**
    * Callback wanneer de navigatielade opent.
    */
   onMenuOpen?: () => void;
@@ -159,6 +174,8 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
       secondaryNavigation,
       secondaryNavigationLarge,
       searchSlot,
+      menuButtonBadge,
+      menuButtonBadgeLabel,
       onMenuOpen,
       onMenuClose,
       onSearchOpen,
@@ -288,6 +305,12 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
                   iconStart={<Icon name="menu" aria-hidden />}
                 >
                   Menu
+                  {menuButtonBadgeLabel && (
+                    <span className="dsn-visually-hidden">
+                      , {menuButtonBadgeLabel}
+                    </span>
+                  )}
+                  {menuButtonBadge}
                 </Button>
               </div>
 

--- a/packages/storybook/src/DotBadge.stories.tsx
+++ b/packages/storybook/src/DotBadge.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Button, DotBadge, Icon, Link } from '@dsn/components-react';
+import { Button, DotBadge, Icon } from '@dsn/components-react';
 import DocsPage from './DotBadge.docs.mdx';
 
 const meta: Meta<typeof DotBadge> = {
@@ -200,41 +200,6 @@ export const WithButton: Story = {
           <span className="dsn-visually-hidden">, status bijgewerkt</span>
         </Button>
         <DotBadge variant="positive" />
-      </div>
-    </div>
-  ),
-};
-
-export const WithLink: Story = {
-  name: 'With Link',
-  render: () => (
-    <div
-      style={{
-        display: 'flex',
-        gap: '2rem',
-        flexWrap: 'wrap',
-        alignItems: 'flex-start',
-      }}
-    >
-      {/* Link met dot */}
-      <div style={{ position: 'relative', display: 'inline-flex' }}>
-        <Link href="#">
-          Meldingen
-          <span className="dsn-visually-hidden"> (ongelezen)</span>
-        </Link>
-        <DotBadge variant="negative" />
-      </div>
-
-      {/* Link met pulserende dot */}
-      <div style={{ position: 'relative', display: 'inline-flex' }}>
-        <Link href="#">
-          Updates
-          <span className="dsn-visually-hidden">
-            {' '}
-            (nieuwe updates beschikbaar)
-          </span>
-        </Link>
-        <DotBadge variant="info" pulse />
       </div>
     </div>
   ),

--- a/packages/storybook/src/PageHeader.docs.mdx
+++ b/packages/storybook/src/PageHeader.docs.mdx
@@ -17,6 +17,54 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 
 <CodeTabs
   of={PageHeaderStories.Default}
+  react={`<PageHeader
+  logoSlot={
+    <a href="/">
+      <Logo aria-hidden={true} />
+      <span className="dsn-visually-hidden">
+        Starter Kit: terug naar homepage
+      </span>
+    </a>
+  }
+  primaryNavigation={
+    <Menu orientation="vertical">
+      <MenuLink href="/level-1a" level={1} current>
+        Level 1a
+      </MenuLink>
+      <MenuLink href="/level-1b" level={1}>
+        Level 1b
+      </MenuLink>
+    </Menu>
+  }
+  primaryNavigationLarge={
+    <Menu orientation="horizontal">
+      <MenuLink href="/level-1a" level={1} current>
+        Level 1a
+      </MenuLink>
+      <MenuLink href="/level-1b" level={1}>
+        Level 1b
+      </MenuLink>
+    </Menu>
+  }
+  secondaryNavigation={
+    <Menu orientation="vertical">
+      <MenuLink href="/english" level={1}>English</MenuLink>
+      <MenuLink href="/mijn-omgeving" level={1}>Mijn omgeving</MenuLink>
+    </Menu>
+  }
+  secondaryNavigationLarge={
+    <Menu orientation="horizontal">
+      <MenuLink href="/english" level={1}>English</MenuLink>
+      <MenuLink href="/mijn-omgeving" level={1}>Mijn omgeving</MenuLink>
+    </Menu>
+  }
+  searchSlot={
+    <>
+      <SearchInput placeholder="Zoeken…" aria-label="Zoekopdracht" />
+      <Button variant="strong">Zoeken</Button>
+    </>
+  }
+/>`}
   html={`<header class="dsn-page-header">
   <div class="dsn-page-header__inner">
     <div class="dsn-page-header__start">

--- a/packages/storybook/src/PageHeader.stories.tsx
+++ b/packages/storybook/src/PageHeader.stories.tsx
@@ -2,10 +2,16 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   Button,
+  DotBadge,
+  Icon,
   Logo,
   Menu,
+  MenuButton,
   MenuLink,
+  NumberBadge,
   PageHeader,
+  Popover,
+  PopoverBody,
   SearchInput,
 } from '@dsn/components-react';
 import { rtlDecorator } from './story-helpers';
@@ -256,6 +262,196 @@ const searchSlotAR = (
   </>
 );
 
+// =============================================================================
+// INGELOGDE GEBRUIKER — helper-componenten
+// =============================================================================
+
+function LoggedInServiceMenuLarge() {
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return (
+    <>
+      <Menu orientation="horizontal">
+        <MenuLink href="/english" level={1}>
+          English
+        </MenuLink>
+        <MenuButton
+          ref={triggerRef}
+          iconEnd={<Icon name="chevron-down" aria-hidden />}
+          onClick={() => setIsOpen((v) => !v)}
+        >
+          J. van Drouwen
+        </MenuButton>
+      </Menu>
+      <Popover
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        triggerRef={triggerRef}
+        label="Mijn omgeving"
+        placement="bottom"
+      >
+        <PopoverBody>
+          <Menu orientation="vertical">
+            <MenuLink href="/overzicht" level={1}>
+              Overzicht
+            </MenuLink>
+            <MenuLink href="/berichten" level={1}>
+              Berichten
+            </MenuLink>
+            <MenuLink href="/gegevens" level={1}>
+              Gegevens
+            </MenuLink>
+            <MenuLink href="/uitloggen" level={1}>
+              Uitloggen
+            </MenuLink>
+          </Menu>
+        </PopoverBody>
+      </Popover>
+    </>
+  );
+}
+
+function LoggedInServiceMenuSmall() {
+  const [expanded, setExpanded] = React.useState(false);
+
+  return (
+    <Menu orientation="vertical">
+      <MenuLink href="/english" level={1}>
+        English
+      </MenuLink>
+      <MenuLink
+        href="/mijn-omgeving"
+        level={1}
+        subItems
+        expanded={expanded}
+        onExpandToggle={() => setExpanded((v) => !v)}
+      >
+        J. van Drouwen
+      </MenuLink>
+      {expanded && (
+        <>
+          <MenuLink href="/overzicht" level={2}>
+            Overzicht
+          </MenuLink>
+          <MenuLink href="/berichten" level={2}>
+            Berichten
+          </MenuLink>
+          <MenuLink href="/gegevens" level={2}>
+            Gegevens
+          </MenuLink>
+          <MenuLink href="/uitloggen" level={2}>
+            Uitloggen
+          </MenuLink>
+        </>
+      )}
+    </Menu>
+  );
+}
+
+function NewMessageServiceMenuLarge() {
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return (
+    <>
+      <Menu orientation="horizontal">
+        <MenuLink href="/english" level={1}>
+          English
+        </MenuLink>
+        <MenuButton
+          ref={triggerRef}
+          iconEnd={<Icon name="chevron-down" aria-hidden />}
+          dotBadge={<DotBadge variant="negative" pulse />}
+          onClick={() => setIsOpen((v) => !v)}
+        >
+          J. van Drouwen
+          <span className="dsn-visually-hidden">, 2 nieuwe berichten</span>
+        </MenuButton>
+      </Menu>
+      <Popover
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        triggerRef={triggerRef}
+        label="Mijn omgeving"
+        placement="bottom"
+      >
+        <PopoverBody>
+          <Menu orientation="vertical">
+            <MenuLink href="/overzicht" level={1}>
+              Overzicht
+            </MenuLink>
+            <MenuLink
+              href="/berichten"
+              level={1}
+              numberBadge={
+                <NumberBadge variant="negative" aria-hidden>
+                  2
+                </NumberBadge>
+              }
+            >
+              Berichten
+              <span className="dsn-visually-hidden"> (2 ongelezen)</span>
+            </MenuLink>
+            <MenuLink href="/gegevens" level={1}>
+              Gegevens
+            </MenuLink>
+            <MenuLink href="/uitloggen" level={1}>
+              Uitloggen
+            </MenuLink>
+          </Menu>
+        </PopoverBody>
+      </Popover>
+    </>
+  );
+}
+
+function NewMessageServiceMenuSmall() {
+  const [expanded, setExpanded] = React.useState(false);
+
+  return (
+    <Menu orientation="vertical">
+      <MenuLink href="/english" level={1}>
+        English
+      </MenuLink>
+      <MenuLink
+        href="/mijn-omgeving"
+        level={1}
+        subItems
+        expanded={expanded}
+        onExpandToggle={() => setExpanded((v) => !v)}
+      >
+        J. van Drouwen
+      </MenuLink>
+      {expanded && (
+        <>
+          <MenuLink href="/overzicht" level={2}>
+            Overzicht
+          </MenuLink>
+          <MenuLink
+            href="/berichten"
+            level={2}
+            numberBadge={
+              <NumberBadge variant="negative" aria-hidden>
+                2
+              </NumberBadge>
+            }
+          >
+            Berichten
+            <span className="dsn-visually-hidden"> (2 ongelezen)</span>
+          </MenuLink>
+          <MenuLink href="/gegevens" level={2}>
+            Gegevens
+          </MenuLink>
+          <MenuLink href="/uitloggen" level={2}>
+            Uitloggen
+          </MenuLink>
+        </>
+      )}
+    </Menu>
+  );
+}
+
 const meta: Meta<typeof PageHeader> = {
   title: 'Components/PageHeader',
   component: PageHeader,
@@ -396,38 +592,187 @@ function PageContent() {
 }
 
 // =============================================================================
-// DEFAULT
+// COMPACT
 // =============================================================================
 
-export const Default: Story = {};
-
-// =============================================================================
-// VARIANTEN
-// =============================================================================
-
-export const WithStickyHeader: Story = {
-  name: 'With sticky header',
+export const Compact: Story = {
+  name: 'Compact',
   args: {
-    sticky: 'sticky',
+    layout: 'compact',
   },
-  render: (args) => (
-    <>
-      <PageHeader {...args} />
-      <PageContent />
-    </>
-  ),
   parameters: {
+    viewport: { defaultViewport: 'large' },
     docs: {
       description: {
         story:
-          'De header blijft bovenaan de viewport vastgeplakt bij het scrollen. `position: sticky; inset-block-start: 0`.',
+          'Op viewports ≥ 64em toont de compact variant één enkele rij: logo (inline-start), primaire navigatie (optisch gecentreerd via CSS-grid `1fr auto 1fr`), en servicemenu + zoek-iconknop (inline-end). Gebruikt `primaryNavigationLarge` voor de compacte balk en `primaryNavigation` (verticaal) voor de Drawer op small viewport.',
       },
     },
   },
 };
 
-export const WithAutoHide: Story = {
-  name: 'With auto-hide',
+export const CompactInverse: Story = {
+  name: 'Compact: Inverse',
+  args: {
+    layout: 'compact',
+    colorScheme: 'inverse',
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'Combinatie van `layout="compact"` en `colorScheme="inverse"`: de compacte balk (logo, primaire navigatie, servicemenu) heeft een `accent-1-inverse` achtergrond. Het zoekpaneel gebruikt `accent-1-inverse.bg-document` voor visuele scheiding.',
+      },
+    },
+  },
+};
+
+export const CompactLoggedIn: Story = {
+  name: 'Compact: Logged In',
+  args: {
+    layout: 'compact',
+    secondaryNavigation: <LoggedInServiceMenuSmall />,
+    secondaryNavigationLarge: <LoggedInServiceMenuLarge />,
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'Ingelogde gebruiker met de compact layout op large viewport. De gebruikersnaam met Popover staat in de compacte balk inline-end. Op small viewport valt de layout terug op de Drawer met uitklapbare accountnavigatie.',
+      },
+    },
+  },
+};
+
+export const CompactNewMessage: Story = {
+  name: 'Compact: New message',
+  args: {
+    layout: 'compact',
+    menuButtonBadge: <DotBadge variant="negative" pulse />,
+    menuButtonBadgeLabel: '2 nieuwe berichten',
+    secondaryNavigation: <NewMessageServiceMenuSmall />,
+    secondaryNavigationLarge: <NewMessageServiceMenuLarge />,
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'Ingelogde gebruiker met ongelezen berichten, compact layout. Op large viewport toont de MenuButton een pulserende DotBadge; in de Popover heeft "Berichten" een NumberBadge. Op small viewport toont de Menu-knop een DotBadge en draagt de MenuLink "Berichten" een NumberBadge in de Drawer.',
+      },
+    },
+  },
+};
+
+export const CompactRTL: Story = {
+  name: 'Compact: RTL',
+  decorators: [rtlDecorator],
+  args: {
+    layout: 'compact',
+    logoSlot: logoSlotAR,
+    primaryNavigation: primaryNavigationAR,
+    primaryNavigationLarge: primaryNavigationLargeAR,
+    secondaryNavigation: secondaryNavigationAR,
+    secondaryNavigationLarge: secondaryNavigationLargeAR,
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'RTL compact layout: logo inline-end, primaire navigatie gecentreerd, servicemenu + zoekknop inline-start.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {};
+
+export const DefaultInverse: Story = {
+  name: 'Default: Inverse',
+  args: {
+    colorScheme: 'inverse',
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'De inverse kleurvariant (`colorScheme="inverse"`) gebruikt `accent-1-inverse` achtergronden op de navbar en het zoekpaneel voor prominente branding. Het masthead blijft neutraal. Het logo past zijn kleuren automatisch aan via CSS context overrides.',
+      },
+    },
+  },
+};
+
+export const DefaultLoggedIn: Story = {
+  name: 'Default: Logged In',
+  args: {
+    secondaryNavigation: <LoggedInServiceMenuSmall />,
+    secondaryNavigationLarge: <LoggedInServiceMenuLarge />,
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'Ingelogde gebruiker op large viewport. De "Mijn omgeving" link in het servicemenu is vervangen door een MenuButton met de naam van de gebruiker en een chevron-down icoon. Bij klikken opent een Popover met accountnavigatie: Overzicht, Berichten, Gegevens en Uitloggen.',
+      },
+    },
+  },
+};
+
+export const DefaultNewMessage: Story = {
+  name: 'Default: New message',
+  args: {
+    menuButtonBadge: <DotBadge variant="negative" pulse />,
+    menuButtonBadgeLabel: '2 nieuwe berichten',
+    secondaryNavigation: <NewMessageServiceMenuSmall />,
+    secondaryNavigationLarge: <NewMessageServiceMenuLarge />,
+  },
+  parameters: {
+    viewport: { defaultViewport: 'large' },
+    docs: {
+      description: {
+        story:
+          'Ingelogde gebruiker met ongelezen berichten, default layout. Op large viewport toont de MenuButton een pulserende DotBadge; in de Popover heeft "Berichten" een NumberBadge. Op small viewport toont de Menu-knop een DotBadge en draagt de MenuLink "Berichten" een NumberBadge in de Drawer.',
+      },
+    },
+  },
+};
+
+export const DefaultRTL: Story = {
+  name: 'Default: RTL',
+  decorators: [rtlDecorator],
+  args: {
+    logoSlot: logoSlotAR,
+    primaryNavigation: primaryNavigationAR,
+    primaryNavigationLarge: primaryNavigationLargeAR,
+    secondaryNavigation: secondaryNavigationAR,
+    secondaryNavigationLarge: secondaryNavigationLargeAR,
+    searchSlot: searchSlotAR,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Right-to-left layout (Arabisch). Logo staat inline-end, menuknop inline-start. CSS logische eigenschappen spiegelen automatisch.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// SCROLL
+// =============================================================================
+
+export const ScrollAutoHide: Story = {
+  name: 'Scroll: auto-hide',
   args: {
     sticky: 'auto-hide',
   },
@@ -447,195 +792,23 @@ export const WithAutoHide: Story = {
   },
 };
 
-export const WithSearchOpen: Story = {
-  name: 'With search open',
+export const ScrollSticky: Story = {
+  name: 'Scroll: sticky',
   args: {
-    initialSearchOpen: true,
+    sticky: 'sticky',
   },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Het zoekpaneel is standaard open (`initialSearchOpen={true}`). Focus verplaatst automatisch naar het zoekveld.',
-      },
-    },
-  },
-};
-
-export const WithMenuOpen: Story = {
-  name: 'With menu open',
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Klik op de menuknop om de navigatielade te openen. De Drawer schuift in vanuit links.',
-      },
-    },
-  },
-};
-
-// =============================================================================
-// OVERZICHTSSTORIES
-// =============================================================================
-
-export const CompactLayout: Story = {
-  name: 'Compact layout',
-  args: {
-    layout: 'compact',
-  },
-  parameters: {
-    viewport: { defaultViewport: 'large' },
-    docs: {
-      description: {
-        story:
-          'Op viewports ≥ 64em toont de compact variant één enkele rij: logo (inline-start), primaire navigatie (optisch gecentreerd via CSS-grid `1fr auto 1fr`), en servicemenu + zoek-iconknop (inline-end). Gebruikt `primaryNavigationLarge` voor de compacte balk en `primaryNavigation` (verticaal) voor de Drawer op small viewport.',
-      },
-    },
-  },
-};
-
-// =============================================================================
-// INVERSE KLEURVARIANT
-// =============================================================================
-
-export const InverseColorScheme: Story = {
-  name: 'Inverse color scheme',
-  args: {
-    colorScheme: 'inverse',
-  },
-  parameters: {
-    viewport: { defaultViewport: 'large' },
-    docs: {
-      description: {
-        story:
-          'De inverse kleurvariant (`colorScheme="inverse"`) gebruikt `accent-1-inverse` achtergronden op de navbar en het zoekpaneel voor prominente branding. Het masthead blijft neutraal. Het logo past zijn kleuren automatisch aan via CSS context overrides.',
-      },
-    },
-  },
-};
-
-export const InverseCompactLayout: Story = {
-  name: 'Inverse compact layout',
-  args: {
-    layout: 'compact',
-    colorScheme: 'inverse',
-  },
-  parameters: {
-    viewport: { defaultViewport: 'large' },
-    docs: {
-      description: {
-        story:
-          'Combinatie van `layout="compact"` en `colorScheme="inverse"`: de compacte balk (logo, primaire navigatie, servicemenu) heeft een `accent-1-inverse` achtergrond. Het zoekpaneel gebruikt `accent-1-inverse.bg-document` voor visuele scheiding.',
-      },
-    },
-  },
-};
-
-// =============================================================================
-// RTL
-// =============================================================================
-
-export const RTL: Story = {
-  name: 'RTL',
-  decorators: [rtlDecorator],
-  args: {
-    logoSlot: logoSlotAR,
-    primaryNavigation: primaryNavigationAR,
-    primaryNavigationLarge: primaryNavigationLargeAR,
-    secondaryNavigation: secondaryNavigationAR,
-    secondaryNavigationLarge: secondaryNavigationLargeAR,
-    searchSlot: searchSlotAR,
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Right-to-left layout (Arabisch) op small viewport. Logo staat inline-end, menuknop inline-start. CSS logische eigenschappen spiegelen automatisch.',
-      },
-    },
-  },
-};
-
-export const RTLLargeViewport: Story = {
-  name: 'RTL large viewport',
-  decorators: [rtlDecorator],
-  args: {
-    logoSlot: logoSlotAR,
-    primaryNavigation: primaryNavigationAR,
-    primaryNavigationLarge: primaryNavigationLargeAR,
-    secondaryNavigation: secondaryNavigationAR,
-    secondaryNavigationLarge: secondaryNavigationLargeAR,
-    searchSlot: searchSlotAR,
-  },
-  parameters: {
-    viewport: { defaultViewport: 'large' },
-    docs: {
-      description: {
-        story:
-          'RTL op large viewport — masthead (logo rechts, servicemenu links) en navbar gespiegeld.',
-      },
-    },
-  },
-};
-
-export const RTLCompact: Story = {
-  name: 'RTL compact layout',
-  decorators: [rtlDecorator],
-  args: {
-    layout: 'compact',
-    logoSlot: logoSlotAR,
-    primaryNavigation: primaryNavigationAR,
-    primaryNavigationLarge: primaryNavigationLargeAR,
-    secondaryNavigation: secondaryNavigationAR,
-    secondaryNavigationLarge: secondaryNavigationLargeAR,
-  },
-  parameters: {
-    viewport: { defaultViewport: 'large' },
-    docs: {
-      description: {
-        story:
-          'RTL compact layout — logo inline-end, primaire navigatie gecentreerd, servicemenu + zoekknop inline-start.',
-      },
-    },
-  },
-};
-
-export const LargeViewport: Story = {
-  name: 'Large viewport',
-  parameters: {
-    viewport: { defaultViewport: 'large' },
-    docs: {
-      description: {
-        story:
-          'Op viewports ≥ 64em toont de header twee horizontale banden: een Masthead (neutrale achtergrond) met logo, servicemenu en inline zoekveld, en een Navigatiebalk (accent-1 achtergrond) met de primaire navigatie. De mobile layout is verborgen via `display: none`.',
-      },
-    },
-  },
-};
-
-export const AllStates: Story = {
-  name: 'All states',
-  render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-      <div>
-        <p
-          style={{
-            marginBottom: '0.5rem',
-            fontWeight: 'bold',
-            fontSize: '0.875rem',
-          }}
-        >
-          Default (zoekpaneel gesloten)
-        </p>
-        <PageHeader
-          logoSlot={logoSlot}
-          primaryNavigation={<PrimaryNavigation />}
-          primaryNavigationLarge={primaryNavigationLarge}
-          secondaryNavigation={secondaryNavigation}
-          secondaryNavigationLarge={secondaryNavigationLarge}
-          searchSlot={searchSlot}
-        />
-      </div>
-    </div>
+  render: (args) => (
+    <>
+      <PageHeader {...args} />
+      <PageContent />
+    </>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'De header blijft bovenaan de viewport vastgeplakt bij het scrollen. `position: sticky; inset-block-start: 0`.',
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary

- **PageHeader uitgebreid** met `menuButtonBadge` en `menuButtonBadgeLabel` props voor een DotBadge bij de Menu-knop op small viewport, inclusief screenreader-tekst
- **Stories herschikt** in drie semantische groepen via naamgeving: Compact, Default en Scroll — overbodige stories verwijderd
- **Vier nieuwe stories:** Default/Compact Logged In (gebruikersmenu via Popover) en Default/Compact New message (DotBadge + NumberBadge)
- **DotBadge-positionering gecorrigeerd:** `position: relative` toegevoegd aan `.dsn-button` en `.dsn-link`; op `.dsn-menu-button__button` verplaatst van de label-span naar de button zelf
- **DotBadge WithLink story** verwijderd
- **PageHeader Docs** React code in CodeTabs handmatig opgemaakt

## Test plan

- [ ] Storybook: Default: New message — DotBadge rechtsboven chevron-down bij "J. van Drouwen" op large viewport
- [ ] Storybook: Default: New message — DotBadge rechtsboven Menu-knop op small viewport
- [ ] Storybook: Popover openen via "J. van Drouwen" — NumberBadge "2" zichtbaar bij Berichten
- [ ] Storybook: Compact: New message — zelfde checks voor compact layout
- [ ] Storybook: DotBadge With Button — positionering ongewijzigd correct
- [ ] Storybook: PageHeader Docs — React code leesbaar opgemaakt
- [ ] Alle 1329 tests groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)