### PR TITLE
feat(Templates): voeg WithSidebarPage template toe

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pnpm --filter @dsn/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (1364 tests across 69 test suites)
+# Run tests (1380 tests across 70 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -162,7 +162,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 
 ### Current Components
 
-**Layout Components (6)**
+**Layout Components (7)**
 
 | Component           | HTML/CSS | React | Web Component |
 | ------------------- | -------- | ----- | ------------- |
@@ -171,6 +171,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Container**       | Yes      | Yes   | No            |
 | **Grid**            | Yes      | Yes   | No            |
 | **GridItem**        | Yes      | Yes   | No            |
+| **Hero**            | Yes      | Yes   | No            |
 | **Stack**           | Yes      | Yes   | No            |
 
 **Content Components (10)**

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1,6 +1,6 @@
 # Components
 
-**Last Updated:** April 20, 2026
+**Last Updated:** April 23, 2026
 
 Complete component specifications and guidelines for the Design System Starter Kit.
 
@@ -283,6 +283,122 @@ Laat een sectie "uitslaan" buiten een beperkte paginabreedte om de volledige vie
 **Vereiste:** Gebruik alleen binnen `PageBody` of een parent met `overflow-x: clip`.
 
 **Design tokens:** Geen eigen component tokens. Gebruikt `--dsn-page-max-inline-size` en `--dsn-page-body-padding-inline` voor de inner wrapper (verantwoordelijkheid van de consumer).
+
+---
+
+### Hero
+
+Prominente introductiesectie direct onder de `PageHeader`. Beslaat de volledige paginabreedte via het BreakoutSection-patroon (`margin-inline: calc(50% - 50vw)`). Vereist een parent met `overflow-x: clip` (standaard aanwezig in `dsn-page-body`).
+
+**HTML/CSS:**
+
+```html
+<section class="dsn-hero" aria-labelledby="hero-heading">
+  <div class="dsn-hero__inner">
+    <div class="dsn-hero__content">
+      <h1 id="hero-heading">Paginatitel</h1>
+      <p class="dsn-paragraph dsn-paragraph--lead">Introductietekst.</p>
+    </div>
+  </div>
+</section>
+
+<!-- Inverse variant -->
+<section class="dsn-hero dsn-hero--inverse" aria-labelledby="hero-heading">
+  ...
+</section>
+
+<!-- Achtergrondafbeelding -->
+<section
+  class="dsn-hero dsn-hero--image"
+  style="--dsn-hero-bg-image: url('/hero.jpg')"
+  aria-labelledby="hero-heading"
+>
+  ...
+</section>
+
+<!-- Afbeelding met kleuroverlay (blend) -->
+<section
+  class="dsn-hero dsn-hero--image dsn-hero--image-blend"
+  style="--dsn-hero-bg-image: url('/hero.jpg')"
+  aria-labelledby="hero-heading"
+>
+  ...
+</section>
+
+<!-- Gecentreerde inhoud -->
+<section class="dsn-hero dsn-hero--align-center" aria-labelledby="hero-heading">
+  ...
+</section>
+```
+
+**React:**
+
+```tsx
+<Hero aria-labelledby="hero-heading">
+  <Stack space="lg">
+    <Heading level={1} id="hero-heading">
+      Paginatitel
+    </Heading>
+    <Paragraph variant="lead">Introductietekst.</Paragraph>
+    <ActionGroup>
+      <ButtonLink href="/start" variant="strong" size="large">
+        Aan de slag
+      </ButtonLink>
+    </ActionGroup>
+  </Stack>
+</Hero>;
+
+{
+  /* Inverse variant */
+}
+<Hero variant="inverse" aria-labelledby="hero-heading">
+  ...
+</Hero>;
+
+{
+  /* Achtergrondafbeelding met blend */
+}
+<Hero
+  variant="image-blend"
+  backgroundImage="/hero.jpg"
+  aria-labelledby="hero-heading"
+>
+  ...
+</Hero>;
+
+{
+  /* Gecentreerde inhoud */
+}
+<Hero align="center" aria-labelledby="hero-heading">
+  ...
+</Hero>;
+```
+
+**Props:**
+
+| Prop              | Type                                                 | Default     | Beschrijving                                                      |
+| ----------------- | ---------------------------------------------------- | ----------- | ----------------------------------------------------------------- |
+| `variant`         | `'default' \| 'inverse' \| 'image' \| 'image-blend'` | `'default'` | Achtergrondstijl                                                  |
+| `backgroundImage` | `string`                                             | —           | URL van achtergrondafbeelding (vereist bij `image`/`image-blend`) |
+| `align`           | `'start' \| 'center'`                                | `'start'`   | Horizontale uitlijning van de inhoud                              |
+
+**Accessibility:** Gebruik `aria-labelledby` met het `id` van de `<Heading level={1}>` binnenin de Hero.
+
+**Design tokens:**
+
+| Token                                 | Waarde                                       | Beschrijving                                  |
+| ------------------------------------- | -------------------------------------------- | --------------------------------------------- |
+| `--dsn-hero-block-size`               | `70svh`                                      | Streefhoogte (via `min-block-size: max(...)`) |
+| `--dsn-hero-min-block-size`           | `400px`                                      | Vloer: minimale hoogte                        |
+| `--dsn-hero-padding-block`            | `{dsn.space.block.4xl}`                      | Verticale padding van de inhoud               |
+| `--dsn-hero-padding-inline`           | `{dsn.space.inline.xl}`                      | Horizontale padding (afgestemd op PageBody)   |
+| `--dsn-hero-background-color-default` | `{dsn.color.accent-1.bg-default}`            | Achtergrond default                           |
+| `--dsn-hero-background-color-inverse` | `{dsn.color.accent-1-inverse.bg-default}`    | Achtergrond inverse                           |
+| `--dsn-hero-color-default`            | `{dsn.color.accent-1.color-default}`         | Tekstkleur default                            |
+| `--dsn-hero-color-inverse`            | `{dsn.color.accent-1-inverse.color-default}` | Tekstkleur inverse                            |
+| `--dsn-hero-image-blend-color`        | `{dsn.color.accent-1-inverse.bg-default}`    | Blendkleur bij `image-blend`                  |
+
+**Location:** `packages/components-{html|react}/src/Hero/`
 
 ---
 
