### PR TITLE
docs: vervang tabel-placeholders na em dash verwijdering

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,23 +166,23 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 
 | Component     | HTML/CSS | React | Web Component |
 | ------------- | -------- | ----- | ------------- |
-| **Body**      | Yes      | Yes   | :             |
-| **Container** | Yes      | Yes   | :             |
-| **Grid**      | Yes      | Yes   | :             |
-| **GridItem**  | Yes      | Yes   | :             |
-| **Stack**     | Yes      | Yes   | :             |
+| **Body**      | Yes      | Yes   | No            |
+| **Container** | Yes      | Yes   | No            |
+| **Grid**      | Yes      | Yes   | No            |
+| **GridItem**  | Yes      | Yes   | No            |
+| **Stack**     | Yes      | Yes   | No            |
 
 **Content Components (10)**
 
 | Component         | HTML/CSS | React | Web Component |
 | ----------------- | -------- | ----- | ------------- |
 | **Button**        | Yes      | Yes   | Yes           |
-| **ButtonLink**    | Yes      | Yes   | :             |
+| **ButtonLink**    | Yes      | Yes   | No            |
 | **Heading**       | Yes      | Yes   | Yes           |
 | **Icon**          | Yes      | Yes   | Yes           |
-| **Image**         | Yes      | Yes   | :             |
+| **Image**         | Yes      | Yes   | No            |
 | **Link**          | Yes      | Yes   | Yes           |
-| **LinkButton**    | Yes      | Yes   | :             |
+| **LinkButton**    | Yes      | Yes   | No            |
 | **OrderedList**   | Yes      | Yes   | Yes           |
 | **Paragraph**     | Yes      | Yes   | Yes           |
 | **UnorderedList** | Yes      | Yes   | Yes           |
@@ -191,62 +191,62 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 
 | Component       | HTML/CSS | React | Web Component |
 | --------------- | -------- | ----- | ------------- |
-| **Alert**       | Yes      | Yes   | :             |
-| **Backdrop**    | Yes      | Yes   | :             |
-| **Card**        | Yes      | Yes   | :             |
-| **Details**     | Yes      | Yes   | :             |
-| **DotBadge**    | Yes      | Yes   | :             |
-| **Note**        | Yes      | Yes   | :             |
-| **NumberBadge** | Yes      | Yes   | :             |
-| **Popover**     | Yes      | Yes   | :             |
-| **StatusBadge** | Yes      | Yes   | :             |
-| **Table**       | Yes      | Yes   | :             |
+| **Alert**       | Yes      | Yes   | No            |
+| **Backdrop**    | Yes      | Yes   | No            |
+| **Card**        | Yes      | Yes   | No            |
+| **Details**     | Yes      | Yes   | No            |
+| **DotBadge**    | Yes      | Yes   | No            |
+| **Note**        | Yes      | Yes   | No            |
+| **NumberBadge** | Yes      | Yes   | No            |
+| **Popover**     | Yes      | Yes   | No            |
+| **StatusBadge** | Yes      | Yes   | No            |
+| **Table**       | Yes      | Yes   | No            |
 
 **Navigation Components (5)**
 
 | Component                | HTML/CSS | React | Web Component |
 | ------------------------ | -------- | ----- | ------------- |
-| **BreadcrumbNavigation** | Yes      | Yes   | :             |
-| **Menu**                 | Yes      | Yes   | :             |
-| **MenuButton**           | Yes      | Yes   | :             |
-| **MenuLink**             | Yes      | Yes   | :             |
-| **PageHeader**           | Yes      | Yes   | :             |
+| **BreadcrumbNavigation** | Yes      | Yes   | No            |
+| **Menu**                 | Yes      | Yes   | No            |
+| **MenuButton**           | Yes      | Yes   | No            |
+| **MenuLink**             | Yes      | Yes   | No            |
+| **PageHeader**           | Yes      | Yes   | No            |
 
 **Accessibility Components (1)**
 
 | Component    | HTML/CSS | React | Web Component |
 | ------------ | -------- | ----- | ------------- |
-| **SkipLink** | Yes      | Yes   | :             |
+| **SkipLink** | Yes      | Yes   | No            |
 
 **Form Components (25)**
 
 | Component                 | HTML/CSS | React | Web Component |
 | ------------------------- | -------- | ----- | ------------- |
