### PR TITLE
docs: voeg ontbrekende semantische tokens toe aan DesignTokens overzicht en synchroniseer documentatie

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,16 +162,19 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 
 ### Current Components
 
-**Layout Components (7)**
+**Layout Components (10)**
 
 | Component           | HTML/CSS | React | Web Component |
 | ------------------- | -------- | ----- | ------------- |
+| **ActionGroup**     | Yes      | Yes   | No            |
 | **Body**            | Yes      | Yes   | No            |
 | **BreakoutSection** | Yes      | Yes   | No            |
 | **Container**       | Yes      | Yes   | No            |
 | **Grid**            | Yes      | Yes   | No            |
 | **GridItem**        | Yes      | Yes   | No            |
 | **Hero**            | Yes      | Yes   | No            |
+| **PageBody**        | Yes      | Yes   | No            |
+| **PageLayout**      | Yes      | Yes   | No            |
 | **Stack**           | Yes      | Yes   | No            |
 
 **Content Components (10)**
@@ -189,7 +192,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Paragraph**     | Yes      | Yes   | Yes           |
 | **UnorderedList** | Yes      | Yes   | Yes           |
 
-**Display & Feedback Components (10)**
+**Display & Feedback Components (12)**
 
 | Component       | HTML/CSS | React | Web Component |
 | --------------- | -------- | ----- | ------------- |
@@ -198,13 +201,15 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Card**        | Yes      | Yes   | No            |
 | **Details**     | Yes      | Yes   | No            |
 | **DotBadge**    | Yes      | Yes   | No            |
+| **Drawer**      | Yes      | Yes   | No            |
+| **ModalDialog** | Yes      | Yes   | No            |
 | **Note**        | Yes      | Yes   | No            |
 | **NumberBadge** | Yes      | Yes   | No            |
 | **Popover**     | Yes      | Yes   | No            |
 | **StatusBadge** | Yes      | Yes   | No            |
 | **Table**       | Yes      | Yes   | No            |
 
-**Navigation Components (5)**
+**Navigation Components (6)**
 
 | Component                | HTML/CSS | React | Web Component |
 | ------------------------ | -------- | ----- | ------------- |
@@ -212,7 +217,14 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Menu**                 | Yes      | Yes   | No            |
 | **MenuButton**           | Yes      | Yes   | No            |
 | **MenuLink**             | Yes      | Yes   | No            |
+| **PageFooter**           | Yes      | Yes   | No            |
 | **PageHeader**           | Yes      | Yes   | No            |
+
+**Branding Components (1)**
+
+| Component | HTML/CSS | React | Web Component |
+| --------- | -------- | ----- | ------------- |
+| **Logo**  | Yes      | Yes   | No            |
 
 **Accessibility Components (1)**
 
@@ -393,18 +405,18 @@ Comprehensive documentation is available in the `/docs` folder:
 
 - **Pre-commit hooks** via Husky + lint-staged (ESLint + Prettier)
 - **Type checking** across all packages (`pnpm type-check`)
-- **1364 tests** covering React components, Web Components, and utilities
+- **1409 tests** covering React components, Web Components, and utilities
 - **CI/CD** via GitHub Actions (lint, type-check, test, build)
 
 ## Tech Stack
 
 - **Build Tool:** Vite
-- **Token Processor:** Style Dictionary 3.9
+- **Token Processor:** Style Dictionary 4.4.0 (DTCG format)
 - **Web Components:** Vanilla TypeScript (Shadow DOM)
 - **React:** 18+
 - **TypeScript:** 5.3+
 - **Testing:** Vitest + React Testing Library
-- **Documentation:** Storybook 7.x
+- **Documentation:** Storybook 7.6
 - **CI/CD:** GitHub Actions
 - **Package Manager:** PNPM 8+
 - **Code Quality:** Husky, lint-staged, ESLint, Prettier

--- a/docs/02-design-tokens-reference.md
+++ b/docs/02-design-tokens-reference.md
@@ -1,6 +1,6 @@
 # Design Tokens Reference
 
-**Last Updated:** March 15, 2026
+**Last Updated:** April 30, 2026
 
 Complete reference for all design tokens in the Design System Starter Kit.
 