@@ -1776,7 +1892,7 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 | Token                       | Waarde                        | Beschrijving                                  |
 | --------------------------- | ----------------------------- | --------------------------------------------- |
-| `--dsn-menu-gap-vertical`   | `{dsn.space.block.xs}` (2px)  | Ruimte tussen items in verticale oriëntatie   |
+| `--dsn-menu-gap-vertical`   | `{dsn.space.block.md}` (8px)  | Ruimte tussen items in verticale oriëntatie   |
 | `--dsn-menu-gap-horizontal` | `{dsn.space.inline.sm}` (4px) | Ruimte tussen items in horizontale oriëntatie |
 
 **Usage:**
@@ -2864,15 +2980,15 @@ defineButton('my-custom-button');
 
 ## Component Statistics
 
-**Total Components:** 51
+**Total Components:** 52
 
 **Implementations:**
 
-- **HTML/CSS:** 51 components
-- **React:** 51 components (1329 tests total, 65 test suites)
+- **HTML/CSS:** 52 components
+- **React:** 52 components (1380 tests total, 70 test suites)
 - **Web Component:** 7 components (Button, Heading, Icon, Link, OrderedList, Paragraph, UnorderedList)
 
-**Test Coverage:** 1329 tests across 65 test suites
+**Test Coverage:** 1380 tests across 70 test suites
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Design System Documentation
 
-**Version:** 5.28.0
-**Last Updated:** April 20, 2026
+**Version:** 5.29.0
+**Last Updated:** April 23, 2026
 
 Complete documentation voor het Design System Starter Kit.
 
@@ -91,8 +91,8 @@ Complete documentation voor het Design System Starter Kit.
 
 - **Tokens per configuration:** ~1100 (400 semantic + 700 component)
 - **Configurations:** 8 (2 themes × 2 modes × 2 project types)
