### PR TITLE
feat(Menu): iconStart prop voor uitlijning level 2+ met icoon level 1

### DIFF
--- a/packages/components-html/src/menu/menu.css
+++ b/packages/components-html/src/menu/menu.css
@@ -35,6 +35,17 @@
 }
 
 /* =============================================================================
+   Icon-start uitlijning — level 2+ indent gelijk aan icon-breedte + gap
+   Gebruik wanneer level-1 items een iconStart hebben.
+   ============================================================================= */
+
+.dsn-menu--icon-start {
+  --dsn-menu-link-level-indent: calc(
+    var(--dsn-menu-item-icon-size) + var(--dsn-menu-item-gap)
+  );
+}
+
+/* =============================================================================
    Horizontale oriëntatie
    ============================================================================= */
 

--- a/packages/components-react/src/Menu/Menu.tsx
+++ b/packages/components-react/src/Menu/Menu.tsx
@@ -14,6 +14,13 @@ export interface MenuProps extends React.HTMLAttributes<HTMLUListElement> {
   orientation?: MenuOrientation;
 
   /**
+   * Geeft aan dat level-1 items een `iconStart` hebben.
+   * Level 2+ items worden dan ingesprongen zodat hun tekst uitlijnt met het label van level 1.
+   * @default false
+   */
+  iconStart?: boolean;
+
+  /**
    * `MenuLink`- en/of `MenuButton`-items (verplicht)
    */
   children: React.ReactNode;
@@ -53,10 +60,20 @@ export interface MenuProps extends React.HTMLAttributes<HTMLUListElement> {
  * ```
  */
 export const Menu = React.forwardRef<HTMLUListElement, MenuProps>(
-  ({ orientation = 'vertical', className, children, ...props }, ref) => {
+  (
+    {
+      orientation = 'vertical',
+      iconStart = false,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
     const classes = classNames(
       'dsn-menu',
       orientation === 'horizontal' && 'dsn-menu--horizontal',
+      iconStart && 'dsn-menu--icon-start',
       className
     );
 

--- a/packages/storybook/src/MenuLink.stories.tsx
+++ b/packages/storybook/src/MenuLink.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Icon, MenuLink, NumberBadge } from '@dsn/components-react';
+import { Icon, Menu, MenuLink, NumberBadge } from '@dsn/components-react';
 import type { IconName } from '@dsn/components-react/icon-registry.generated';
 import DocsPage from './MenuLink.docs.mdx';
 import {
@@ -243,7 +243,7 @@ export const Levels: Story = {
 export const ExpandedWithSubItems: Story = {
   name: 'Expanded with sub-pages',
   render: () => (
-    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+    <Menu iconStart>
       <MenuLink
         href="/rapporten"
         iconStart={<Icon name="file-description" aria-hidden />}
@@ -261,7 +261,7 @@ export const ExpandedWithSubItems: Story = {
       <MenuLink href="/rapporten/jaarlijks" level={2}>
         Jaarlijks
       </MenuLink>
-    </ul>
+    </Menu>
   ),
 };
 
@@ -269,7 +269,7 @@ export const FullNavigation: Story = {
   name: 'Full navigation menu',
   render: () => (
     <nav aria-label="Primaire navigatie" style={{ maxWidth: '280px' }}>
-      <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      <Menu iconStart>
         <MenuLink
           href="/dashboard"
           iconStart={<Icon name="home" aria-hidden />}
@@ -309,7 +309,7 @@ export const FullNavigation: Story = {
         >
           Instellingen
         </MenuLink>
-      </ul>
+      </Menu>
     </nav>
   ),
 };


### PR DESCRIPTION
## Summary

- Voegt `iconStart` prop toe aan `<Menu>` die de CSS modifier `dsn-menu--icon-start` zet
- De modifier overschrijft `--dsn-menu-link-level-indent` naar `icon-size + gap`, zodat level 2+ labels verticaal uitlijnen met de labeltekst van level 1 items die een icoon hebben
- Gedrag zonder `iconStart` is ongewijzigd

## Test plan

- [ ] Controleer "Full navigation menu" story: level 2 items lijnen uit met level 1 labels
- [ ] Controleer "Expanded with sub-pages" story: zelfde uitlijning
- [ ] Controleer "Level hierarchy (1–4)" story zonder icons: gedrag ongewijzigd

🤖 Generated with [Claude Code](https://claude.com/claude-code)