-| **Checkbox**              | Yes      | Yes   | :             |
-| **CheckboxGroup**         | Yes      | Yes   | :             |
-| **CheckboxOption**        | Yes      | Yes   | :             |
-| **DateInput**             | Yes      | Yes   | :             |
-| **DateInputGroup**        | Yes      | Yes   | :             |
-| **EmailInput**            | Yes      | Yes   | :             |
-| **FormField**             | Yes      | Yes   | :             |
-| **FormFieldDescription**  | Yes      | Yes   | :             |
-| **FormFieldErrorMessage** | Yes      | Yes   | :             |
-| **FormFieldLabel**        | Yes      | Yes   | :             |
-| **FormFieldLegend**       | Yes      | Yes   | :             |
-| **FormFieldset**          | Yes      | Yes   | :             |
-| **FormFieldStatus**       | Yes      | Yes   | :             |
-| **NumberInput**           | Yes      | Yes   | :             |
-| **OptionLabel**           | Yes      | Yes   | :             |
-| **PasswordInput**         | Yes      | Yes   | :             |
-| **Radio**                 | Yes      | Yes   | :             |
-| **RadioGroup**            | Yes      | Yes   | :             |
-| **RadioOption**           | Yes      | Yes   | :             |
-| **SearchInput**           | Yes      | Yes   | :             |
-| **Select**                | Yes      | Yes   | :             |
-| **TelephoneInput**        | Yes      | Yes   | :             |
-| **TextArea**              | Yes      | Yes   | :             |
-| **TextInput**             | Yes      | Yes   | :             |
-| **TimeInput**             | Yes      | Yes   | :             |
+| **Checkbox**              | Yes      | Yes   | No            |
+| **CheckboxGroup**         | Yes      | Yes   | No            |
+| **CheckboxOption**        | Yes      | Yes   | No            |
+| **DateInput**             | Yes      | Yes   | No            |
+| **DateInputGroup**        | Yes      | Yes   | No            |
+| **EmailInput**            | Yes      | Yes   | No            |
+| **FormField**             | Yes      | Yes   | No            |
+| **FormFieldDescription**  | Yes      | Yes   | No            |
+| **FormFieldErrorMessage** | Yes      | Yes   | No            |
+| **FormFieldLabel**        | Yes      | Yes   | No            |
+| **FormFieldLegend**       | Yes      | Yes   | No            |
+| **FormFieldset**          | Yes      | Yes   | No            |
+| **FormFieldStatus**       | Yes      | Yes   | No            |
+| **NumberInput**           | Yes      | Yes   | No            |
+| **OptionLabel**           | Yes      | Yes   | No            |
+| **PasswordInput**         | Yes      | Yes   | No            |
+| **Radio**                 | Yes      | Yes   | No            |
+| **RadioGroup**            | Yes      | Yes   | No            |
+| **RadioOption**           | Yes      | Yes   | No            |
+| **SearchInput**           | Yes      | Yes   | No            |
+| **Select**                | Yes      | Yes   | No            |
+| **TelephoneInput**        | Yes      | Yes   | No            |
+| **TextArea**              | Yes      | Yes   | No            |
+| **TextInput**             | Yes      | Yes   | No            |
+| **TimeInput**             | Yes      | Yes   | No            |
 
 See the [Documentation](./docs/) for full component details and specifications.
 

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -794,7 +794,7 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 | Prop   | Type                        | Default | Beschrijving                                                     |
 | ------ | --------------------------- | ------- | ---------------------------------------------------------------- |
 | `blur` | `boolean`                   | `true`  | Schakelt blur-filter in/uit via `dsn-backdrop--no-blur` modifier |
-| `ref`  | `React.Ref<HTMLDivElement>` | :       | Doorgegeven via `React.forwardRef`                               |
+| `ref`  | `React.Ref<HTMLDivElement>` | -       | Doorgegeven via `React.forwardRef`                               |
 
 **Gebruik:**
 
@@ -943,8 +943,8 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 
 | Component     | Prop       | Type            | Default | Beschrijving                                                          |
 | ------------- | ---------- | --------------- | ------- | --------------------------------------------------------------------- |
-| `Card`        | `href`     | `string`        | :       | URL voor de stretched link; doorgegeven via context aan `CardHeading` |
-| `CardHeader`  | `children` | `ReactNode`     | :       | Afbeelding; zonder children → placeholder                             |
+| `Card`        | `href`     | `string`        | -       | URL voor de stretched link; doorgegeven via context aan `CardHeading` |
+| `CardHeader`  | `children` | `ReactNode`     | -       | Afbeelding; zonder children → placeholder                             |
 | `CardHeading` | `level`    | `2 \| 3 \| 4`   | `2`     | Semantisch heading-niveau                                             |
 | `CardGroup`   | `as`       | `'ul' \| 'div'` | `'ul'`  | Container-element; `ul` rendert `role="list"`                         |
 
@@ -1381,10 +1381,10 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 
 | Prop       | Type                           | Default | Beschrijving                                             |
 | ---------- | ------------------------------ | ------- | -------------------------------------------------------- |
-| `isOpen`   | `boolean`                      | :       | Bepaalt of het dialoogvenster getoond wordt              |
-| `onClose`  | `() => void`                   | :       | Callback bij sluiten (sluitknop, Escape, buiten klikken) |
-| `children` | `React.ReactNode`              | :       | Sub-componenten: Header, Body, Footer                    |
-| `ref`      | `React.Ref<HTMLDialogElement>` | :       | Doorgegeven via `React.forwardRef`                       |
+| `isOpen`   | `boolean`                      | -       | Bepaalt of het dialoogvenster getoond wordt              |
+| `onClose`  | `() => void`                   | -       | Callback bij sluiten (sluitknop, Escape, buiten klikken) |
+| `children` | `React.ReactNode`              | -       | Sub-componenten: Header, Body, Footer                    |
+| `ref`      | `React.Ref<HTMLDialogElement>` | -       | Doorgegeven via `React.forwardRef`                       |
 
 **HTML/CSS:**
 
