### PR TITLE
fix(Templates/FormStepPage): pas paragraaftekst aan

### DIFF
--- a/packages/storybook/src/templates/FormStepPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepPage.stories.tsx
@@ -141,8 +141,7 @@ export const Default: Story = {
                     </h2>
 
                     <Paragraph>
-                      Vul hieronder uw persoonlijke gegevens in. Alle velden
-                      zijn verplicht, tenzij anders aangegeven.
+                      Vul alles in. Als iets niet verplicht is, staat dat erbij.
                     </Paragraph>
                   </Stack>
 


### PR DESCRIPTION
## Summary
- Paragraaftekst in de Form Step Page template aangepast van "Vul hieronder uw persoonlijke gegevens in. Alle velden zijn verplicht, tenzij anders aangegeven." naar "Vul alles in. Als iets niet verplicht is, staat dat erbij."

## Test plan
- [ ] Controleer de FormStepPage story in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)