### PR TITLE
feat(Templates/Form flow): hernoem FormStepPage story naar Form step: Example

### DIFF
--- a/packages/storybook/src/templates/FormStepPage.docs.mdx
+++ b/packages/storybook/src/templates/FormStepPage.docs.mdx
@@ -12,7 +12,7 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 ## Voorbeeld
 
 <PreviewFrame>
-  <Story of={FormStepPageStories.Default} />
+  <Story of={FormStepPageStories.Example} />
 </PreviewFrame>
 
 <Markdown>{rest}</Markdown>

--- a/packages/storybook/src/templates/FormStepPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepPage.stories.tsx
@@ -98,7 +98,7 @@ const mainStyle: React.CSSProperties = {
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Templates/FormStepPage',
+  title: 'Templates/Form flow/Form step: Example',
   parameters: {
     layout: 'fullscreen',
   },
@@ -112,8 +112,8 @@ type Story = StoryObj;
 // STORIES
 // =============================================================================
 
-export const Default: Story = {
-  name: 'Form Step Page',
+export const Example: Story = {
+  name: 'Form step: Example',
   render: () => (
     <Body>
       <SkipLink href="#main-content" />


### PR DESCRIPTION
## Summary

- Storybook title gewijzigd van `'Templates/FormStepPage'` naar `'Templates/Form flow/Form step: Example'`
- Story export hernoemd van `Default` naar `Example` met name `'Form step: Example'`
- MDX Docs bijgewerkt: verwijzing van `FormStepPageStories.Default` naar `FormStepPageStories.Example`

Closes #197

## Test plan

- [ ] Storybook sidebar toont story onder `Templates > Form flow > Form step: Example`
- [ ] Docs page laadt zonder errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)