### PR TITLE
fix(Templates): verwijder inline padding-inline van main

### DIFF
--- a/packages/storybook/src/templates/BasePage.stories.tsx
+++ b/packages/storybook/src/templates/BasePage.stories.tsx
@@ -210,12 +210,10 @@ const footerSlot4 = (
 );
 
 // Padding op <main>: 64px boven/onder (--dsn-space-block-6xl),
-// 16px links/rechts (--dsn-space-inline-xl).
 // Template-specifiek: bewust niet via Container of een herbruikbare klasse —
 // andere templates kiezen zelf hun eigen spacing.
 const mainStyle: React.CSSProperties = {
   paddingBlock: 'var(--dsn-space-block-6xl)',
-  paddingInline: 'var(--dsn-space-inline-xl)',
 };
 
 // =============================================================================

--- a/packages/storybook/src/templates/GridPage.stories.tsx
+++ b/packages/storybook/src/templates/GridPage.stories.tsx
@@ -168,7 +168,6 @@ const footerSlot4 = (
 
 const mainStyle: React.CSSProperties = {
   paddingBlock: 'var(--dsn-space-block-6xl)',
-  paddingInline: 'var(--dsn-space-inline-xl)',
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Verwijdert de inline `paddingInline`-stijl van het `<main>`-element in `BasePage` en `GridPage`

## Test plan

- [ ] Controleer visueel in Storybook dat de templates correct renderen

🤖 Generated with [Claude Code](https://claude.com/claude-code)