@@ -1502,12 +1502,12 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 | Prop       | Type                           | Default   | Beschrijving                                       |
 | ---------- | ------------------------------ | --------- | -------------------------------------------------- |
-| `isOpen`   | `boolean`                      | :         | Bepaalt of het zijpaneel getoond wordt             |
-| `onClose`  | `() => void`                   | :         | Callback bij sluiten (sluitknop, Escape)           |
+| `isOpen`   | `boolean`                      | -         | Bepaalt of het zijpaneel getoond wordt             |
+| `onClose`  | `() => void`                   | -         | Callback bij sluiten (sluitknop, Escape)           |
 | `modal`    | `boolean`                      | `true`    | Modal (focus-trap, backdrop) of niet-modaal        |
 | `side`     | `'right' \| 'left'`            | `'right'` | Zijde van het scherm waaraan het paneel verschijnt |
-| `children` | `React.ReactNode`              | :         | Sub-componenten: Header, Body, Footer              |
-| `ref`      | `React.Ref<HTMLDialogElement>` | :         | Doorgegeven via `React.forwardRef`                 |
+| `children` | `React.ReactNode`              | -         | Sub-componenten: Header, Body, Footer              |
+| `ref`      | `React.Ref<HTMLDialogElement>` | -         | Doorgegeven via `React.forwardRef`                 |
 
 **HTML/CSS:**
 
@@ -1631,12 +1631,12 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 | Prop         | Type                                    | Default    | Beschrijving                                                          |
 | ------------ | --------------------------------------- | ---------- | --------------------------------------------------------------------- |
-| `isOpen`     | `boolean`                               | :          | Bepaalt of de popover getoond wordt                                   |
-| `onClose`    | `() => void`                            | :          | Callback bij sluiten (Escape, klik buiten, sluitknop in header)       |
-| `triggerRef` | `React.RefObject<HTMLElement>`          | :          | Referentie naar het triggerelement voor positionering + focus-herstel |
+| `isOpen`     | `boolean`                               | -          | Bepaalt of de popover getoond wordt                                   |
+| `onClose`    | `() => void`                            | -          | Callback bij sluiten (Escape, klik buiten, sluitknop in header)       |
+| `triggerRef` | `React.RefObject<HTMLElement>`          | -          | Referentie naar het triggerelement voor positionering + focus-herstel |
 | `placement`  | `'top' \| 'bottom' \| 'start' \| 'end'` | `'bottom'` | Gewenste plaatsing relatief aan het triggerelement                    |
-| `label`      | `string`                                | :          | `aria-label` voor popovers zonder `PopoverHeading`                    |
-| `children`   | `React.ReactNode`                       | :          | Sub-componenten: `PopoverHeader`, `PopoverBody`, `PopoverFooter`      |
+| `label`      | `string`                                | -          | `aria-label` voor popovers zonder `PopoverHeading`                    |
+| `children`   | `React.ReactNode`                       | -          | Sub-componenten: `PopoverHeader`, `PopoverBody`, `PopoverFooter`      |
 
 **HTML/CSS:**
 

--- a/docs/05-storybook-configuration.md
+++ b/docs/05-storybook-configuration.md
@@ -409,7 +409,7 @@ const meta: Meta<typeof Button> = {
 
 | Prop            | Type          | Default  | Description                         |
 | --------------- | ------------- | -------- | ----------------------------------- |
-| `tokens`        | `Token[]`     | :        | Array of `{ name, cssVar, value? }` |
+| `tokens`        | `Token[]`     | -        | Array of `{ name, cssVar, value? }` |
 | `previewType`   | `PreviewType` | `'none'` | Visual preview type                 |
 | `showLiveValue` | `boolean`     | `true`   | Show computed CSS value             |
 


### PR DESCRIPTION
## Summary

- Implementatietabellen (`HTML/CSS | React | Web Component`): `:` → `No`
- Prop-tabellen (kolom `Default`): `:` → `-`

Na het verwijderen van em dashes in f5cec94 werden tabel-placeholders vervangen door `:`, wat verwarrend leest in markdown-tabellen. Dit lost dat op met semantisch correcte waarden.

## Bestanden

- `README.md` — 49 plaatsen in Web Component-kolom
- `docs/03-components.md` — Default-kolom prop-tabellen
- `docs/05-storybook-configuration.md` — Default-kolom prop-tabel

## Test plan

- [ ] Bekijk de tabellen in GitHub markdown preview — `No` en `-` renderen correct
- [ ] Geen functionele wijzigingen

🤖 Generated with [Claude Code](https://claude.com/claude-code)