### PR TITLE
feat(PageBody): Storybook documentatie

### DIFF
--- a/packages/storybook/src/PageBody.docs.md
+++ b/packages/storybook/src/PageBody.docs.md
@@ -1,0 +1,76 @@
+# PageBody
+
+Structurele inhoudcontainer die de ruimte tussen `PageHeader` en `PageFooter` opvult.
+
+## Doel
+
+`PageBody` is het flex-item met `flex: 1` binnen `PageLayout`. Het zorgt ervoor dat de footer altijd onderaan de viewport staat, ongeacht de hoeveelheid inhoud. In de eenvoudigste template bevat `PageBody` alleen een `<main>`. In complexere templates kan het ook breadcrumbs, een zijnavigatie of andere structurele elementen bevatten die geen onderdeel zijn van `<main>` zelf.
+
+`PageBody` is een transparante structuurlaag zonder eigen visuele stijl.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Je de ruimte tussen `PageHeader` en `PageFooter` wilt opvullen zodat de footer altijd onderaan staat.
+- Je structurele elementen zoals `<main>`, breadcrumbs of een side navigation wilt groeperen.
+- Je een layoutpunt nodig hebt voor complexere paginastructuren.
+
+## Don't use when
+
+- Je `PageBody` buiten een `PageLayout` plaatst: gebruik dan `Stack`, `Grid` of `Container`.
+- Je alleen een kaart of sectie wilt opmaken: gebruik dan `Stack` of `Grid`.
+
+## Best practices
+
+### `<main>` en skip-link
+
+De `<main>` met `id="main-content"` is een verantwoordelijkheid van de **template**, niet van `PageBody` zelf. Plaatst `<main id="main-content" tabIndex={-1}>` als directe child zodat de skip-link ernaar kan springen. Het `tabIndex={-1}` is nodig zodat programmatische focus werkt ook al is `<main>` niet natively focusbaar.
+
+```html
+<div class="dsn-page-body">
+  <main id="main-content" tabindex="-1">
+    <!-- pagina-inhoud -->
+  </main>
+</div>
+```
+
+```tsx
+<PageBody>
+  <main id="main-content" tabIndex={-1}>
+    <Container>...</Container>
+  </main>
+</PageBody>
+```
+
+### Toekomstige uitbreiding: side navigation
+
+`dsn-page-body__content` (nog niet geïmplementeerd) biedt straks een inner wrapper voor side nav + main naast elkaar:
+
+```html
+<div class="dsn-page-body">
+  <nav class="dsn-breadcrumbs" aria-label="Kruimelpad">...</nav>
+  <div class="dsn-page-body__content">
+    <nav class="dsn-side-nav" aria-label="Sectienavigatie">...</nav>
+    <main id="main-content" tabindex="-1">...</main>
+  </div>
+</div>
+```
+
+## Design tokens
+
+`PageBody` heeft geen component-specifieke tokens. `flex: 1` is een layout-constante.
+
+| Keuze     | Reden                                                                                                                           |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `flex: 1` | Shorthand voor `flex-grow: 1; flex-shrink: 1; flex-basis: 0%`. Vult alle beschikbare ruimte op zonder vaste hoogte op te geven. |
+
+## Accessibility
+
+### Transparante structuurlaag
+
+`PageBody` heeft geen `role`, `aria-label` of andere ARIA-attributen. Screenreaders navigeren via de children: de `<main>` is het relevante landmark.
+
+### Skip-link bestemming
+
+De skip-link wijst altijd naar de `<main id="main-content">` binnen `PageBody`, niet naar `PageBody` zelf. Zorg dat de `<main>` het `id` heeft en niet de `PageBody`-wrapper.

