### PR TITLE
feat(Templates): voeg HomePage template toe (#175)

### DIFF
--- a/packages/components-html/src/hero/hero.css
+++ b/packages/components-html/src/hero/hero.css
@@ -1,0 +1,204 @@
+/**
+ * Hero Component
+ * Prominente introductiesectie direct onder de PageHeader. Beslaat de volledige
+ * paginabreedte via het BreakoutSection-patroon (margin-inline: calc(50% - 50vw)).
+ *
+ * Vereiste: de parent heeft overflow-x: clip (dsn-page-body).
+ *
+ * Usage:
+ * <section class="dsn-hero" aria-labelledby="hero-heading">
+ *   <div class="dsn-hero__inner">
+ *     <div class="dsn-hero__content">
+ *       <!-- heading, paragraph, action group of searchbox -->
+ *     </div>
+ *   </div>
+ * </section>
+ *
+ * Searchbox (zoekfunctie als primaire actie):
+ * <div class="dsn-hero__searchbox">
+ *   <!-- SearchInput wrapper + submit button -->
+ * </div>
+ */
+
+/* =============================================================================
+   Base
+   ============================================================================= */
+
+.dsn-hero {
+  margin-inline: calc(50% - 50vw);
+  min-block-size: max(
+    var(--dsn-hero-min-block-size),
+    var(--dsn-hero-block-size)
+  );
+  background-color: var(--dsn-hero-background-color-default);
+  color: var(--dsn-hero-color-default);
+  display: flex;
+  flex-direction: column;
+}
+
+/* =============================================================================
+   Inner — centrerende wrapper (stemt af op dsn-page-body__inner)
+   ============================================================================= */
+
+.dsn-hero__inner {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  max-inline-size: var(--dsn-page-max-inline-size);
+  margin-inline: auto;
+  padding-inline: var(--dsn-hero-padding-inline);
+  padding-block: var(--dsn-hero-padding-block);
+  inline-size: 100%;
+}
+
+/* =============================================================================
+   Content — verticaal gecentreerde slot-container
+   ============================================================================= */
+
+.dsn-hero__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+/* =============================================================================
+   Searchbox — zoekveld + submit button naast elkaar
+   ============================================================================= */
+
+.dsn-hero__searchbox {
+  display: flex;
+  align-items: center;
+  gap: var(--dsn-space-inline-md);
+}
+
+/* SearchInput wrapper vult beschikbare ruimte; button behoudt zijn natuurlijke breedte */
+.dsn-hero__searchbox .dsn-search-input-wrapper {
+  flex: 1;
+  min-inline-size: 0;
+  max-inline-size: none;
+}
+
+.dsn-hero__searchbox .dsn-text-input {
+  max-inline-size: none;
+  inline-size: 100%;
+}
+
+/* =============================================================================
+   Modifier: --inverse
+   Achtergrond + tekst- en componentkleur-overrides via CSS custom properties.
+   Patroon identiek aan PageHeader en PageFooter --inverse.
+   ============================================================================= */
+
+.dsn-hero--inverse {
+  background-color: var(--dsn-hero-background-color-inverse);
+  color: var(--dsn-hero-color-inverse);
+
+  /* Tekst-componenten */
+  --dsn-heading-level-1-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-2-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-3-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-4-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-5-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-6-color: var(--dsn-hero-color-inverse);
+  --dsn-paragraph-color: var(--dsn-hero-color-inverse);
+
+  /* Strong button — action-1 kleurenschaal op inverse achtergrond */
+  --dsn-button-strong-background-color: var(--dsn-color-action-1-bg-default);
+  --dsn-button-strong-color: var(--dsn-color-action-1-color-default);
+  --dsn-button-strong-hover-background-color: var(
+    --dsn-color-action-1-bg-hover
+  );
+  --dsn-button-strong-hover-color: var(--dsn-color-action-1-color-hover);
+  --dsn-button-strong-active-background-color: var(
+    --dsn-color-action-1-bg-active
+  );
+  --dsn-button-strong-active-color: var(--dsn-color-action-1-color-active);
+
+  /* Subtle button — transparant met lichte tekst/rand op inverse achtergrond */
+  --dsn-button-subtle-color: var(--dsn-color-accent-1-inverse-color-default);
+  --dsn-button-subtle-hover-background-color: var(
+    --dsn-color-accent-1-inverse-bg-hover
+  );
+  --dsn-button-subtle-hover-color: var(
+    --dsn-color-accent-1-inverse-color-hover
+  );
+  --dsn-button-subtle-active-background-color: var(
+    --dsn-color-accent-1-inverse-bg-active
+  );
+  --dsn-button-subtle-active-color: var(
+    --dsn-color-accent-1-inverse-color-active
+  );
+}
+
+/* =============================================================================
+   Modifier: --image
+   ============================================================================= */
+
+.dsn-hero--image {
+  background-image: var(--dsn-hero-bg-image);
+  background-size: cover;
+  background-position: center;
+  color: var(--dsn-hero-color-inverse);
+
+  /* Tekst-componenten */
+  --dsn-heading-level-1-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-2-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-3-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-4-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-5-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-6-color: var(--dsn-hero-color-inverse);
+  --dsn-paragraph-color: var(--dsn-hero-color-inverse);
+
+  /* Buttons — zelfde als inverse */
+  --dsn-button-strong-background-color: var(--dsn-color-action-1-bg-default);
+  --dsn-button-strong-color: var(--dsn-color-action-1-color-default);
+  --dsn-button-strong-hover-background-color: var(
+    --dsn-color-action-1-bg-hover
+  );
+  --dsn-button-strong-hover-color: var(--dsn-color-action-1-color-hover);
+  --dsn-button-strong-active-background-color: var(
+    --dsn-color-action-1-bg-active
+  );
+  --dsn-button-strong-active-color: var(--dsn-color-action-1-color-active);
+  --dsn-button-subtle-color: var(--dsn-color-accent-1-inverse-color-default);
+  --dsn-button-subtle-hover-background-color: var(
+    --dsn-color-accent-1-inverse-bg-hover
+  );
+  --dsn-button-subtle-hover-color: var(
+    --dsn-color-accent-1-inverse-color-hover
+  );
+  --dsn-button-subtle-active-background-color: var(
+    --dsn-color-accent-1-inverse-bg-active
+  );
+  --dsn-button-subtle-active-color: var(
+    --dsn-color-accent-1-inverse-color-active
+  );
+}
+
+/* =============================================================================
+   Modifier: --image-blend (gecombineerd met --image)
+   ============================================================================= */
+
+.dsn-hero--image.dsn-hero--image-blend {
+  background-color: var(--dsn-hero-image-blend-color);
+  background-blend-mode: multiply;
+}
+
+/* =============================================================================
+   Modifier: --align-center
+   ============================================================================= */
+
+.dsn-hero--align-center .dsn-hero__content {
+  align-items: center;
+  text-align: center;
+}
+
+/* ActionGroup en searchbox centreren mee */
+.dsn-hero--align-center .dsn-action-group {
+  justify-content: center;
+}
+
+.dsn-hero--align-center .dsn-hero__searchbox {
+  justify-content: center;
+}

--- a/packages/components-react/src/Hero/Hero.css
+++ b/packages/components-react/src/Hero/Hero.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/hero/hero.css';

--- a/packages/components-react/src/Hero/Hero.test.tsx
+++ b/packages/components-react/src/Hero/Hero.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { createRef } from 'react';
+import { Hero } from './Hero';
+
+describe('Hero', () => {
+  it('renders a <section> element as root', () => {
+    const { container } = render(<Hero />);
+    expect(container.firstChild?.nodeName).toBe('SECTION');
+  });
+
+  it('always has dsn-hero class', () => {
+    const { container } = render(<Hero />);
+    expect(container.firstChild).toHaveClass('dsn-hero');
+  });
+
+  it('renders dsn-hero__inner and dsn-hero__content wrappers', () => {
+    const { container } = render(<Hero />);
+    expect(container.querySelector('.dsn-hero__inner')).toBeInTheDocument();
+    expect(container.querySelector('.dsn-hero__content')).toBeInTheDocument();
+  });
+
+  it('renders children inside dsn-hero__content', () => {
+    const { getByText } = render(<Hero>Welkom</Hero>);
+    expect(getByText('Welkom')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<Hero className="custom" />);
+    expect(container.firstChild).toHaveClass('dsn-hero');
+    expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('forwards ref to the section element', () => {
+    const ref = createRef<HTMLElement>();
+    const { container } = render(<Hero ref={ref} />);
+    expect(ref.current).toBe(container.firstChild);
+  });
+
+  it('passes additional HTML attributes', () => {
+    const { container } = render(
+      <Hero data-testid="hero" aria-labelledby="hero-heading" />
+    );
+    expect(container.firstChild).toHaveAttribute('data-testid', 'hero');
+    expect(container.firstChild).toHaveAttribute(
+      'aria-labelledby',
+      'hero-heading'
+    );
+  });
+
+  // Variant tests
+  it('has no variant modifier class by default', () => {
+    const { container } = render(<Hero />);
+    expect(container.firstChild).not.toHaveClass('dsn-hero--inverse');
+    expect(container.firstChild).not.toHaveClass('dsn-hero--image');
+    expect(container.firstChild).not.toHaveClass('dsn-hero--image-blend');
+  });
+
+  it('applies dsn-hero--inverse for variant="inverse"', () => {
+    const { container } = render(<Hero variant="inverse" />);
+    expect(container.firstChild).toHaveClass('dsn-hero--inverse');
+  });
+
+  it('applies dsn-hero--image for variant="image"', () => {
+    const { container } = render(<Hero variant="image" />);
+    expect(container.firstChild).toHaveClass('dsn-hero--image');
+    expect(container.firstChild).not.toHaveClass('dsn-hero--image-blend');
+  });
+
+  it('applies dsn-hero--image and dsn-hero--image-blend for variant="image-blend"', () => {
+    const { container } = render(<Hero variant="image-blend" />);
+    expect(container.firstChild).toHaveClass('dsn-hero--image');
+    expect(container.firstChild).toHaveClass('dsn-hero--image-blend');
+  });
+
+  it('sets --dsn-hero-bg-image inline style when backgroundImage is provided', () => {
+    const { container } = render(
+      <Hero variant="image" backgroundImage="https://example.com/photo.jpg" />
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.getPropertyValue('--dsn-hero-bg-image')).toBe(
+      "url('https://example.com/photo.jpg')"
+    );
+  });
+
+  it('does not set --dsn-hero-bg-image when backgroundImage is not provided', () => {
+    const { container } = render(<Hero />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.getPropertyValue('--dsn-hero-bg-image')).toBe('');
+  });
+
+  // Align tests
+  it('has no align modifier class by default', () => {
+    const { container } = render(<Hero />);
+    expect(container.firstChild).not.toHaveClass('dsn-hero--align-center');
+  });
+
+  it('applies dsn-hero--align-center for align="center"', () => {
+    const { container } = render(<Hero align="center" />);
+    expect(container.firstChild).toHaveClass('dsn-hero--align-center');
+  });
+
+  it('merges backgroundImage style with provided style prop', () => {
+    const { container } = render(
+      <Hero
+        variant="image"
+        backgroundImage="https://example.com/photo.jpg"
+        style={{ color: 'red' }}
+      />
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.getPropertyValue('--dsn-hero-bg-image')).toBe(
+      "url('https://example.com/photo.jpg')"
+    );
+    expect(el.style.color).toBe('red');
+  });
+});

--- a/packages/components-react/src/Hero/Hero.tsx
+++ b/packages/components-react/src/Hero/Hero.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import './Hero.css';
+
+export type HeroVariant = 'default' | 'inverse' | 'image' | 'image-blend';
+export type HeroAlign = 'start' | 'center';
+
+export interface HeroProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * Achtergrondstijl van de Hero.
+   * @default 'default'
+   */
+  variant?: HeroVariant;
+
+  /**
+   * URL van de achtergrondafbeelding — vereist bij `variant="image"` of `"image-blend"`.
+   * Wordt toegepast als CSS custom property `--dsn-hero-bg-image`.
+   */
+  backgroundImage?: string;
+
+  /**
+   * Horizontale uitlijning van de inhoud en tekst.
+   * @default 'start'
+   */
+  align?: HeroAlign;
+
+  children?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Hero component
+ * Prominente introductiesectie direct onder de PageHeader. Beslaat de volledige
+ * paginabreedte via het BreakoutSection-patroon.
+ *
+ * Vereiste: de parent heeft `overflow-x: clip` (dsn-page-body).
+ *
+ * @example
+ * ```tsx
+ * <Hero>
+ *   <Stack space="lg">
+ *     <Heading level={1}>Paginatitel</Heading>
+ *     <Paragraph variant="lead">Introductietekst.</Paragraph>
+ *     <ActionGroup>
+ *       <ButtonLink href="/start" variant="strong" size="large">Aan de slag</ButtonLink>
+ *     </ActionGroup>
+ *   </Stack>
+ * </Hero>
+ * ```
+ */
+export const Hero = React.forwardRef<HTMLElement, HeroProps>(
+  (
+    {
+      variant = 'default',
+      backgroundImage,
+      align = 'start',
+      className,
+      children,
+      style,
+      ...props
+    },
+    ref
+  ) => {
+    const classes = classNames(
+      'dsn-hero',
+      variant === 'inverse' && 'dsn-hero--inverse',
+      (variant === 'image' || variant === 'image-blend') && 'dsn-hero--image',
+      variant === 'image-blend' && 'dsn-hero--image-blend',
+      align === 'center' && 'dsn-hero--align-center',
+      className
+    );
+
+    const inlineStyle: React.CSSProperties & {
+      '--dsn-hero-bg-image'?: string;
+    } = backgroundImage
+      ? { '--dsn-hero-bg-image': `url('${backgroundImage}')`, ...style }
+      : { ...style };
+
+    return (
+      <section ref={ref} className={classes} style={inlineStyle} {...props}>
+        <div className="dsn-hero__inner">
+          <div className="dsn-hero__content">{children}</div>
+        </div>
+      </section>
+    );
+  }
+);
+
+Hero.displayName = 'Hero';

--- a/packages/components-react/src/Hero/index.ts
+++ b/packages/components-react/src/Hero/index.ts
@@ -1,0 +1,2 @@
+export { Hero } from './Hero';
+export type { HeroProps, HeroVariant, HeroAlign } from './Hero';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -10,6 +10,7 @@ export * from './ActionGroup';
 export * from './Body';
 export * from './BreakoutSection';
 export * from './Container';
+export * from './Hero';
 export * from './Grid';
 export * from './Stack';
 

--- a/packages/design-tokens/src/tokens/components/hero.json
+++ b/packages/design-tokens/src/tokens/components/hero.json
@@ -1,0 +1,57 @@
+{
+  "dsn": {
+    "hero": {
+      "block-size": {
+        "value": "70svh",
+        "type": "dimension",
+        "comment": "Hoogte van de Hero via min-block-size: max(--dsn-hero-min-block-size, --dsn-hero-block-size); aanpasbaar per instantie via inline style"
+      },
+      "min-block-size": {
+        "value": "400px",
+        "type": "dimension",
+        "comment": "Minimale hoogte van de Hero — vloer zodat de Hero niet te klein wordt bij weinig inhoud of kleine viewport"
+      },
+      "padding-block": {
+        "value": "{dsn.space.block.4xl}",
+        "type": "spacing",
+        "comment": "Verticale padding van de Hero-inhoud"
+      },
+      "padding-inline": {
+        "value": "{dsn.space.inline.xl}",
+        "type": "spacing",
+        "comment": "Horizontale padding van de dsn-hero__inner wrapper — stemt af op dsn-page-body-padding-inline"
+      },
+      "background-color": {
+        "default": {
+          "value": "{dsn.color.accent-1.bg-default}",
+          "type": "color",
+          "comment": "Achtergrondkleur van de standaard Hero — licht blauw accent-1"
+        },
+        "inverse": {
+          "value": "{dsn.color.accent-1-inverse.bg-default}",
+          "type": "color",
+          "comment": "Achtergrondkleur van de inverse Hero — donker blauw"
+        }
+      },
+      "color": {
+        "default": {
+          "value": "{dsn.color.accent-1.color-default}",
+          "type": "color",
+          "comment": "Tekstkleur in de standaard Hero"
+        },
+        "inverse": {
+          "value": "{dsn.color.accent-1-inverse.color-default}",
+          "type": "color",
+          "comment": "Tekstkleur in de inverse Hero — lichte kleur op donkere achtergrond"
+        }
+      },
+      "image": {
+        "blend-color": {
+          "value": "{dsn.color.accent-1-inverse.bg-default}",
+          "type": "color",
+          "comment": "Blendkleur voor de image-blend variant — zelfde als inverse achtergrond voor visuele samenhang"
+        }
+      }
+    }
+  }
+}

--- a/packages/storybook/src/BreakoutSection.stories.tsx
+++ b/packages/storybook/src/BreakoutSection.stories.tsx
@@ -30,20 +30,22 @@ const meta: Meta<typeof BreakoutSection> = {
 export default meta;
 type Story = StoryObj<typeof BreakoutSection>;
 
-// Wrapper die een beperkte paginabreedte simuleert zodat het uitslaan zichtbaar is
+// Wrapper die een beperkte paginabreedte simuleert zodat het uitslaan zichtbaar is.
+// De buitenste div is volle breedte met overflow-x: clip (zoals dsn-page-body).
+// De binnenste div is geconstrained (zoals dsn-page-body__inner).
 function ConstrainedPage({ children }: { children: React.ReactNode }) {
   return (
     <div
       style={{
-        maxInlineSize: '960px',
-        marginInline: 'auto',
         overflowX: 'clip',
-        paddingBlock: 'var(--dsn-space-block-4xl)',
       }}
     >
       <div
         style={{
+          maxInlineSize: '960px',
+          marginInline: 'auto',
           paddingInline: 'var(--dsn-space-inline-3xl)',
+          paddingBlock: 'var(--dsn-space-block-4xl)',
         }}
       >
         {children}

--- a/packages/storybook/src/Hero.docs.md
+++ b/packages/storybook/src/Hero.docs.md
@@ -1,0 +1,91 @@
+# Hero
+
+Prominente introductiecomponent die direct onder de PageHeader verschijnt en de volledige paginabreedte beslaat.
+
+## Doel
+
+Hero is de primaire introductiesectie bovenaan een pagina. Het beslaat de volledige viewportbreedte via het BreakoutSection-patroon (`margin-inline: calc(50% - 50vw)`) en biedt een gestructureerde slot voor een kop, beschrijvende tekst en een call-to-action of zoekfunctie.
+
+De component ondersteunt vier achtergrondvarianten — licht blauw, donker blauw, achtergrondafbeelding en afbeelding met kleur-blend — en twee uitlijningsopties voor de inhoud.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- De pagina een prominente introductiesectie nodig heeft direct onder de header (landingspagina's, startpagina's, campagnepagina's).
+- U een kernboodschap wilt presenteren met één of twee calls-to-action.
+- U een zoekfunctie aanbiedt als primaire pagina-actie.
+- U de begininhoud visueel wilt onderscheiden via een gekleurde of beeldachtergrond.
+
+## Don't use when
+
+- De sectie verderop op de pagina staat: gebruik dan BreakoutSection als basis voor een eigen sectie.
+- U een carrousel wilt bouwen: dit schaadt toegankelijkheid en gebruikersbetrokkenheid.
+- De pagina geen duidelijke primaire boodschap heeft: een Hero zonder inhoudelijk doel leidt af en voegt geen waarde toe.
+
+## Best practices
+
+### Kop en beschrijving
+
+Gebruik altijd een `Heading` met `level={1}` als de Hero de eerste kop op de pagina is. Geef de kop een uniek `id` en koppel dit via `aria-labelledby` op het `<section>` element. De beschrijvende tekst werkt het beste als korte lead-alinea van één of twee zinnen.
+
+### Calls-to-action
+
+Gebruik maximaal twee prominente knoppen in een ActionGroup. De primaire actie krijgt `variant="strong"`, de secundaire actie `variant="subtle"`. Gebruik `size="large"` voor beide om de Hero-hoogte visueel te complementeren.
+
+### Achtergrondafbeelding
+
+Bij `variant="image"` of `"image-blend"` levert u de afbeelding via de `backgroundImage` prop (React) of het CSS custom property `--dsn-hero-bg-image` (HTML/CSS). Achtergrondafbeeldingen zijn decoratief en vereisen geen alt-tekst. Als de afbeelding informatieve waarde heeft, voeg dan een tekstuele beschrijving toe in de Hero-inhoud zelf.
+
+Gebruik bij voorkeur `variant="image-blend"` boven `variant="image"`: de kleur-overlay verbetert de kans op voldoende contrast en geeft de Hero een consistentere uitstraling bij wisselende afbeeldingen.
+
+### Hoogte
+
+De standaardhoogte is `70svh` met een minimum van `400px`. Overschrijf `--dsn-hero-block-size` via een inline stijl om de hoogte per instantie aan te passen:
+
+```html
+<section class="dsn-hero" style="--dsn-hero-block-size: 50svh;">...</section>
+```
+
+## Design tokens
+
+| Token                                 | Beschrijving                                                                       |
+| ------------------------------------- | ---------------------------------------------------------------------------------- |
+| `--dsn-hero-block-size`               | Hoogte van de Hero (`70svh` standaard); aanpasbaar per instantie                   |
+| `--dsn-hero-min-block-size`           | Minimale hoogte (`400px`); vloer zodat de Hero niet te klein wordt                 |
+| `--dsn-hero-padding-block`            | Verticale padding van de inhoud                                                    |
+| `--dsn-hero-padding-inline`           | Horizontale padding van de inner wrapper                                           |
+| `--dsn-hero-background-color-default` | Achtergrondkleur standaard variant (licht blauw)                                   |
+| `--dsn-hero-background-color-inverse` | Achtergrondkleur inverse variant (donker blauw)                                    |
+| `--dsn-hero-color-default`            | Tekstkleur standaard variant                                                       |
+| `--dsn-hero-color-inverse`            | Tekstkleur inverse variant (licht op donker)                                       |
+| `--dsn-hero-image-blend-color`        | Blendkleur voor de image-blend variant                                             |
+| `--dsn-hero-bg-image`                 | CSS custom property voor de achtergrondafbeelding (niet in tokens — per instantie) |
+
+## Accessibility
+
+### Sectie-landmark
+
+Het `<section>` element krijgt een toegankelijke naam via `aria-labelledby` gekoppeld aan de kop binnen de Hero. Screenreaders kondigen de Hero aan als een named landmark, waardoor toetsenbordgebruikers er direct naartoe kunnen navigeren.
+
+```html
+<section class="dsn-hero" aria-labelledby="hero-heading">
+  <div class="dsn-hero__inner">
+    <div class="dsn-hero__content">
+      <h1 id="hero-heading">Paginatitel</h1>
+      ...
+    </div>
+  </div>
+</section>
+```
+
+### Contrast
+
+- **Default variant**: tekst op lichtblauwe achtergrond — voldoet aan WCAG 4.5:1 voor kleine tekst.
+- **Inverse variant**: witte tekst op donkerblauwe achtergrond — voldoet aan WCAG 4.5:1.
+- **Image variant (zonder blend)**: contrast is afhankelijk van de afbeelding en **kan niet worden gegarandeerd** — gebruik deze variant alleen als de afbeelding licht genoeg is of de tekst een extra contrastlaag krijgt.
+- **Image-blend variant**: de kleur-overlay verhoogt de kans op voldoende contrast, maar geeft geen garantie bij elke afbeelding.
+
+### Achtergrondafbeeldingen
+
+Achtergrondafbeeldingen zijn CSS `background-image` en worden door screenreaders genegeerd. Als de afbeelding inhoudelijke waarde heeft die niet in de tekst staat, voeg dan een beschrijving toe in de zichtbare Hero-inhoud.

--- a/packages/storybook/src/Hero.docs.mdx
+++ b/packages/storybook/src/Hero.docs.mdx
@@ -1,0 +1,44 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as HeroStories from './Hero.stories';
+import docs from './Hero.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={HeroStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={HeroStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={HeroStories.Default}
+  html={`<section class="dsn-hero" aria-labelledby="hero-heading">
+  <div class="dsn-hero__inner">
+    <div class="dsn-hero__content">
+      <div class="dsn-stack dsn-stack--space-lg">
+        <h1 class="dsn-heading dsn-heading--level-1" id="hero-heading">Paginatitel</h1>
+        <p class="dsn-paragraph dsn-paragraph--lead">
+          Introductietekst die de kernboodschap samenvat in één of twee zinnen.
+        </p>
+        <div class="dsn-action-group">
+          <a href="/start" class="dsn-button dsn-button--strong dsn-button--size-large">
+            <span class="dsn-button__label">Aan de slag</span>
+          </a>
+          <a href="/meer" class="dsn-button dsn-button--subtle dsn-button--size-large">
+            <span class="dsn-button__label">Meer informatie</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>`}
+/>
+
+<Controls of={HeroStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/Hero.stories.tsx
+++ b/packages/storybook/src/Hero.stories.tsx
@@ -1,0 +1,510 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Hero,
+  Stack,
+  Heading,
+  Paragraph,
+  ActionGroup,
+  ButtonLink,
+  Button,
+  SearchInput,
+} from '@dsn/components-react';
+import DocsPage from './Hero.docs.mdx';
+
+const meta: Meta<typeof Hero> = {
+  title: 'Components/Hero',
+  component: Hero,
+  parameters: {
+    layout: 'fullscreen',
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (_args: any) =>
+        `<section class="dsn-hero" aria-labelledby="hero-heading">\n  <div class="dsn-hero__inner">\n    <div class="dsn-hero__content">\n      <div class="dsn-stack dsn-stack--space-lg">\n        <h1 class="dsn-heading dsn-heading--level-1" id="hero-heading">Paginatitel</h1>\n        <p class="dsn-paragraph dsn-paragraph--lead">Introductietekst die de kernboodschap samenvat in één of twee zinnen.</p>\n        <div class="dsn-action-group">\n          <a href="/start" class="dsn-button dsn-button--strong dsn-button--size-large"><span class="dsn-button__label">Aan de slag</span></a>\n          <a href="/meer" class="dsn-button dsn-button--subtle dsn-button--size-large"><span class="dsn-button__label">Meer informatie</span></a>\n        </div>\n      </div>\n    </div>\n  </div>\n</section>`,
+    },
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'inverse', 'image', 'image-blend'],
+    },
+    align: {
+      control: 'select',
+      options: ['start', 'center'],
+    },
+    backgroundImage: { control: 'text' },
+    children: { control: false },
+  },
+  args: {
+    variant: 'default',
+    align: 'start',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Hero>;
+
+// Simuleert de paginastructuur: de Hero staat als directe child van de outer
+// overflow-x: clip container (net als dsn-page-body), zodat margin-inline: calc(50% - 50vw)
+// correct wordt berekend. De voor- en na-content is herbeperkt tot 960px.
+function ConstrainedPage({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ overflowX: 'clip' }}>
+      <div
+        style={{
+          maxInlineSize: '960px',
+          marginInline: 'auto',
+          paddingInline: 'var(--dsn-space-inline-3xl)',
+          paddingBlock: 'var(--dsn-space-block-4xl)',
+        }}
+      >
+        <Paragraph>Normale paginainhoud boven de Hero.</Paragraph>
+      </div>
+      {children}
+      <div
+        style={{
+          maxInlineSize: '960px',
+          marginInline: 'auto',
+          paddingInline: 'var(--dsn-space-inline-3xl)',
+          paddingBlock: 'var(--dsn-space-block-4xl)',
+        }}
+      >
+        <Paragraph>Normale paginainhoud onder de Hero.</Paragraph>
+      </div>
+    </div>
+  );
+}
+
+const IMAGE_URL = 'https://picsum.photos/id/1043/1600/900';
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {
+  render: (args) => (
+    <ConstrainedPage>
+      <Hero {...args} aria-labelledby="hero-heading-default">
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-default">
+            Paginatitel
+          </Heading>
+          <Paragraph variant="lead">
+            Introductietekst die de kernboodschap samenvat in één of twee
+            zinnen.
+          </Paragraph>
+          <ActionGroup>
+            <ButtonLink href="#" variant="strong" size="large">
+              Aan de slag
+            </ButtonLink>
+            <ButtonLink href="#" variant="subtle" size="large">
+              Meer informatie
+            </ButtonLink>
+          </ActionGroup>
+        </Stack>
+      </Hero>
+    </ConstrainedPage>
+  ),
+};
+
+// =============================================================================
+// VARIANTEN
+// =============================================================================
+
+export const Inverse: Story = {
+  render: (args) => (
+    <ConstrainedPage>
+      <Hero {...args} variant="inverse" aria-labelledby="hero-heading-inverse">
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-inverse">
+            Paginatitel
+          </Heading>
+          <Paragraph variant="lead">
+            Introductietekst die de kernboodschap samenvat in één of twee
+            zinnen.
+          </Paragraph>
+          <ActionGroup>
+            <ButtonLink href="#" variant="strong" size="large">
+              Aan de slag
+            </ButtonLink>
+            <ButtonLink href="#" variant="subtle" size="large">
+              Meer informatie
+            </ButtonLink>
+          </ActionGroup>
+        </Stack>
+      </Hero>
+    </ConstrainedPage>
+  ),
+};
+
+export const WithImage: Story = {
+  name: 'With image',
+  render: (args) => (
+    <ConstrainedPage>
+      <Hero
+        {...args}
+        variant="image"
+        backgroundImage={IMAGE_URL}
+        aria-labelledby="hero-heading-image"
+      >
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-image">
+            Paginatitel
+          </Heading>
+          <Paragraph variant="lead">
+            Introductietekst die de kernboodschap samenvat in één of twee
+            zinnen.
+          </Paragraph>
+          <ActionGroup>
+            <ButtonLink href="#" variant="strong" size="large">
+              Aan de slag
+            </ButtonLink>
+          </ActionGroup>
+        </Stack>
+      </Hero>
+    </ConstrainedPage>
+  ),
+};
+
+export const WithImageBlend: Story = {
+  name: 'With image blend',
+  render: (args) => (
+    <ConstrainedPage>
+      <Hero
+        {...args}
+        variant="image-blend"
+        backgroundImage={IMAGE_URL}
+        aria-labelledby="hero-heading-image-blend"
+      >
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-image-blend">
+            Paginatitel
+          </Heading>
+          <Paragraph variant="lead">
+            Introductietekst die de kernboodschap samenvat in één of twee
+            zinnen.
+          </Paragraph>
+          <ActionGroup>
+            <ButtonLink href="#" variant="strong" size="large">
+              Aan de slag
+            </ButtonLink>
+          </ActionGroup>
+        </Stack>
+      </Hero>
+    </ConstrainedPage>
+  ),
+};
+
+export const AlignCenter: Story = {
+  name: 'Align center',
+  render: (args) => (
+    <ConstrainedPage>
+      <Hero {...args} align="center" aria-labelledby="hero-heading-center">
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-center">
+            Paginatitel
+          </Heading>
+          <Paragraph variant="lead">
+            Introductietekst die de kernboodschap samenvat in één of twee
+            zinnen.
+          </Paragraph>
+          <ActionGroup>
+            <ButtonLink href="#" variant="strong" size="large">
+              Aan de slag
+            </ButtonLink>
+            <ButtonLink href="#" variant="subtle" size="large">
+              Meer informatie
+            </ButtonLink>
+          </ActionGroup>
+        </Stack>
+      </Hero>
+    </ConstrainedPage>
+  ),
+};
+
+export const WithSearch: Story = {
+  name: 'With search',
+  render: (args) => (
+    <ConstrainedPage>
+      <Hero
+        {...args}
+        variant="inverse"
+        align="center"
+        aria-labelledby="hero-heading-search"
+      >
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-search">
+            Wat zoekt u?
+          </Heading>
+          <Paragraph variant="lead">
+            Zoek in ons aanbod van diensten en informatie.
+          </Paragraph>
+          <div className="dsn-hero__searchbox">
+            <SearchInput aria-label="Zoekterm" placeholder="Zoek…" />
+            <Button variant="strong">Zoeken</Button>
+          </div>
+        </Stack>
+      </Hero>
+    </ConstrainedPage>
+  ),
+};
+
+export const WithSingleButton: Story = {
+  name: 'With single button',
+  render: (args) => (
+    <ConstrainedPage>
+      <Hero {...args} aria-labelledby="hero-heading-single">
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-single">
+            Paginatitel
+          </Heading>
+          <Paragraph variant="lead">
+            Introductietekst die de kernboodschap samenvat in één of twee
+            zinnen.
+          </Paragraph>
+          <ActionGroup>
+            <ButtonLink href="#" variant="strong" size="large">
+              Aan de slag
+            </ButtonLink>
+          </ActionGroup>
+        </Stack>
+      </Hero>
+    </ConstrainedPage>
+  ),
+};
+
+// =============================================================================
+// WITHOUT INNER CONSTRAINT
+// =============================================================================
+
+export const WithoutInnerConstraint: Story = {
+  name: 'Without inner constraint',
+  render: (args) => (
+    <ConstrainedPage>
+      <Hero
+        {...args}
+        variant="image-blend"
+        backgroundImage={IMAGE_URL}
+        aria-labelledby="hero-heading-no-constraint"
+        style={{ '--dsn-page-max-inline-size': 'none' } as React.CSSProperties}
+      >
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-no-constraint">
+            Paginatitel
+          </Heading>
+          <Paragraph variant="lead">
+            Met <code>--dsn-page-max-inline-size: none</code> loopt de inhoud
+            van rand tot rand mee. Passend voor afbeeldingen of visuele secties;
+            minder geschikt voor lopende tekst.
+          </Paragraph>
+        </Stack>
+      </Hero>
+    </ConstrainedPage>
+  ),
+};
+
+// =============================================================================
+// OVERZICHTSSTORIES
+// =============================================================================
+
+export const AllVariants: Story = {
+  name: 'All variants',
+  render: () => (
+    <div style={{ overflowX: 'clip' }}>
+      <Hero variant="default" aria-labelledby="hero-all-default">
+        <Stack space="lg">
+          <Heading level={2} id="hero-all-default">
+            Default
+          </Heading>
+          <Paragraph variant="lead">
+            Introductietekst die de kernboodschap samenvat.
+          </Paragraph>
+        </Stack>
+      </Hero>
+      <Hero variant="inverse" aria-labelledby="hero-all-inverse">
+        <Stack space="lg">
+          <Heading level={2} id="hero-all-inverse">
+            Inverse
+          </Heading>
+          <Paragraph variant="lead">
+            Introductietekst die de kernboodschap samenvat.
+          </Paragraph>
+        </Stack>
+      </Hero>
+      <Hero
+        variant="image"
+        backgroundImage={IMAGE_URL}
+        aria-labelledby="hero-all-image"
+      >
+        <Stack space="lg">
+          <Heading level={2} id="hero-all-image">
+            Image
+          </Heading>
+          <Paragraph variant="lead">
+            Introductietekst die de kernboodschap samenvat.
+          </Paragraph>
+        </Stack>
+      </Hero>
+      <Hero
+        variant="image-blend"
+        backgroundImage={IMAGE_URL}
+        aria-labelledby="hero-all-blend"
+      >
+        <Stack space="lg">
+          <Heading level={2} id="hero-all-blend">
+            Image blend
+          </Heading>
+          <Paragraph variant="lead">
+            Introductietekst die de kernboodschap samenvat.
+          </Paragraph>
+        </Stack>
+      </Hero>
+    </div>
+  ),
+};
+
+// =============================================================================
+// TEKST VARIANTEN
+// =============================================================================
+
+export const ShortText: Story = {
+  name: 'Short text',
+  render: (args) => (
+    <ConstrainedPage>
+      <Hero {...args} aria-labelledby="hero-heading-short">
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-short">
+            Korte kop
+          </Heading>
+          <Paragraph variant="lead">Kort intro.</Paragraph>
+        </Stack>
+      </Hero>
+    </ConstrainedPage>
+  ),
+};
+
+export const LongText: Story = {
+  name: 'Long text',
+  render: (args) => (
+    <ConstrainedPage>
+      <Hero {...args} aria-labelledby="hero-heading-long">
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-long">
+            Een langere paginatitel die over meerdere regels kan lopen op smalle
+            viewports
+          </Heading>
+          <Paragraph variant="lead">
+            Dit is een langere introductietekst om te tonen hoe de Hero omgaat
+            met meer inhoud. De tekst beslaat meerdere zinnen en geeft een
+            bredere indruk van de pagina-inhoud die volgt. Gebruik een
+            lead-alinea van maximaal twee à drie zinnen voor de beste
+            leesbaarheid.
+          </Paragraph>
+          <ActionGroup>
+            <ButtonLink href="#" variant="strong" size="large">
+              Aan de slag
+            </ButtonLink>
+            <ButtonLink href="#" variant="subtle" size="large">
+              Meer informatie
+            </ButtonLink>
+          </ActionGroup>
+        </Stack>
+      </Hero>
+    </ConstrainedPage>
+  ),
+};
+
+// =============================================================================
+// RTL
+// =============================================================================
+
+export const RTL: Story = {
+  name: 'RTL',
+  render: (args) => (
+    <div dir="rtl" style={{ overflowX: 'clip' }}>
+      <div
+        style={{
+          maxInlineSize: '960px',
+          marginInline: 'auto',
+          paddingInline: 'var(--dsn-space-inline-3xl)',
+          paddingBlock: 'var(--dsn-space-block-4xl)',
+        }}
+      >
+        <Paragraph>محتوى الصفحة العادي فوق Hero.</Paragraph>
+      </div>
+      <Hero {...args} aria-labelledby="hero-heading-rtl">
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-rtl">
+            عنوان الصفحة
+          </Heading>
+          <Paragraph variant="lead">
+            نص تمهيدي يلخص الرسالة الرئيسية في جملة أو جملتين.
+          </Paragraph>
+          <ActionGroup>
+            <ButtonLink href="#" variant="strong" size="large">
+              ابدأ
+            </ButtonLink>
+            <ButtonLink href="#" variant="subtle" size="large">
+              المزيد من المعلومات
+            </ButtonLink>
+          </ActionGroup>
+        </Stack>
+      </Hero>
+      <div
+        style={{
+          maxInlineSize: '960px',
+          marginInline: 'auto',
+          paddingInline: 'var(--dsn-space-inline-3xl)',
+          paddingBlock: 'var(--dsn-space-block-4xl)',
+        }}
+      >
+        <Paragraph>محتوى الصفحة العادي تحت Hero.</Paragraph>
+      </div>
+    </div>
+  ),
+};
+
+export const RTLLongText: Story = {
+  name: 'RTL long text',
+  render: (args) => (
+    <div dir="rtl" style={{ overflowX: 'clip' }}>
+      <div
+        style={{
+          maxInlineSize: '960px',
+          marginInline: 'auto',
+          paddingInline: 'var(--dsn-space-inline-3xl)',
+          paddingBlock: 'var(--dsn-space-block-4xl)',
+        }}
+      >
+        <Paragraph>محتوى الصفحة العادي فوق Hero.</Paragraph>
+      </div>
+      <Hero {...args} aria-labelledby="hero-heading-rtl-long">
+        <Stack space="lg">
+          <Heading level={1} id="hero-heading-rtl-long">
+            عنوان صفحة أطول يمتد على عدة أسطر في أجهزة العرض الضيقة
+          </Heading>
+          <Paragraph variant="lead">
+            هذا نص تمهيدي أطول لإظهار كيفية تعامل البطل مع المحتوى الإضافي. يغطي
+            النص عدة جمل ويعطي انطباعًا أوسع عن محتوى الصفحة التالي.
+          </Paragraph>
+          <ActionGroup>
+            <ButtonLink href="#" variant="strong" size="large">
+              ابدأ
+            </ButtonLink>
+          </ActionGroup>
+        </Stack>
+      </Hero>
+      <div
+        style={{
+          maxInlineSize: '960px',
+          marginInline: 'auto',
+          paddingInline: 'var(--dsn-space-inline-3xl)',
+          paddingBlock: 'var(--dsn-space-block-4xl)',
+        }}
+      >
+        <Paragraph>محتوى الصفحة العادي تحت Hero.</Paragraph>
+      </div>
+    </div>
+  ),
+};

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -72,6 +72,10 @@ function App() {
 - **Grid**: 12-koloms CSS Grid container met gutter, margin en optionele max-width (`contained`)
 - **Stack**: Verticale stapeling met consistente row-spacing (9 space-varianten)
 
+### Section Components (1)
+
+- **Hero**: Prominente introductiesectie direct onder de PageHeader: volledige viewportbreedte, vier achtergrondvarianten (default, inverse, image, image-blend) en uitlijningsopties
+
 ### Content Components (9)
 
 - **Button**: Knoppen met varianten (`strong`, `default`, `subtle`), groottes en laadstatus
@@ -178,4 +182,4 @@ MIT License: zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.27.0 | **Laatste update:** 17 april 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.28.0 | **Laatste update:** 21 april 2026 | **Auteur:** Jeffrey Lauwers

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -129,9 +129,11 @@ function App() {
 - **Form Fields**: FormFieldLabel, FormFieldLegend, FormFieldDescription, FormFieldErrorMessage, FormFieldStatus
 - **Form Containers**: FormField (enkelvoudige inputs) en FormFieldset (groepen met legend)
 
-### Templates (1)
+### Templates (3)
 
 - **BasePage**: Volledige paginastructuur met `Body`, `SkipLink`, `PageLayout`, `PageHeader`, `PageBody` en `PageFooter`: fundament voor alle verdere paginatemplates
+- **GridPage**: Paginatemplate met drierijige responsieve grid-layout; kolommen stapelen op mobiel en staan naast elkaar vanaf het md-breakpoint
+- **HomePage**: Paginatemplate met een prominente Hero direct onder de PageHeader, gevolgd door responsieve grid-inhoud; ondersteunt full-width en inverse kleurschema's
 
 ## Design Tokens
 

--- a/packages/storybook/src/templates/HomePage.docs.md
+++ b/packages/storybook/src/templates/HomePage.docs.md
@@ -1,0 +1,104 @@
+# Home Page
+
+Paginatemplate met een prominente Hero direct onder de Page Header, gevolgd door een responsieve grid-layout.
+
+## Doel
+
+Het Home Page template bouwt voort op de Grid Page-structuur en plaatst een `Hero` als eerste element in de `<main>`, direct onder de `PageHeader`. Het template laat zien hoe je de Hero combineert met verschillende PageHeader-varianten (default, inverse, compact) en hoe je full-width en inverse kleurschema's combineert voor een sterk visueel openingsscherm.
+
+Templates zijn Storybook-only composities van bestaande componenten. Ze bevatten geen eigen CSS of React component.
+
+<!-- VOORBEELD -->
+
+## Paginaopbouw
+
+```html
+<body class="dsn-body">
+  <a href="#main-content" class="dsn-skip-link">Ga naar hoofdinhoud</a>
+  <div class="dsn-page-layout">
+    <header class="dsn-page-header">…</header>
+    <div class="dsn-page-body">
+      <main id="main-content" tabindex="-1">
+        <section
+          class="dsn-hero dsn-hero--inverse"
+          aria-labelledby="hero-heading"
+        >
+          <div class="dsn-hero__inner">
+            <div class="dsn-hero__content">…</div>
+          </div>
+        </section>
+        <!-- grid-inhoud onder de Hero -->
+      </main>
+    </div>
+    <footer class="dsn-page-footer">…</footer>
+  </div>
+</body>
+```
+
+```tsx
+<Body>
+  <SkipLink href="#main-content" />
+  <PageLayout>
+    <PageHeader logoSlot={…} … />
+    <PageBody>
+      <main id="main-content" tabIndex={-1}>
+        <Hero variant="inverse" aria-labelledby="hero-heading">
+          <Stack space="lg">
+            <Heading level={1} id="hero-heading">Paginatitel</Heading>
+            <Paragraph variant="lead">Introductietekst.</Paragraph>
+            <ActionGroup>
+              <ButtonLink href="/start" variant="strong" size="large">Aan de slag</ButtonLink>
+              <ButtonLink href="/meer" variant="subtle" size="large">Meer informatie</ButtonLink>
+            </ActionGroup>
+          </Stack>
+        </Hero>
+        {/* grid-inhoud onder de Hero */}
+      </main>
+    </PageBody>
+    <PageFooter … />
+  </PageLayout>
+</Body>
+```
+
+## Varianten
+
+| Story                                     | PageHeader                   | Hero                |
+| ----------------------------------------- | ---------------------------- | ------------------- |
+| Home Page                                 | default                      | inverse             |
+| Home Page: Full Width                     | default, full width          | inverse, full width |
+| Home Page: Inverse                        | inverse                      | image-blend         |
+| Home Page: Compact + Inverse + Full Width | compact, inverse, full width | inverse, full width |
+
+### Full width
+
+Stel `--dsn-page-max-inline-size: none` in op `PageLayout` voor een volledige paginabreedte. Stel dezelfde custom property ook in op de `Hero` zelf om de inhoud van rand tot rand te laten lopen.
+
+```tsx
+<PageLayout style={{ '--dsn-page-max-inline-size': 'none' }}>
+  …
+  <Hero variant="inverse" style={{ '--dsn-page-max-inline-size': 'none' }}>
+    …
+  </Hero>
+</PageLayout>
+```
+
+### Inverse PageHeader + image-blend Hero
+
+Combineer `colorScheme="inverse"` op de `PageHeader` met `variant="image-blend"` op de `Hero` voor een doorgaand visueel thema van header naar hero.
+
+## Use when
+
+- Je een homepage of landingspagina bouwt met een prominente openingssectie.
+- Je een visuele nadruk wilt op het eerste scherm met een Hero-afbeelding of inversekleurschema.
+- Je de PageHeader en Hero thematisch op elkaar wilt afstemmen.
+
+## Don't use when
+
+- De pagina geen bijzondere openingssectie nodig heeft: gebruik dan het Grid Page of Base Page template.
+- De Hero alleen decoratief is zonder informatieve koptekst: een Hero vereist altijd een herkenbare `<h1>` met `aria-labelledby`.
+
+## Accessibility
+
+- Geef de `Hero` altijd `aria-labelledby` dat verwijst naar de `<h1>` erin, zodat het `<section>`-element een toegankelijke naam heeft.
+- De `<h1>` staat in de Hero en is de eerste heading op de pagina — gebruik geen andere `<h1>` elders op de pagina.
+- Zorg dat knoppen en links in de Hero ook op de inversebehtergrond voldoende contrast hebben (WCAG AA).

--- a/packages/storybook/src/templates/HomePage.docs.mdx
+++ b/packages/storybook/src/templates/HomePage.docs.mdx
@@ -1,0 +1,18 @@
+import { Meta, Story, Markdown } from '@storybook/blocks';
+import * as HomePageStories from './HomePage.stories';
+import docs from './HomePage.docs.md?raw';
+import { PreviewFrame } from '../components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={HomePageStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={HomePageStories.Default} />
+</PreviewFrame>
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/templates/HomePage.stories.tsx
+++ b/packages/storybook/src/templates/HomePage.stories.tsx
@@ -1,0 +1,432 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  ActionGroup,
+  Body,
+  Button,
+  ButtonLink,
+  Container,
+  Grid,
+  GridItem,
+  Heading,
+  Hero,
+  Link,
+  Logo,
+  Menu,
+  MenuLink,
+  PageBody,
+  PageFooter,
+  PageHeader,
+  PageLayout,
+  Paragraph,
+  SearchInput,
+  SkipLink,
+  Stack,
+  UnorderedList,
+} from '@dsn/components-react';
+
+// =============================================================================
+// GEDEELDE CONTENT (identiek aan GridPage stories)
+// =============================================================================
+
+const logoSlot = (
+  <a href="/">
+    <Logo aria-hidden={true} />
+    <span className="dsn-visually-hidden">
+      Starter Kit — terug naar homepage
+    </span>
+  </a>
+);
+
+function PrimaryNavigation() {
+  const [exp1b, setExp1b] = React.useState(false);
+
+  return (
+    <Menu orientation="vertical">
+      <MenuLink href="/level-1a" level={1} current>
+        Level 1a
+      </MenuLink>
+      <MenuLink
+        href="/level-1b"
+        level={1}
+        subItems
+        expanded={exp1b}
+        onExpandToggle={() => setExp1b((v) => !v)}
+      >
+        Level 1b
+      </MenuLink>
+      {exp1b && (
+        <>
+          <MenuLink href="/level-2a" level={2}>
+            Level 2a
+          </MenuLink>
+          <MenuLink href="/level-2b" level={2}>
+            Level 2b
+          </MenuLink>
+        </>
+      )}
+      <MenuLink href="/level-1c" level={1}>
+        Level 1c
+      </MenuLink>
+      <MenuLink href="/level-1d" level={1}>
+        Level 1d
+      </MenuLink>
+    </Menu>
+  );
+}
+
+const primaryNavigationLarge = (
+  <Menu orientation="horizontal">
+    <MenuLink href="/level-1a" level={1} current>
+      Level 1a
+    </MenuLink>
+    <MenuLink href="/level-1b" level={1}>
+      Level 1b
+    </MenuLink>
+    <MenuLink href="/level-1c" level={1}>
+      Level 1c
+    </MenuLink>
+    <MenuLink href="/level-1d" level={1}>
+      Level 1d
+    </MenuLink>
+  </Menu>
+);
+
+const secondaryNavigation = (
+  <Menu orientation="vertical">
+    <MenuLink href="/english" level={1}>
+      English
+    </MenuLink>
+    <MenuLink href="/mijn-omgeving" level={1}>
+      Mijn omgeving
+    </MenuLink>
+  </Menu>
+);
+
+const secondaryNavigationLarge = (
+  <Menu orientation="horizontal">
+    <MenuLink href="/english" level={1}>
+      English
+    </MenuLink>
+    <MenuLink href="/mijn-omgeving" level={1}>
+      Mijn omgeving
+    </MenuLink>
+  </Menu>
+);
+
+const searchSlot = (
+  <>
+    <SearchInput placeholder="Zoeken…" aria-label="Zoekopdracht" />
+    <Button variant="strong">Zoeken</Button>
+  </>
+);
+
+const footerSlot1 = (
+  <a href="/">
+    <Logo aria-hidden={true} />
+    <span className="dsn-visually-hidden">
+      Starter Kit — terug naar homepage
+    </span>
+  </a>
+);
+
+const footerSlot2 = (
+  <Paragraph>
+    Dit is een voorbeeldorganisatie. <Link href="/about">Meer informatie</Link>.
+  </Paragraph>
+);
+
+const footerSlot3 = (
+  <UnorderedList>
+    <li>
+      <Link href="/nieuws">Nieuws</Link>
+    </li>
+    <li>
+      <Link href="/over-ons">Over ons</Link>
+    </li>
+    <li>
+      <Link href="/werken-bij">Werken bij</Link>
+    </li>
+    <li>
+      <Link href="/klachten">Klachten</Link>
+    </li>
+  </UnorderedList>
+);
+
+const footerSlot4 = (
+  <UnorderedList>
+    <li>
+      <Link href="/privacy">Privacyverklaring</Link>
+    </li>
+    <li>
+      <Link href="/accessibility">Toegankelijkheid</Link>
+    </li>
+    <li>
+      <Link href="/cookies">Cookies</Link>
+    </li>
+    <li>
+      <Link href="/contact">Contact</Link>
+    </li>
+  </UnorderedList>
+);
+
+const IMAGE_URL = 'https://picsum.photos/id/1043/1600/900';
+
+const mainContentStyle: React.CSSProperties = {
+  paddingBlockEnd: 'var(--dsn-space-block-6xl)',
+};
+
+const gridContentStyle: React.CSSProperties = {
+  paddingBlockStart: 'var(--dsn-space-block-6xl)',
+};
+
+// =============================================================================
+// GEDEELDE HERO-INHOUD
+// =============================================================================
+
+function HeroContent({ headingId }: { headingId: string }) {
+  return (
+    <Stack space="lg">
+      <Heading level={1} id={headingId}>
+        Welkom bij Starter Kit
+      </Heading>
+      <Paragraph variant="lead">
+        Introductietekst die de kernboodschap samenvat in één of twee zinnen.
+      </Paragraph>
+      <ActionGroup>
+        <ButtonLink href="#" variant="strong" size="large">
+          Aan de slag
+        </ButtonLink>
+        <ButtonLink href="#" variant="subtle" size="large">
+          Meer informatie
+        </ButtonLink>
+      </ActionGroup>
+    </Stack>
+  );
+}
+
+// =============================================================================
+// GEDEELDE GRID-INHOUD (identiek aan GridPage)
+// =============================================================================
+
+function GridContent() {
+  return (
+    <Stack space="2xl" style={gridContentStyle}>
+      {/* Rij 1: volle breedte */}
+      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+        <GridItem colSpan={12}>
+          <Container>
+            <Paragraph>Rij 1 — volle breedte (12 kolommen)</Paragraph>
+          </Container>
+        </GridItem>
+      </Grid>
+
+      {/* Rij 2: 2 kolommen vanaf md */}
+      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+        <GridItem colSpan={12} colSpanMd={6}>
+          <Container>
+            <Paragraph>Rij 2 — kolom 1 van 2</Paragraph>
+          </Container>
+        </GridItem>
+        <GridItem colSpan={12} colSpanMd={6}>
+          <Container>
+            <Paragraph>Rij 2 — kolom 2 van 2</Paragraph>
+          </Container>
+        </GridItem>
+      </Grid>
+
+      {/* Rij 3: 3 kolommen vanaf md */}
+      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+        <GridItem colSpan={12} colSpanMd={4}>
+          <Container>
+            <Paragraph>Rij 3 — kolom 1 van 3</Paragraph>
+          </Container>
+        </GridItem>
+        <GridItem colSpan={12} colSpanMd={4}>
+          <Container>
+            <Paragraph>Rij 3 — kolom 2 van 3</Paragraph>
+          </Container>
+        </GridItem>
+        <GridItem colSpan={12} colSpanMd={4}>
+          <Container>
+            <Paragraph>Rij 3 — kolom 3 van 3</Paragraph>
+          </Container>
+        </GridItem>
+      </Grid>
+    </Stack>
+  );
+}
+
+// =============================================================================
+// META
+// =============================================================================
+
+const meta: Meta = {
+  title: 'Templates/HomePage',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// =============================================================================
+// STORIES
+// =============================================================================
+
+export const Default: Story = {
+  name: 'Home Page',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation />}
+          primaryNavigationLarge={primaryNavigationLarge}
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainContentStyle}>
+            <Hero variant="inverse" aria-labelledby="hero-heading-home">
+              <HeroContent headingId="hero-heading-home" />
+            </Hero>
+            <GridContent />
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};
+
+export const FullWidth: Story = {
+  name: 'Home Page: Full Width',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout
+        style={{ '--dsn-page-max-inline-size': 'none' } as React.CSSProperties}
+      >
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation />}
+          primaryNavigationLarge={primaryNavigationLarge}
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainContentStyle}>
+            <Hero
+              variant="inverse"
+              style={
+                { '--dsn-page-max-inline-size': 'none' } as React.CSSProperties
+              }
+              aria-labelledby="hero-heading-home-fullwidth"
+            >
+              <HeroContent headingId="hero-heading-home-fullwidth" />
+            </Hero>
+            <GridContent />
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};
+
+export const Inverse: Story = {
+  name: 'Home Page: Inverse',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          colorScheme="inverse"
+          primaryNavigation={<PrimaryNavigation />}
+          primaryNavigationLarge={primaryNavigationLarge}
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainContentStyle}>
+            <Hero
+              variant="image-blend"
+              backgroundImage={IMAGE_URL}
+              aria-labelledby="hero-heading-home-inverse"
+            >
+              <HeroContent headingId="hero-heading-home-inverse" />
+            </Hero>
+            <GridContent />
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};
+
+export const CompactInverseFullWidth: Story = {
+  name: 'Home Page: Compact + Inverse + Full Width',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout
+        style={{ '--dsn-page-max-inline-size': 'none' } as React.CSSProperties}
+      >
+        <PageHeader
+          logoSlot={logoSlot}
+          layout="compact"
+          colorScheme="inverse"
+          primaryNavigation={<PrimaryNavigation />}
+          primaryNavigationLarge={primaryNavigationLarge}
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainContentStyle}>
+            <Hero
+              variant="inverse"
+              style={
+                { '--dsn-page-max-inline-size': 'none' } as React.CSSProperties
+              }
+              aria-labelledby="hero-heading-home-compact"
+            >
+              <HeroContent headingId="hero-heading-home-compact" />
+            </Hero>
+            <GridContent />
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};


### PR DESCRIPTION
## Summary

- Nieuw `HomePage` template met 4 stories op basis van de GridPage-structuur
- Hero staat direct onder de PageHeader, gevolgd door de bekende grid-inhoud
- Introduction.mdx bijgewerkt: Templates teller van 1 naar 3 (GridPage en HomePage toegevoegd)

## Stories

| Story | PageHeader | Hero |
|---|---|---|
| Home Page | default | inverse |
| Home Page: Full Width | default, full width | inverse + full width |
| Home Page: Inverse | inverse kleurschema | image-blend + achtergrondafbeelding |
| Home Page: Compact + Inverse + Full Width | compact, inverse, full width | inverse + full width |

## Test plan

- [ ] Alle 4 stories laden zonder fouten in Storybook
- [ ] TypeScript: `pnpm --filter storybook exec tsc --noEmit` geeft 0 fouten
- [ ] Docs-pagina toont het voorbeeld en documentatie correct

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)