### PR TITLE
fix(BreakoutSection): herstel uitslag-effect in stories

### DIFF
--- a/packages/storybook/src/BreakoutSection.stories.tsx
+++ b/packages/storybook/src/BreakoutSection.stories.tsx
@@ -30,20 +30,22 @@ const meta: Meta<typeof BreakoutSection> = {
 export default meta;
 type Story = StoryObj<typeof BreakoutSection>;
 
-// Wrapper die een beperkte paginabreedte simuleert zodat het uitslaan zichtbaar is
+// Wrapper die een beperkte paginabreedte simuleert zodat het uitslaan zichtbaar is.
+// De buitenste div is volle breedte met overflow-x: clip (zoals dsn-page-body).
+// De binnenste div is geconstrained (zoals dsn-page-body__inner).
 function ConstrainedPage({ children }: { children: React.ReactNode }) {
   return (
     <div
       style={{
-        maxInlineSize: '960px',
-        marginInline: 'auto',
         overflowX: 'clip',
-        paddingBlock: 'var(--dsn-space-block-4xl)',
       }}
     >
       <div
         style={{
+          maxInlineSize: '960px',
+          marginInline: 'auto',
           paddingInline: 'var(--dsn-space-inline-3xl)',
+          paddingBlock: 'var(--dsn-space-block-4xl)',
         }}
       >
         {children}


### PR DESCRIPTION
## Summary

- `ConstrainedPage` in de stories had `overflow-x: clip` op de geconstrained 960px-wrapper, waardoor de BreakoutSection werd geclipt op exact de containerbreedte — geen zichtbare uitslag
- Fix spiegelt de structuur van `PageBody`/`PageBody__inner`: buitenste div volle breedte met `overflow-x: clip`, binnenste div geconstrained met `max-inline-size`

## Test plan

- [ ] Controleer de Default story: BreakoutSection beslaat de volle canvasbreedte, omringende tekst is geconstrained
- [ ] Controleer de Without inner constraint story: zelfde uitslag-effect
- [ ] Vergelijk visueel met de template stories (BasePage: with BreakoutSection) — zelfde gedrag

🤖 Generated with [Claude Code](https://claude.com/claude-code)