-- **Components:** 52 (6 layout + 10 content + 9 display/feedback + 1 branding + 5 navigation + 25 form + 1 accessibility; HTML/CSS + React)
-- **Tests:** 1364 across 69 test suites
+- **Components:** 53 (7 layout + 10 content + 9 display/feedback + 1 branding + 5 navigation + 25 form + 1 accessibility; HTML/CSS + React)
+- **Tests:** 1380 across 70 test suites
 - **Storybook stories:** 130+
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,33 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 5.29.0 (April 23, 2026)
+
+### Hero component + HomePage & WithSidebar templates + Menu gap
+
+#### Added
+
+- **Hero** component: prominente introductiesectie die de volledige paginabreedte beslaat via het BreakoutSection-patroon (`margin-inline: calc(50% - 50vw)`)
+  - 4 varianten: `default`, `inverse`, `image`, `image-blend`
+  - `align` prop: `start` (default) of `center` voor horizontale uitlijning van de inhoud
+  - `backgroundImage` prop: CSS custom property `--dsn-hero-bg-image` voor afbeeldingsvarianten
+  - `--dsn-hero-block-size` (70svh) + `--dsn-hero-min-block-size` (400px) voor instelbare hoogte
+  - 8 design tokens in `tokens/components/hero.json`
+- **HomePage template** (issue #184): paginatemplate met Hero direct onder de PageHeader gevolgd door responsieve grid-inhoud
+  - 4 stories: _Default_, _Full Width_, _Inverse_ (image-blend + inverse PageHeader), _Compact + Inverse + Full Width_
+- **WithSidebar template** (issue #186, PR #187): paginatemplate met vaste zijkolom voor subnavigatie
+  - `dsn-sidebar-layout` CSS in `page-body.css`: flexbox twee-koloms splitsing, sidebar verborgen op < 64em, zichtbaar op >= 64em
+  - Sidebar breedte via `--dsn-sidebar-layout-sidebar-inline-size` (default `20rem`)
+  - Sidebar current-staat: `background-color: transparent`, border-inline-start indicator behouden
+  - `margin-block: var(--dsn-space-block-3xl)` op de sidebar
+  - 3 stories: _Default_ (met sidebar), _Full Width_, _geen sub-items_ (sidebar weggelaten)
+
+#### Changed
+
+- **Menu `gap.vertical` token**: `{dsn.space.block.xs}` (2px) → `{dsn.space.block.md}` (8px) voor meer ademruimte tussen menu-items in verticale oriëntatie
+
+---
+
 ## Version 5.28.0 (April 20, 2026)
 
 ### BreakoutSection component (issue #173, PR #181)

--- a/packages/components-html/src/page-body/page-body.css
+++ b/packages/components-html/src/page-body/page-body.css
@@ -55,23 +55,13 @@
   .dsn-sidebar-layout__sidebar {
     display: block;
     flex-shrink: 0;
-    inline-size: var(--dsn-sidebar-layout-sidebar-inline-size, 16rem);
+    inline-size: var(--dsn-sidebar-layout-sidebar-inline-size, 20rem);
     padding-inline-end: var(--dsn-space-inline-2xl);
     margin-block: var(--dsn-space-block-3xl);
   }
 }
 
-/* Current-staat override in sidebar: geen border-indicator, transparante achtergrond */
+/* Current-staat override in sidebar: transparante achtergrond */
 .dsn-sidebar-layout__sidebar .dsn-menu-link__link[aria-current='page'] {
-  border-inline-start: none;
-  padding-inline-start: var(--dsn-space-inline-xl);
   background-color: transparent;
-}
-
-.dsn-sidebar-layout__sidebar .dsn-menu-link__link[aria-current='page']:hover {
-  background-color: var(--dsn-menu-item-hover-background-color);
-}
-
-.dsn-sidebar-layout__sidebar .dsn-menu-link__link[aria-current='page']:active {
-  background-color: var(--dsn-menu-item-active-background-color);
 }

--- a/packages/components-html/src/page-body/page-body.css
+++ b/packages/components-html/src/page-body/page-body.css
@@ -31,3 +31,31 @@
   max-inline-size: var(--dsn-page-max-inline-size);
   margin-inline: auto;
 }
+
+/* =============================================================================
+   Sidebar layout — twee-koloms splitsing binnen dsn-page-body__inner
+   Sidebar zichtbaar op large viewport (>= 64em), gelijktijdig met
+   dsn-page-header__large-layout.
+   ============================================================================= */
+
+.dsn-sidebar-layout {
+  display: flex;
+}
+
+.dsn-sidebar-layout__sidebar {
+  display: none;
+}
+
+.dsn-sidebar-layout__main {
+  flex: 1;
+  min-inline-size: 0;
+}
+
+@media (min-width: 64em) {
+  .dsn-sidebar-layout__sidebar {
+    display: block;
+    flex-shrink: 0;
+    inline-size: var(--dsn-sidebar-layout-sidebar-inline-size, 16rem);
+    padding-inline-end: var(--dsn-space-inline-2xl);
+  }
+}

