### PR TITLE
fix(PageHeader): hernoem aria-labels naar Hoofd-navigatie en Service-navigatie

### DIFF
--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -2332,7 +2332,9 @@ const [isOpen, setIsOpen] = React.useState(false);
         </div>
         <div class="dsn-page-header__secondary-nav">
           <nav aria-labelledby="service-nav-id">
-            <h2 id="service-nav-id" class="dsn-visually-hidden">Servicemenu</h2>
+            <h2 id="service-nav-id" class="dsn-visually-hidden">
+              Service-navigatie
+            </h2>
             <ul class="dsn-menu dsn-menu--horizontal">
               <!-- MenuLink items -->
             </ul>
@@ -2355,7 +2357,7 @@ const [isOpen, setIsOpen] = React.useState(false);
     </div>
     <div class="dsn-page-header__navbar">
       <nav aria-labelledby="primary-nav-id">
-        <h2 id="primary-nav-id" class="dsn-visually-hidden">Hoofdmenu</h2>
+        <h2 id="primary-nav-id" class="dsn-visually-hidden">Hoofd-navigatie</h2>
         <ul class="dsn-menu dsn-menu--horizontal">
           <!-- MenuLink items -->
         </ul>

--- a/packages/components-react/src/PageHeader/PageHeader.test.tsx
+++ b/packages/components-react/src/PageHeader/PageHeader.test.tsx
@@ -223,7 +223,7 @@ describe('PageHeader', () => {
     expect(container.querySelector('.dsn-page-header__searchbox')).toBeNull();
   });
 