--- a/packages/storybook/src/PageBody.docs.mdx
+++ b/packages/storybook/src/PageBody.docs.mdx
@@ -1,0 +1,32 @@
+import { Meta, Story, Markdown } from '@storybook/blocks';
+import * as PageBodyStories from './PageBody.stories';
+import docs from './PageBody.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={PageBodyStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={PageBodyStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={PageBodyStories.Default}
+  react={`<PageBody>
+  <main id="main-content" tabIndex={-1}>
+    <Container>...</Container>
+  </main>
+</PageBody>`}
+  html={`<div class="dsn-page-body">
+  <main id="main-content" tabindex="-1">
+    <!-- pagina-inhoud -->
+  </main>
+</div>`}
+/>
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/PageBody.stories.tsx
+++ b/packages/storybook/src/PageBody.stories.tsx
@@ -1,0 +1,272 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Button,
+  Logo,
+  Menu,
+  MenuLink,
+  PageBody,
+  PageFooter,
+  PageHeader,
+  PageLayout,
+  Link,
+  Paragraph,
+  SearchInput,
+  SkipLink,
+  UnorderedList,
+} from '@dsn/components-react';
+
+// =============================================================================
+// GEDEELDE CONTENT (identiek aan PageLayout/PageHeader/PageFooter stories)
+// =============================================================================
+
+const logoSlot = (
+  <a href="/">
+    <Logo aria-hidden={true} />
+    <span className="dsn-visually-hidden">
+      Starter Kit — terug naar homepage
+    </span>
+  </a>
+);
+
+function PrimaryNavigation() {
+  const [exp1b, setExp1b] = React.useState(false);
+  const [exp2b, setExp2b] = React.useState(false);
+  const [exp3b, setExp3b] = React.useState(false);
+
+  return (
+    <Menu orientation="vertical">
+      <MenuLink href="/level-1a" level={1} current>
+        Level 1a
+      </MenuLink>
+      <MenuLink
+        href="/level-1b"
+        level={1}
+        subItems
+        expanded={exp1b}
+        onExpandToggle={() => setExp1b((v) => !v)}
+      >
+        Level 1b
+      </MenuLink>
+      {exp1b && (
+        <>
+          <MenuLink href="/level-2a" level={2}>
+            Level 2a
+          </MenuLink>
+          <MenuLink
+            href="/level-2b"
+            level={2}
+            subItems
+            expanded={exp2b}
+            onExpandToggle={() => setExp2b((v) => !v)}
+          >
+            Level 2b
+          </MenuLink>
+          {exp2b && (
+            <>
+              <MenuLink href="/level-3a" level={3}>
+                Level 3a
+              </MenuLink>
+              <MenuLink
+                href="/level-3b"
+                level={3}
+                subItems
+                expanded={exp3b}
+                onExpandToggle={() => setExp3b((v) => !v)}
+              >
+                Level 3b
+              </MenuLink>
+              {exp3b && (
+                <>
+                  <MenuLink href="/level-4a" level={4}>
+                    Level 4a
+                  </MenuLink>
+                  <MenuLink href="/level-4b" level={4}>
+                    Level 4b
+                  </MenuLink>
+                </>
+              )}
+              <MenuLink href="/level-3c" level={3}>
+                Level 3c
+              </MenuLink>
+              <MenuLink href="/level-3d" level={3}>
+                Level 3d
+              </MenuLink>
+            </>
+          )}
+          <MenuLink href="/level-2c" level={2}>
+            Level 2c
+          </MenuLink>
+          <MenuLink href="/level-2d" level={2}>
+            Level 2d
+          </MenuLink>
+        </>
+      )}
+      <MenuLink href="/level-1c" level={1}>
+        Level 1c
+      </MenuLink>
+      <MenuLink href="/level-1d" level={1}>
+        Level 1d
+      </MenuLink>
+    </Menu>
+  );
+}
+
+const primaryNavigationLarge = (
+  <Menu orientation="horizontal">
+    <MenuLink href="/level-1a" level={1} current>
+      Level 1a
+    </MenuLink>
+    <MenuLink href="/level-1b" level={1}>
+      Level 1b
+    </MenuLink>
+    <MenuLink href="/level-1c" level={1}>
+      Level 1c
+    </MenuLink>
+    <MenuLink href="/level-1d" level={1}>
+      Level 1d
+    </MenuLink>
+  </Menu>
+);
+
+const secondaryNavigation = (
+  <Menu orientation="vertical">
+    <MenuLink href="/english" level={1}>
+      English
+    </MenuLink>
+    <MenuLink href="/mijn-omgeving" level={1}>
+      Mijn omgeving
+    </MenuLink>
+  </Menu>
+);
+
+const secondaryNavigationLarge = (
+  <Menu orientation="horizontal">
+    <MenuLink href="/english" level={1}>
+      English
+    </MenuLink>
+    <MenuLink href="/mijn-omgeving" level={1}>
+      Mijn omgeving
+    </MenuLink>
+  </Menu>
+);
+
+const searchSlot = (
+  <>
+    <SearchInput placeholder="Zoeken…" aria-label="Zoekopdracht" />
+    <Button variant="strong">Zoeken</Button>
+  </>
+);
+
+const footerSlot1 = (
+  <a href="/">
+    <Logo aria-hidden={true} />
+    <span className="dsn-visually-hidden">
+      Starter Kit — terug naar homepage
+    </span>
+  </a>
+);
+
+const footerSlot2 = (
+  <Paragraph>
+    Dit is een voorbeeldorganisatie. <Link href="/about">Meer informatie</Link>.
+  </Paragraph>
+);
+
+const footerSlot3 = (
+  <UnorderedList>
+    <li>
+      <Link href="/nieuws">Nieuws</Link>
+    </li>
+    <li>
+      <Link href="/over-ons">Over ons</Link>
+    </li>
+    <li>
+      <Link href="/werken-bij">Werken bij</Link>
+    </li>
+    <li>
+      <Link href="/klachten">Klachten</Link>
+    </li>
+  </UnorderedList>
+);
+
+const footerSlot4 = (
+  <UnorderedList>
+    <li>
+      <Link href="/privacy">Privacyverklaring</Link>
+    </li>
+    <li>
+      <Link href="/accessibility">Toegankelijkheid</Link>
+    </li>
+    <li>
+      <Link href="/cookies">Cookies</Link>
+    </li>
+    <li>
+      <Link href="/contact">Contact</Link>
+    </li>
+  </UnorderedList>
+);
+
+// =============================================================================
+// META
+// =============================================================================
+
+const meta: Meta<typeof PageBody> = {
+  title: 'Components/PageBody',
+  component: PageBody,
+  parameters: {
+    layout: 'fullscreen',
+    dsn: {
+      htmlTemplate: () => `<div class="dsn-page-body">
+  <main id="main-content" tabindex="-1">
+    <!-- pagina-inhoud -->
+  </main>
+</div>`,
+    },
+  },
+  argTypes: {
+    className: { control: false },
+    children: { control: false },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PageBody>;
+
+// =============================================================================
+// STORIES
+// =============================================================================
+
+export const Default: Story = {
+  name: 'Default',
+  render: () => (
+    <>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation />}
+          primaryNavigationLarge={primaryNavigationLarge}
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={{ padding: '2rem' }}>
+            <p>
+              Paginainhoud staat hier. De footer staat altijd onderaan de
+              viewport.
+            </p>
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </>
+  ),
+};


### PR DESCRIPTION
Sluit #164.

## Summary

Voegt de drie Storybook-bestanden toe voor `PageBody`, dat al geïmplementeerd was als onderdeel van #163/#166:

- `PageBody.stories.tsx`: Default story in een volledige `PageLayout` context (identieke header/footer content als de PageLayout, PageHeader en PageFooter stories)
- `PageBody.docs.mdx`: Docs-pagina met CodeTabs (React + HTML)
- `PageBody.docs.md`: Documentatie over doel, use when/don't use when, best practices (`<main>` verantwoordelijkheid van template, toekomstige side-nav uitbreiding), design tokens en accessibility

## Test plan

- [x] 1354 tests groen (`pnpm test`)
- [x] TypeScript schoon (`pnpm --filter storybook exec tsc --noEmit`)
- [x] Lint schoon (`pnpm lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)