@@ -15,6 +15,7 @@ Complete reference for all design tokens in the Design System Starter Kit.
 5. [Borders](#borders)
 6. [Focus States](#focus-states)
 7. [Motion](#motion)
+8. [Breakpoints](#breakpoints)
 
 ---
 
@@ -170,6 +171,29 @@ Icon sizes scale fluidly with the viewport because they reference the fluid `cla
 - **min-block-size:** 3rem (48px)
 - **min-inline-size:** 3rem (48px)
 - **Rationale:** WCAG 2.5.5 Target Size compliance
+
+### Content Sizing
+
+Maximum width constraints for page layout and readable text lines.
+
+| Token                      | CSS Variable                 | Value | Purpose                                            |
+| -------------------------- | ---------------------------- | ----- | -------------------------------------------------- |
+| `dsn.page.max-inline-size` | `--dsn-page-max-inline-size` | 75rem | Maximum content width within page-level components |
+| `dsn.text.max-inline-size` | `--dsn-text-max-inline-size` | 65ch  | Maximum line length for readable body text         |
+
+### Form Control Sizing
+
+Width presets based on expected character count, and a default maximum width cap.
+
+| Token                              | CSS Variable                         | Value | Purpose                                      |
+| ---------------------------------- | ------------------------------------ | ----- | -------------------------------------------- |
+| `dsn.form-control.max-inline-size` | `--dsn-form-control-max-inline-size` | 25rem | Default maximum width when no preset applies |
+| `dsn.form-control.width.xs`        | `--dsn-form-control-width-xs`        | 10ch  | Very short inputs (postal code, year, CVV)   |
+| `dsn.form-control.width.sm`        | `--dsn-form-control-width-sm`        | 14ch  | Short inputs (time HH:MM, short codes)       |
+| `dsn.form-control.width.md`        | `--dsn-form-control-width-md`        | 20ch  | Medium inputs (date, phone number)           |
+| `dsn.form-control.width.lg`        | `--dsn-form-control-width-lg`        | 32ch  | Standard inputs (name, email) — default      |
+| `dsn.form-control.width.xl`        | `--dsn-form-control-width-xl`        | 48ch  | Longer inputs (URL)                          |
+| `dsn.form-control.width.full`      | `--dsn-form-control-width-full`      | 100%  | Full width, responsive to container          |
 
 ---
 
@@ -355,12 +379,25 @@ Five semantic easing curves for consistent motion feel.
 
 ## Token Statistics
 
-**Total Tokens (as of v4.9.0):**
+**Total Tokens (as of v5.32.0):**
 
-- Semantic tokens: ~400 per configuration
-- Component tokens: ~700 (30 component JSON files: 9 content + 3 display/feedback + 25 form, incl. variant kleur-tokens Alert/Note/StatusBadge)
+- Semantic tokens: ~420 per configuration (incl. content sizing, form control sizing, breakpoints)
+- Component tokens: ~700 (component JSON files per categorie: layout, content, display/feedback, navigation, branding, form)
 - **Total: ~1100+ tokens per full configuration**
 - **Total configurations: 8** (2 themes × 2 modes × 2 project types)
+
+---
+
+## Breakpoints
+
+Reference breakpoints for responsive design. Available as CSS custom properties for JavaScript use, but **cannot be used inside CSS `@media` rules** — browsers do not resolve custom properties in media queries. Use the hardcoded `em` values directly in CSS.
+
+| Token               | CSS Variable          | Value | Approx. px |
+| ------------------- | --------------------- | ----- | ---------- |
+| `dsn.breakpoint.sm` | `--dsn-breakpoint-sm` | 36em  | ~576px     |
+| `dsn.breakpoint.md` | `--dsn-breakpoint-md` | 44em  | ~704px     |
+| `dsn.breakpoint.lg` | `--dsn-breakpoint-lg` | 64em  | ~1024px    |
+| `dsn.breakpoint.xl` | `--dsn-breakpoint-xl` | 74em  | ~1184px    |
 
 ---
 

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -2999,15 +2999,15 @@ defineButton('my-custom-button');
 
 ## Component Statistics
 
-**Total Components:** 52
+**Total Components:** 65
 
 **Implementations:**
 
-- **HTML/CSS:** 52 components
-- **React:** 52 components (1380 tests total, 70 test suites)
+- **HTML/CSS:** 65 components
+- **React:** 65 components (1409 tests total, 70 test suites)
 - **Web Component:** 7 components (Button, Heading, Icon, Link, OrderedList, Paragraph, UnorderedList)
 
-**Test Coverage:** 1380 tests across 70 test suites
+**Test Coverage:** 1409 tests across 70 test suites
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,49 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 5.32.0 (April 30, 2026)
+
+### Design Tokens: overzichtspagina uitgebreid met ontbrekende semantische tokens
+
+#### Added
+
+- **Content Sizing** tokens gedocumenteerd in Storybook Design Tokens overzicht:
+  - `--dsn-page-max-inline-size` (75rem): maximale inhoudsbreedte voor page-level componenten
+  - `--dsn-text-max-inline-size` (65ch): maximale regellengte voor leesbare bodytekst
+- **Form Control Sizing** tokens gedocumenteerd: `--dsn-form-control-max-inline-size` (25rem) en zes breedte-presets `xs`–`full` (10ch–100%)
+- **Breakpoints** gedocumenteerd als referentie-sectie: `sm` (36em), `md` (44em), `lg` (64em), `xl` (74em), met toelichting dat ze niet bruikbaar zijn in CSS `@media`-regels
+- `docs/02-design-tokens-reference.md` bijgewerkt met Content Sizing, Form Control Sizing en Breakpoints secties
+
+---
+
+## Version 5.31.0 (April 30, 2026)
+
+### Form flow templates + focus ring fixes + aria-label hernamingen
+
+#### Added
+
+- **FormIntroductionPage template** (issue #198, PR #218): introductietemplate voor meerstappenformulieren
+  - Toont formuliertitel (H1), uitgebreide introductietekst (meerdere paragrafen), en een enkel CTA-formulier met RadioGroup en knop
+  - Gecentreerd via `colStartLg={3} colEndLg={11}` op large viewport
+  - Story staat in de `Templates/Form flow` groep
+- **`dsn.text.max-inline-size` token** (65ch): gedeeld semantic token voor maximale regellengte; toegepast op `dsn-unordered-list` en `dsn-ordered-list` (gelijkgesteld aan `dsn-paragraph`), nieuw token in `base.json` van beide thema's (PR #218)
+
+#### Changed
+
+- **FormStepPage story hernoemd** naar "Form step: Example" en verplaatst naar `Templates/Form flow` groep (PR #217)
+
+#### Fixed
+
+- **PageHeader aria-labels** hernoemd voor consistente navigatie-landmark namen (PR #215):
+  - `'Hoofdmenu'` → `'Hoofd-navigatie'`
+  - `'Servicemenu'` → `'Service-navigatie'`
+- **Focus ring consistentie** voor logo-links en inline-flex componenten (PR #216):
+  - `box-shadow` toegevoegd aan globale `:focus-visible` in `reset.css` voor witte inverse-outline op donkere achtergronden
+  - `display: inline-block` toegevoegd aan logo-link in PageFooter zodat de focus ring als één rechthoek omhult
+  - `align-self: flex-start` toegevoegd aan `.dsn-link` en `.dsn-button` zodat ze niet uitstrekken tot volledige breedte als direct kind van een Stack
+
+---
+
 ## Version 5.30.0 (April 26, 2026)
 
 ### FormStepPage template + GridItem colStart/colEnd + PageHeader hideMenuButton/hideSearchButton

--- a/packages/storybook/src/DesignTokens.mdx
+++ b/packages/storybook/src/DesignTokens.mdx
@@ -23,8 +23,11 @@ Design tokens are the single source of truth for colors, typography, spacing, bo
   <li><TocLink targetId="focus-indicators">Focus Indicators</TocLink></li>
   <li><TocLink targetId="icon-sizes">Icon Sizes</TocLink></li>
   <li><TocLink targetId="pointer-target-sizing">Pointer Target Sizing</TocLink></li>
+  <li><TocLink targetId="content-sizing">Content Sizing</TocLink></li>
+  <li><TocLink targetId="form-control-sizing">Form Control Sizing</TocLink></li>
   <li><TocLink targetId="box-shadows">Box Shadows</TocLink></li>
   <li><TocLink targetId="motion">Motion</TocLink></li>
+  <li><TocLink targetId="breakpoints">Breakpoints</TocLink></li>
 </OrderedList>
 
 ---
@@ -665,6 +668,37 @@ Minimum touch/click target sizes following WCAG 2.5.5 Target Size.
 
 ---
 
+## Content Sizing
+
+Maximum width constraints for page content and readable text lines.
+
+<TokenTable
+  tokens={[
+    { name: 'Page Max Inline Size', cssVar: '--dsn-page-max-inline-size', value: '75rem' },
+    { name: 'Text Max Inline Size', cssVar: '--dsn-text-max-inline-size', value: '65ch' },
+  ]}
+/>
+
+---
+
+## Form Control Sizing
+
+Width presets for form inputs, based on the expected character count of the input value. Use `max-inline-size` as the default cap when no specific width preset applies.
+
+<TokenTable
+  tokens={[
+    { name: 'Max Inline Size', cssVar: '--dsn-form-control-max-inline-size', value: '25rem' },
+    { name: 'Width xs', cssVar: '--dsn-form-control-width-xs', value: '10ch' },
+    { name: 'Width sm', cssVar: '--dsn-form-control-width-sm', value: '14ch' },
+    { name: 'Width md', cssVar: '--dsn-form-control-width-md', value: '20ch' },
+    { name: 'Width lg', cssVar: '--dsn-form-control-width-lg', value: '32ch' },
+    { name: 'Width xl', cssVar: '--dsn-form-control-width-xl', value: '48ch' },
+    { name: 'Width full', cssVar: '--dsn-form-control-width-full', value: '100%' },
+  ]}
+/>
+
+---
+
 ## Box Shadows
 
 Elevation shadows communicate depth: which surface floats above another. Each shadow is composed of two drop shadow layers (direct + ambient) and a spread-only outline layer (highlight). Only the color tokens differ between light and dark mode; the shadow structure is identical.
@@ -724,5 +758,20 @@ Bij `prefers-reduced-motion: reduce` worden alle duration-tokens naar `0ms` geze
     { name: 'Exit', cssVar: '--dsn-transition-easing-exit', value: 'cubic-bezier(0.4, 0, 1, 1)' },
     { name: 'Move', cssVar: '--dsn-transition-easing-move', value: 'cubic-bezier(0.4, 0, 0.2, 1)' },
     { name: 'Linear', cssVar: '--dsn-transition-easing-linear', value: 'linear' },
+  ]}
+/>
+
+---
+
+## Breakpoints
+
+Reference breakpoints for responsive design. These tokens are available as CSS custom properties but **should not be used in CSS `@media` rules** — browsers do not resolve custom properties inside media queries. Use the hardcoded values directly in your CSS.
+
+<TokenTable
+  tokens={[
+    { name: 'sm', cssVar: '--dsn-breakpoint-sm', value: '36em (~576px)' },
+    { name: 'md', cssVar: '--dsn-breakpoint-md', value: '44em (~704px)' },
+    { name: 'lg', cssVar: '--dsn-breakpoint-lg', value: '64em (~1024px)' },
+    { name: 'xl', cssVar: '--dsn-breakpoint-xl', value: '74em (~1184px)' },
   ]}
 />


### PR DESCRIPTION
## Summary

- **DesignTokens.mdx**: drie nieuwe secties toegevoegd aan het Storybook token-overzicht: Content Sizing (`--dsn-page-max-inline-size`, `--dsn-text-max-inline-size`), Form Control Sizing (7 tokens) en Breakpoints (4 referentie-tokens) — geen preview voor deze tokens
- **docs/02-design-tokens-reference.md**: zelfde nieuwe secties gedocumenteerd, datum bijgewerkt naar april 2026, token statistics bijgewerkt
- **docs/03-components.md**: component statistieken bijgewerkt (52 → 65 componenten, 1380 → 1409 tests)
- **README.md**: 7 ontbrekende componenten toegevoegd (ActionGroup, PageBody, PageLayout, PageFooter, Drawer, ModalDialog, Logo), nieuwe Branding-categorie, Style Dictionary 3.9 → 4.4.0, Storybook 7.x → 7.6, testcount 1364 → 1409
- **docs/changelog.md**: versie-entries 5.31.0 (PRs #215–#218) en 5.32.0 (deze PR) toegevoegd

## Test plan

- [ ] Storybook openen en navigeren naar Foundations/Design Tokens
- [ ] Controleer dat de drie nieuwe secties (Content Sizing, Form Control Sizing, Breakpoints) zichtbaar zijn in de inhoudsopgave en op de pagina
- [ ] README.md componenttelling en tech stack controleren op juistheid

🤖 Generated with [Claude Code](https://claude.com/claude-code)