-  it('masthead nav heeft aria-label="Servicemenu"', () => {
+  it('masthead nav heeft aria-label="Service-navigatie"', () => {
     const { container } = render(
       <PageHeader
         logoSlot={defaultLogo}
@@ -231,15 +231,15 @@ describe('PageHeader', () => {
       />
     );
     const nav = container.querySelector('.dsn-page-header__masthead nav');
-    expect(nav).toHaveAttribute('aria-label', 'Servicemenu');
+    expect(nav).toHaveAttribute('aria-label', 'Service-navigatie');
   });
 
-  it('navbar nav heeft aria-label="Hoofdmenu"', () => {
+  it('navbar nav heeft aria-label="Hoofd-navigatie"', () => {
     const { container } = render(
       <PageHeader logoSlot={defaultLogo} primaryNavigation={<span>nav</span>} />
     );
     const nav = container.querySelector('.dsn-page-header__navbar nav');
-    expect(nav).toHaveAttribute('aria-label', 'Hoofdmenu');
+    expect(nav).toHaveAttribute('aria-label', 'Hoofd-navigatie');
   });
 
   // ---------------------------------------------------------------------------
@@ -394,7 +394,7 @@ describe('PageHeader', () => {
     expect(compactLayout?.textContent).toContain('Contact');
   });
 
-  it('compact layout primaire nav heeft aria-label="Hoofdmenu"', () => {
+  it('compact layout primaire nav heeft aria-label="Hoofd-navigatie"', () => {
     const { container } = render(
       <PageHeader
         logoSlot={defaultLogo}
@@ -405,10 +405,10 @@ describe('PageHeader', () => {
     const nav = container.querySelector(
       '.dsn-page-header__compact-primary-nav nav'
     );
-    expect(nav).toHaveAttribute('aria-label', 'Hoofdmenu');
+    expect(nav).toHaveAttribute('aria-label', 'Hoofd-navigatie');
   });
 
-  it('compact layout servicemenu nav heeft aria-label="Servicemenu"', () => {
+  it('compact layout servicemenu nav heeft aria-label="Service-navigatie"', () => {
     const { container } = render(
       <PageHeader
         logoSlot={defaultLogo}
@@ -419,7 +419,7 @@ describe('PageHeader', () => {
     const nav = container.querySelector(
       '.dsn-page-header__compact-secondary nav'
     );
-    expect(nav).toHaveAttribute('aria-label', 'Servicemenu');
+    expect(nav).toHaveAttribute('aria-label', 'Service-navigatie');
   });
 
   it('compact layout heeft een zoekpaneel', () => {

--- a/packages/components-react/src/PageHeader/PageHeader.tsx
+++ b/packages/components-react/src/PageHeader/PageHeader.tsx
@@ -166,14 +166,14 @@ export interface PageHeaderProps extends Omit<
   /**
    * `aria-label` van de primaire navigatie-`<nav>` (large viewport) en
    * visueel verborgen heading in de Drawer.
-   * @default 'Hoofdmenu'
+   * @default 'Hoofd-navigatie'
    */
   primaryNavAriaLabel?: string;
 
   /**
    * `aria-label` van het servicemenu-`<nav>` (large viewport) en
    * visueel verborgen heading in de Drawer.
-   * @default 'Servicemenu'
+   * @default 'Service-navigatie'
    */
   secondaryNavAriaLabel?: string;
 
@@ -252,8 +252,8 @@ export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
       searchInputPlaceholder = 'Zoeken…',
       searchInputAriaLabel = 'Zoekopdracht',
       searchSubmitLabel = 'Zoeken',
-      primaryNavAriaLabel = 'Hoofdmenu',
-      secondaryNavAriaLabel = 'Servicemenu',
+      primaryNavAriaLabel = 'Hoofd-navigatie',
+      secondaryNavAriaLabel = 'Service-navigatie',
       hideMenuButton = false,
       hideSearchButton = false,
       ...props

--- a/packages/storybook/src/PageHeader.docs.md
+++ b/packages/storybook/src/PageHeader.docs.md
@@ -98,7 +98,7 @@ De mobile layout (hamburger + drawer) valt via `display: none` volledig uit de a
           <a href="/"><!-- Logo --></a>
         </div>
         <div class="dsn-page-header__secondary-nav">
-          <nav aria-label="Servicemenu">
+          <nav aria-label="Service-navigatie">
             <ul class="dsn-menu dsn-menu--horizontal">
               <li><a class="dsn-menu-link" href="/contact">Contact</a></li>
             </ul>
@@ -111,7 +111,7 @@ De mobile layout (hamburger + drawer) valt via `display: none` volledig uit de a
     </div>
     <div class="dsn-page-header__navbar">
       <div class="dsn-page-header__navbar-inner">
-        <nav aria-label="Hoofdmenu">
+        <nav aria-label="Hoofd-navigatie">
           <ul class="dsn-menu dsn-menu--horizontal">
             <li><a class="dsn-menu-link" href="/home">Home</a></li>
           </ul>
@@ -156,7 +156,7 @@ De mobile layout (hamburger + drawer) valt via `display: none` volledig uit de a
 **Tab-volgorde op large viewport** (visuele leesvolgorde = DOM-volgorde = focus-volgorde):
 
 1. Logo (link naar homepage)
-2. Servicemenu items
+2. Service-navigatie items
 3. Inline zoekveld + Zoeken-knop
 4. Primaire navigatie items
 
@@ -177,7 +177,7 @@ De `layout="compact"` variant plaatst logo, primaire navigatie en servicemenu in
         <a href="/"><!-- Logo --></a>
       </div>
       <div class="dsn-page-header__compact-primary-nav">
-        <nav aria-label="Hoofdmenu">
+        <nav aria-label="Hoofd-navigatie">
           <!-- horizontale Menu met MenuLink items -->
         </nav>
       </div>
@@ -314,4 +314,4 @@ Het zoekpaneel verschijnt direct onder de header-binnenbalk. Het paneel bevat ee
 - Elke `<nav>` in de Drawer heeft een unieke toegankelijke naam via `aria-labelledby` + visueel verborgen `<h3>`.
 - Drawer-focusbeheer wordt verzorgd door het bestaande `Drawer`-component.
 - Op large viewport: `dsn-page-header__small-layout` en `dsn-page-header__large-layout` worden geswitcht met `display: none`: de inactieve sectie valt automatisch uit de accessibility tree.
-- Op large viewport: beide `<nav>` elementen gebruiken `aria-label` ("Servicemenu", "Hoofdmenu"): geen verborgen headings, zodat de heading-hiërarchie van de pagina niet vervuild wordt vóór de `<h1>`.
+- Op large viewport: beide `<nav>` elementen gebruiken `aria-label` ("Service-navigatie", "Hoofd-navigatie"): geen verborgen headings, zodat de heading-hiërarchie van de pagina niet vervuild wordt vóór de `<h1>`.


### PR DESCRIPTION
## Summary

- `Hoofdmenu` → `Hoofd-navigatie`
- `Servicemenu` → `Service-navigatie`
- `Sub-navigatie` blijft ongewijzigd

Gewijzigd in: default prop values, JSDoc, tests, Storybook docs en component docs.

## Test plan

- [x] 47 PageHeader tests groen
- [x] Geen TypeScript fouten

🤖 Generated with [Claude Code](https://claude.com/claude-code)