--- a/packages/components-html/src/page-body/page-body.css
+++ b/packages/components-html/src/page-body/page-body.css
@@ -57,5 +57,21 @@
     flex-shrink: 0;
     inline-size: var(--dsn-sidebar-layout-sidebar-inline-size, 16rem);
     padding-inline-end: var(--dsn-space-inline-2xl);
+    margin-block: var(--dsn-space-block-3xl);
   }
+}
+
+/* Current-staat override in sidebar: geen border-indicator, transparante achtergrond */
+.dsn-sidebar-layout__sidebar .dsn-menu-link__link[aria-current='page'] {
+  border-inline-start: none;
+  padding-inline-start: var(--dsn-space-inline-xl);
+  background-color: transparent;
+}
+
+.dsn-sidebar-layout__sidebar .dsn-menu-link__link[aria-current='page']:hover {
+  background-color: var(--dsn-menu-item-hover-background-color);
+}
+
+.dsn-sidebar-layout__sidebar .dsn-menu-link__link[aria-current='page']:active {
+  background-color: var(--dsn-menu-item-active-background-color);
 }

--- a/packages/design-tokens/src/tokens/components/menu.json
+++ b/packages/design-tokens/src/tokens/components/menu.json
@@ -3,7 +3,7 @@
     "menu": {
       "gap": {
         "vertical": {
-          "value": "{dsn.space.block.xs}",
+          "value": "{dsn.space.block.md}",
           "type": "spacing",
           "comment": "Kleine ruimte tussen items in verticale oriëntatie"
         },

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -129,11 +129,12 @@ function App() {
 - **Form Fields**: FormFieldLabel, FormFieldLegend, FormFieldDescription, FormFieldErrorMessage, FormFieldStatus
 - **Form Containers**: FormField (enkelvoudige inputs) en FormFieldset (groepen met legend)
 
-### Templates (3)
+### Templates (4)
 
 - **BasePage**: Volledige paginastructuur met `Body`, `SkipLink`, `PageLayout`, `PageHeader`, `PageBody` en `PageFooter`: fundament voor alle verdere paginatemplates
 - **GridPage**: Paginatemplate met drierijige responsieve grid-layout; kolommen stapelen op mobiel en staan naast elkaar vanaf het md-breakpoint
 - **HomePage**: Paginatemplate met een prominente Hero direct onder de PageHeader, gevolgd door responsieve grid-inhoud; ondersteunt full-width en inverse kleurschema's
+- **WithSidebarPage**: Paginatemplate met een vaste zijkolom voor subnavigatie (Level 2 MenuLinks), zichtbaar vanaf het large breakpoint (64em) naast de GridPage-inhoud
 
 ## Design Tokens
 
@@ -184,4 +185,4 @@ MIT License: zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.28.0 | **Laatste update:** 21 april 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.29.0 | **Laatste update:** 23 april 2026 | **Auteur:** Jeffrey Lauwers

--- a/packages/storybook/src/templates/WithSidebarPage.docs.md
+++ b/packages/storybook/src/templates/WithSidebarPage.docs.md
@@ -1,0 +1,107 @@
+# With Sidebar Page
+
+Paginatemplate met een vaste zijkolom voor subnavigatie, zichtbaar vanaf het large breakpoint.
+
+## Doel
+
+Het With Sidebar Page template bouwt voort op de GridPage-structuur en voegt een `dsn-sidebar-layout` toe: een flexbox-tweekoloms splitsing waarbij de linkerzijde een vaste breedte heeft voor subnavigatie en de rechterkolom de hoofdinhoud bevat.
+
+De sidebar is alleen zichtbaar op large viewport (>= 64em), hetzelfde moment waarop `dsn-page-header__large-layout` actief wordt en de Level 1 navigatie horizontaal in de header verschijnt. Op kleinere viewports staat de sidebar verborgen (`display: none`) en vult de hoofdinhoud de volledige breedte.
+
+Templates zijn Storybook-only composities van bestaande componenten. De `dsn-sidebar-layout` CSS staat in `page-body.css`.
+
+<!-- VOORBEELD -->
+
+## Layout-structuur
+
+```html
+<!-- Met sidebar (pagina met sub-items) -->
+<div class="dsn-sidebar-layout">
+  <aside class="dsn-sidebar-layout__sidebar">
+    <nav aria-label="Sub-navigatie">
+      <!-- Menu met level-2 MenuLinks -->
+    </nav>
+  </aside>
+  <main id="main-content" class="dsn-sidebar-layout__main">
+    <!-- 12-koloms grid identiek aan GridPage -->
+  </main>
+</div>
+
+<!-- Zonder sidebar (pagina zonder sub-items) -->
+<main id="main-content">
+  <!-- 12-koloms grid identiek aan GridPage -->
+</main>
+```
+
+```tsx
+{
+  /* Met sidebar */
+}
+<PageBody>
+  <div className="dsn-sidebar-layout">
+    <aside className="dsn-sidebar-layout__sidebar">
+      <nav aria-label="Sub-navigatie">
+        <Menu orientation="vertical">
+          <MenuLink href="/sub-1" level={2} current>
+            Overzicht
+          </MenuLink>
+          <MenuLink href="/sub-2" level={2}>
+            Sub-item 1
+          </MenuLink>
+        </Menu>
+      </nav>
+    </aside>
+    <main id="main-content" tabIndex={-1} className="dsn-sidebar-layout__main">
+      {/* grid-inhoud */}
+    </main>
+  </div>
+</PageBody>;
+
+{
+  /* Zonder sidebar */
+}
+<PageBody>
+  <main id="main-content" tabIndex={-1}>
+    {/* grid-inhoud */}
+  </main>
+</PageBody>;
+```
+
+| Viewport | Sidebar                                                                     | Hoofdinhoud   |
+| -------- | --------------------------------------------------------------------------- | ------------- |
+| < 64em   | verborgen                                                                   | volle breedte |
+| >= 64em  | vaste breedte (`--dsn-sidebar-layout-sidebar-inline-size`, default `16rem`) | `flex: 1`     |
+
+## Sidebar breedte aanpassen
+
+De sidebar breedte is instelbaar via een CSS custom property:
+
+```html
+<div
+  class="dsn-sidebar-layout"
+  style="--dsn-sidebar-layout-sidebar-inline-size: 20rem;"
+></div>
+```
+
+```tsx
+<div
+  className="dsn-sidebar-layout"
+  style={{ '--dsn-sidebar-layout-sidebar-inline-size': '20rem' } as React.CSSProperties}
+>
+```
+
+## Use when
+
+- Een pagina heeft subnavigatie (Level 2 menu-items) die naast de hoofdinhoud getoond moeten worden.
+- Je dezelfde paginastructuur als GridPage wilt, aangevuld met een zijkolom.
+
+## Don't use when
+
+- De pagina geen Level 2 sub-items heeft: gebruik dan GridPage rechtstreeks.
+- Je sidebar-content wilt tonen op alle viewports: dit patroon verbergt de sidebar op small en medium viewports.
+
+## Accessibility
+
+- De `<aside>` bevat een `<nav>` met een beschrijvend `aria-label` (bijv. `"Sub-navigatie"`).
+- De sidebar-inhoud is alleen zichtbaar op large viewport. Zorg dat de subnavigatie op small/medium viewports op een andere manier bereikbaar is als dat inhoudelijk noodzakelijk is.
+- De `<main>` heeft `id="main-content"` en `tabIndex={-1}` voor de SkipLink focus.

--- a/packages/storybook/src/templates/WithSidebarPage.docs.mdx
+++ b/packages/storybook/src/templates/WithSidebarPage.docs.mdx
@@ -1,0 +1,18 @@
+import { Meta, Story, Markdown } from '@storybook/blocks';
+import * as WithSidebarPageStories from './WithSidebarPage.stories';
+import docs from './WithSidebarPage.docs.md?raw';
+import { PreviewFrame } from '../components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={WithSidebarPageStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={WithSidebarPageStories.Default} />
+</PreviewFrame>
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/templates/WithSidebarPage.stories.tsx
+++ b/packages/storybook/src/templates/WithSidebarPage.stories.tsx
@@ -1,0 +1,335 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Body,
+  Button,
+  Container,
+  Grid,
+  GridItem,
+  Link,
+  Logo,
+  Menu,
+  MenuLink,
+  PageBody,
+  PageFooter,
+  PageHeader,
+  PageLayout,
+  Paragraph,
+  SearchInput,
+  SkipLink,
+  Stack,
+  UnorderedList,
+} from '@dsn/components-react';
+
+// =============================================================================
+// GEDEELDE CONTENT (identiek aan GridPage stories)
+// =============================================================================
+
+const logoSlot = (
+  <a href="/">
+    <Logo aria-hidden={true} />
+    <span className="dsn-visually-hidden">
+      Starter Kit — terug naar homepage
+    </span>
+  </a>
+);
+
+function PrimaryNavigation() {
+  const [exp1b, setExp1b] = React.useState(false);
+
+  return (
+    <Menu orientation="vertical">
+      <MenuLink href="/level-1a" level={1} current>
+        Level 1a
+      </MenuLink>
+      <MenuLink
+        href="/level-1b"
+        level={1}
+        subItems
+        expanded={exp1b}
+        onExpandToggle={() => setExp1b((v) => !v)}
+      >
+        Level 1b
+      </MenuLink>
+      {exp1b && (
+        <>
+          <MenuLink href="/level-2a" level={2}>
+            Level 2a
+          </MenuLink>
+          <MenuLink href="/level-2b" level={2}>
+            Level 2b
+          </MenuLink>
+        </>
+      )}
+      <MenuLink href="/level-1c" level={1}>
+        Level 1c
+      </MenuLink>
+      <MenuLink href="/level-1d" level={1}>
+        Level 1d
+      </MenuLink>
+    </Menu>
+  );
+}
+
+const primaryNavigationLarge = (
+  <Menu orientation="horizontal">
+    <MenuLink href="/level-1a" level={1} current>
+      Level 1a
+    </MenuLink>
+    <MenuLink href="/level-1b" level={1}>
+      Level 1b
+    </MenuLink>
+    <MenuLink href="/level-1c" level={1}>
+      Level 1c
+    </MenuLink>
+    <MenuLink href="/level-1d" level={1}>
+      Level 1d
+    </MenuLink>
+  </Menu>
+);
+
+const secondaryNavigation = (
+  <Menu orientation="vertical">
+    <MenuLink href="/english" level={1}>
+      English
+    </MenuLink>
+    <MenuLink href="/mijn-omgeving" level={1}>
+      Mijn omgeving
+    </MenuLink>
+  </Menu>
+);
+
+const secondaryNavigationLarge = (
+  <Menu orientation="horizontal">
+    <MenuLink href="/english" level={1}>
+      English
+    </MenuLink>
+    <MenuLink href="/mijn-omgeving" level={1}>
+      Mijn omgeving
+    </MenuLink>
+  </Menu>
+);
+
+const searchSlot = (
+  <>
+    <SearchInput placeholder="Zoeken…" aria-label="Zoekopdracht" />
+    <Button variant="strong">Zoeken</Button>
+  </>
+);
+
+const footerSlot1 = (
+  <a href="/">
+    <Logo aria-hidden={true} />
+    <span className="dsn-visually-hidden">
+      Starter Kit — terug naar homepage
+    </span>
+  </a>
+);
+
+const footerSlot2 = (
+  <Paragraph>
+    Dit is een voorbeeldorganisatie. <Link href="/about">Meer informatie</Link>.
+  </Paragraph>
+);
+
+const footerSlot3 = (
+  <UnorderedList>
+    <li>
+      <Link href="/nieuws">Nieuws</Link>
+    </li>
+    <li>
+      <Link href="/over-ons">Over ons</Link>
+    </li>
+    <li>
+      <Link href="/werken-bij">Werken bij</Link>
+    </li>
+    <li>
+      <Link href="/klachten">Klachten</Link>
+    </li>
+  </UnorderedList>
+);
+
+const footerSlot4 = (
+  <UnorderedList>
+    <li>
+      <Link href="/privacy">Privacyverklaring</Link>
+    </li>
+    <li>
+      <Link href="/accessibility">Toegankelijkheid</Link>
+    </li>
+    <li>
+      <Link href="/cookies">Cookies</Link>
+    </li>
+    <li>
+      <Link href="/contact">Contact</Link>
+    </li>
+  </UnorderedList>
+);
+
+const mainStyle: React.CSSProperties = {
+  paddingBlock: 'var(--dsn-space-block-6xl)',
+};
+
+// =============================================================================
+// SIDEBAR NAVIGATIE (uitsluitend Level 2 MenuLinks)
+// =============================================================================
+
+const sidebarNavigation = (
+  <nav aria-label="Sub-navigatie">
+    <Menu orientation="vertical">
+      <MenuLink href="/level-1a" level={2} current>
+        Overzicht
+      </MenuLink>
+      <MenuLink href="/level-1a/sub-1" level={2}>
+        Sub-item 1
+      </MenuLink>
+      <MenuLink href="/level-1a/sub-2" level={2}>
+        Sub-item 2
+      </MenuLink>
+      <MenuLink href="/level-1a/sub-3" level={2}>
+        Sub-item 3
+      </MenuLink>
+    </Menu>
+  </nav>
+);
+
+// =============================================================================
+// GEDEELDE GRID-INHOUD (identiek aan GridPage)
+// =============================================================================
+
+function GridContent() {
+  return (
+    <Stack space="2xl">
+      {/* Rij 1: volle breedte */}
+      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+        <GridItem colSpan={12}>
+          <Container>
+            <Paragraph>Rij 1 — volle breedte (12 kolommen)</Paragraph>
+          </Container>
+        </GridItem>
+      </Grid>
+
+      {/* Rij 2: 2 kolommen vanaf md */}
+      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+        <GridItem colSpan={12} colSpanMd={6}>
+          <Container>
+            <Paragraph>Rij 2 — kolom 1 van 2</Paragraph>
+          </Container>
+        </GridItem>
+        <GridItem colSpan={12} colSpanMd={6}>
+          <Container>
+            <Paragraph>Rij 2 — kolom 2 van 2</Paragraph>
+          </Container>
+        </GridItem>
+      </Grid>
+
+      {/* Rij 3: 3 kolommen vanaf md */}
+      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+        <GridItem colSpan={12} colSpanMd={4}>
+          <Container>
+            <Paragraph>Rij 3 — kolom 1 van 3</Paragraph>
+          </Container>
+        </GridItem>
+        <GridItem colSpan={12} colSpanMd={4}>
+          <Container>
+            <Paragraph>Rij 3 — kolom 2 van 3</Paragraph>
+          </Container>
+        </GridItem>
+        <GridItem colSpan={12} colSpanMd={4}>
+          <Container>
+            <Paragraph>Rij 3 — kolom 3 van 3</Paragraph>
+          </Container>
+        </GridItem>
+      </Grid>
+    </Stack>
+  );
+}
+
+// =============================================================================
+// META
+// =============================================================================
+
+const meta: Meta = {
+  title: 'Templates/WithSidebarPage',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// =============================================================================
+// STORIES
+// =============================================================================
+
+export const Default: Story = {
+  name: 'With Sidebar Page',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation />}
+          primaryNavigationLarge={primaryNavigationLarge}
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <div className="dsn-sidebar-layout">
+            <aside className="dsn-sidebar-layout__sidebar">
+              {sidebarNavigation}
+            </aside>
+            <main
+              id="main-content"
+              tabIndex={-1}
+              className="dsn-sidebar-layout__main"
+              style={mainStyle}
+            >
+              <GridContent />
+            </main>
+          </div>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};
+
+export const WithoutSidebar: Story = {
+  name: 'With Sidebar Page: geen sub-items',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation />}
+          primaryNavigationLarge={primaryNavigationLarge}
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainStyle}>
+            <GridContent />
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};

