### PR TITLE
feat(PageHeader/PageFooter/PageBody): apply max-inline-size to inner containers

### DIFF
--- a/packages/components-html/src/page-body/page-body.css
+++ b/packages/components-html/src/page-body/page-body.css
@@ -27,4 +27,6 @@
 
 .dsn-page-body__inner {
   padding-inline: var(--dsn-page-body-padding-inline);
+  max-inline-size: var(--dsn-page-max-inline-size);
+  margin-inline: auto;
 }

--- a/packages/components-html/src/page-footer/page-footer.css
+++ b/packages/components-html/src/page-footer/page-footer.css
@@ -38,6 +38,8 @@
 .dsn-page-footer__inner {
   padding-block: var(--dsn-page-footer-padding-block);
   padding-inline: var(--dsn-page-footer-padding-inline);
+  max-inline-size: var(--dsn-page-max-inline-size);
+  margin-inline: auto;
 }
 
 /* =============================================================================

--- a/packages/components-html/src/page-header/page-header.css
+++ b/packages/components-html/src/page-header/page-header.css
@@ -85,13 +85,15 @@
 .dsn-page-header__masthead {
   background-color: var(--dsn-page-header-masthead-background-color);
   padding-block: var(--dsn-page-header-masthead-padding-block);
-  padding-inline: var(--dsn-page-header-masthead-padding-inline);
 }
 
 .dsn-page-header__masthead-inner {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding-inline: var(--dsn-page-header-masthead-padding-inline);
+  max-inline-size: var(--dsn-page-max-inline-size);
+  margin-inline: auto;
 }
 
 /* =============================================================================
@@ -133,13 +135,18 @@
    logo (inline-start) en servicemenu + zoekknop (inline-end).
    ============================================================================= */
 
+.dsn-page-header__compact-layout {
+  background-color: var(--dsn-page-header-compact-background-color);
+}
+
 .dsn-page-header__compact-inner {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  background-color: var(--dsn-page-header-compact-background-color);
   padding-block: var(--dsn-page-header-compact-padding-block);
   padding-inline: var(--dsn-page-header-compact-padding-inline);
+  max-inline-size: var(--dsn-page-max-inline-size);
+  margin-inline: auto;
 }
 
 /* Logo in compact context links uitlijnen — niet centreren zoals in de mobile bar.
@@ -168,13 +175,18 @@
 
 .dsn-page-header__navbar {
   background-color: var(--dsn-page-header-navbar-background-color);
-  padding-inline: var(--dsn-page-header-navbar-padding-inline);
 
   /* MenuLink-items in de navbar krijgen een grotere min-block-size en ruimere
      padding-inline. Door de tokens te overschrijven op de container werkt de
      calc()-compensatie voor de current-indicator automatisch mee. */
   --dsn-menu-item-min-block-size: 4rem;
   --dsn-menu-item-padding-inline: var(--dsn-space-inline-xl);