--- a/packages/storybook/src/templates/WithSidebarPage.stories.tsx
+++ b/packages/storybook/src/templates/WithSidebarPage.stories.tsx
@@ -175,8 +175,8 @@ const mainStyle: React.CSSProperties = {
 // =============================================================================
 
 function SidebarNavigation() {
-  const [exp2b, setExp2b] = React.useState(true);
-  const [exp3b, setExp3b] = React.useState(true);
+  const [exp2b, setExp2b] = React.useState(false);
+  const [exp3b, setExp3b] = React.useState(false);
 
   return (
     <nav aria-label="Sub-navigatie">

--- a/packages/storybook/src/templates/WithSidebarPage.stories.tsx
+++ b/packages/storybook/src/templates/WithSidebarPage.stories.tsx
@@ -347,6 +347,48 @@ export const Default: Story = {
   ),
 };
 
+export const FullWidth: Story = {
+  name: 'With Sidebar Page: Full Width',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout
+        style={{ '--dsn-page-max-inline-size': 'none' } as React.CSSProperties}
+      >
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation />}
+          primaryNavigationLarge={primaryNavigationLarge}
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <div className="dsn-sidebar-layout">
+            <aside className="dsn-sidebar-layout__sidebar">
+              <SidebarNavigation />
+            </aside>
+            <main
+              id="main-content"
+              tabIndex={-1}
+              className="dsn-sidebar-layout__main"
+              style={mainStyle}
+            >
+              <GridContent />
+            </main>
+          </div>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};
+
 export const WithoutSidebar: Story = {
   name: 'With Sidebar Page: geen sub-items',
   render: () => (

--- a/packages/storybook/src/templates/WithSidebarPage.stories.tsx
+++ b/packages/storybook/src/templates/WithSidebarPage.stories.tsx
@@ -171,27 +171,70 @@ const mainStyle: React.CSSProperties = {
 };
 
 // =============================================================================
-// SIDEBAR NAVIGATIE (uitsluitend Level 2 MenuLinks)
+// SIDEBAR NAVIGATIE
 // =============================================================================
 
-const sidebarNavigation = (
-  <nav aria-label="Sub-navigatie">
-    <Menu orientation="vertical">
-      <MenuLink href="/level-1a" level={2} current>
-        Overzicht
-      </MenuLink>
-      <MenuLink href="/level-1a/sub-1" level={2}>
-        Sub-item 1
-      </MenuLink>
-      <MenuLink href="/level-1a/sub-2" level={2}>
-        Sub-item 2
-      </MenuLink>
-      <MenuLink href="/level-1a/sub-3" level={2}>
-        Sub-item 3
-      </MenuLink>
-    </Menu>
-  </nav>
-);
+function SidebarNavigation() {
+  const [exp2b, setExp2b] = React.useState(true);
+  const [exp3b, setExp3b] = React.useState(true);
+
+  return (
+    <nav aria-label="Sub-navigatie">
+      <Menu orientation="vertical">
+        <MenuLink href="/level-2a" level={1} current>
+          Level 2a
+        </MenuLink>
+        <MenuLink
+          href="/level-2b"
+          level={1}
+          subItems
+          expanded={exp2b}
+          onExpandToggle={() => setExp2b((v) => !v)}
+        >
+          Level 2b
+        </MenuLink>
+        {exp2b && (
+          <>
+            <MenuLink href="/level-3a" level={2}>
+              Level 3a
+            </MenuLink>
+            <MenuLink
+              href="/level-3b"
+              level={2}
+              subItems
+              expanded={exp3b}
+              onExpandToggle={() => setExp3b((v) => !v)}
+            >
+              Level 3b
+            </MenuLink>
+            {exp3b && (
+              <>
+                <MenuLink href="/level-4a" level={3}>
+                  Level 4a
+                </MenuLink>
+                <MenuLink href="/level-4b" level={3}>
+                  Level 4b
+                </MenuLink>
+              </>
+            )}
+            <MenuLink href="/level-3c" level={2}>
+              Level 3c
+            </MenuLink>
+            <MenuLink href="/level-3d" level={2}>
+              Level 3d
+            </MenuLink>
+          </>
+        )}
+        <MenuLink href="/level-2c" level={1}>
+          Level 2c
+        </MenuLink>
+        <MenuLink href="/level-2d" level={1}>
+          Level 2d
+        </MenuLink>
+      </Menu>
+    </nav>
+  );
+}
 
 // =============================================================================
 // GEDEELDE GRID-INHOUD (identiek aan GridPage)
@@ -281,7 +324,7 @@ export const Default: Story = {
         <PageBody>
           <div className="dsn-sidebar-layout">
             <aside className="dsn-sidebar-layout__sidebar">
-              {sidebarNavigation}
+              <SidebarNavigation />
             </aside>
             <main
               id="main-content"


### PR DESCRIPTION
## Summary

- Voegt `dsn-sidebar-layout` CSS toe aan `page-body.css` als herbruikbaar flexbox-patroon: sidebar verborgen op < 64em, zichtbaar met vaste breedte op >= 64em (gelijktijdig met `dsn-page-header__large-layout`)
- Sidebar breedte instelbaar via `--dsn-sidebar-layout-sidebar-inline-size` (default: `16rem`)
- Twee stories: met sidebar (Level 2 MenuLinks in `<aside>`) en zonder sidebar (`<main>` direct in `dsn-page-body__inner`)
- Docs en Introduction.mdx bijgewerkt (Templates teller: 3 → 4)

Sluit #186.

## Test plan

- [ ] Storybook: `Templates/WithSidebarPage` zichtbaar met twee stories
- [ ] Sidebar verborgen op viewport < 64em, zichtbaar op >= 64em
- [ ] `pnpm test` groen (1380 tests)
- [ ] `pnpm --filter storybook exec tsc --noEmit` schoon
- [ ] `pnpm lint` schoon

🤖 Generated with [Claude Code](https://claude.com/claude-code)