+}
+
+.dsn-page-header__navbar-inner {
+  padding-inline: var(--dsn-page-header-navbar-padding-inline);
+  max-inline-size: var(--dsn-page-max-inline-size);
+  margin-inline: auto;
 }
 
 /* =============================================================================
@@ -226,6 +238,8 @@
   align-items: center;
   padding-block: var(--dsn-page-header-padding-block);
   padding-inline: var(--dsn-page-header-padding-inline);
+  max-inline-size: var(--dsn-page-max-inline-size);
+  margin-inline: auto;
 }
 
 /* =============================================================================
@@ -281,13 +295,15 @@
 .dsn-page-header__search-panel {
   background-color: var(--dsn-page-header-search-panel-background-color);
   padding-block: var(--dsn-page-header-search-panel-padding-block);
-  padding-inline: var(--dsn-page-header-search-panel-padding-inline);
 }
 
 .dsn-page-header__search-inner {
   display: flex;
   gap: var(--dsn-space-inline-md);
   align-items: flex-start;
+  padding-inline: var(--dsn-page-header-search-panel-padding-inline);
+  max-inline-size: var(--dsn-page-max-inline-size);
+  margin-inline: auto;
 }
 
 /* SearchInput wrapper vult beschikbare ruimte volledig — overschrijft de standaard

--- a/packages/storybook/src/templates/BasePage.stories.tsx
+++ b/packages/storybook/src/templates/BasePage.stories.tsx
@@ -332,9 +332,14 @@ export const FullWidth: Story = {
           <main id="main-content" tabIndex={-1} style={mainStyle}>
             <Heading level={1}>Paginatitel</Heading>
             <Paragraph>
-              Full-width variant: <code>--dsn-page-max-inline-size</code> is
-              ingesteld op <code>none</code> op de PageLayout. Header, body en
-              footer nemen de volledige viewport-breedte in.
+              Dit is de basisstructuur van een pagina in het design system. De
+              footer staat altijd onderaan de viewport, ongeacht de hoeveelheid
+              inhoud.
+            </Paragraph>
+            <Paragraph>
+              Voeg hier de paginaspecifieke inhoud toe:{' '}
+              <Link href="#">tekst</Link>, formulieren, tabellen of andere
+              componenten.
             </Paragraph>
           </main>
         </PageBody>

--- a/packages/storybook/src/templates/BasePage.stories.tsx
+++ b/packages/storybook/src/templates/BasePage.stories.tsx
@@ -311,3 +311,40 @@ export const Inverse: Story = {
     </Body>
   ),
 };
+
+export const FullWidth: Story = {
+  name: 'Base Page: Full Width',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout
+        style={{ '--dsn-page-max-inline-size': 'none' } as React.CSSProperties}
+      >
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation />}
+          primaryNavigationLarge={primaryNavigationLarge}
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainStyle}>
+            <Heading level={1}>Paginatitel</Heading>
+            <Paragraph>
+              Full-width variant: <code>--dsn-page-max-inline-size</code> is
+              ingesteld op <code>none</code> op de PageLayout. Header, body en
+              footer nemen de volledige viewport-breedte in.
+            </Paragraph>
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};

--- a/packages/storybook/src/templates/GridPage.stories.tsx
+++ b/packages/storybook/src/templates/GridPage.stories.tsx
@@ -260,3 +260,46 @@ export const Default: Story = {
     </Body>
   ),
 };
+
+export const FullWidth: Story = {
+  name: 'Grid Page: Full Width',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout
+        style={{ '--dsn-page-max-inline-size': 'none' } as React.CSSProperties}
+      >
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation />}
+          primaryNavigationLarge={primaryNavigationLarge}
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainStyle}>
+            <Stack space="2xl">
+              <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+                <GridItem colSpan={12}>
+                  <Container>
+                    <Paragraph>
+                      Full-width: inhoud strekt zich uit over de volledige
+                      viewport-breedte.
+                    </Paragraph>
+                  </Container>
+                </GridItem>
+              </Grid>
+            </Stack>
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};

--- a/packages/storybook/src/templates/GridPage.stories.tsx
+++ b/packages/storybook/src/templates/GridPage.stories.tsx
@@ -280,13 +280,44 @@ export const FullWidth: Story = {
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
             <Stack space="2xl">
+              {/* Rij 1: volle breedte */}
               <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
                 <GridItem colSpan={12}>
                   <Container>
-                    <Paragraph>
-                      Full-width: inhoud strekt zich uit over de volledige
-                      viewport-breedte.
-                    </Paragraph>
+                    <Paragraph>Rij 1 — volle breedte (12 kolommen)</Paragraph>
+                  </Container>
+                </GridItem>
+              </Grid>
+
+              {/* Rij 2: 2 kolommen vanaf md */}
+              <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+                <GridItem colSpan={12} colSpanMd={6}>
+                  <Container>
+                    <Paragraph>Rij 2 — kolom 1 van 2</Paragraph>
+                  </Container>
+                </GridItem>
+                <GridItem colSpan={12} colSpanMd={6}>
+                  <Container>
+                    <Paragraph>Rij 2 — kolom 2 van 2</Paragraph>
+                  </Container>
+                </GridItem>
+              </Grid>
+
+              {/* Rij 3: 3 kolommen vanaf md */}
+              <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+                <GridItem colSpan={12} colSpanMd={4}>
+                  <Container>
+                    <Paragraph>Rij 3 — kolom 1 van 3</Paragraph>
+                  </Container>
+                </GridItem>
+                <GridItem colSpan={12} colSpanMd={4}>
+                  <Container>
+                    <Paragraph>Rij 3 — kolom 2 van 3</Paragraph>
+                  </Container>
+                </GridItem>
+                <GridItem colSpan={12} colSpanMd={4}>
+                  <Container>
+                    <Paragraph>Rij 3 — kolom 3 van 3</Paragraph>
                   </Container>
                 </GridItem>
               </Grid>


### PR DESCRIPTION
## Summary

- Applies `var(--dsn-page-max-inline-size)` (75rem) to all `__inner` containers in PageBody, PageFooter, and PageHeader
- Backgrounds remain full-bleed; only content width is constrained
- PageHeader: moved `padding-inline` from outer elements (`__masthead`, `__navbar`, `__search-panel`, `__compact-inner`) to their respective inner containers so the background stays edge-to-edge
- Added `FullWidth` story variants to BasePage and GridPage templates demonstrating `--dsn-page-max-inline-size: none` override on PageLayout

## Test plan

- [x] `pnpm test` — 1355 tests, 68 suites, all green
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors
- [ ] Visual verification via Chromatic on CI

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)