### PR TITLE
fix(Templates): extraheer gedeelde footer/logo slots naar templateSharedContent

### DIFF
--- a/packages/storybook/src/templates/BasePage.stories.tsx
+++ b/packages/storybook/src/templates/BasePage.stories.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   Heading,
   Link,
-  Logo,
   Menu,
   MenuLink,
   PageBody,
@@ -16,21 +15,18 @@ import {
   Paragraph,
   SearchInput,
   SkipLink,
-  UnorderedList,
 } from '@dsn/components-react';
+import {
+  logoSlot,
+  footerSlot1,
+  footerSlot2,
+  footerSlot3,
+  footerSlot4,
+} from './templateSharedContent';
 
 // =============================================================================
 // GEDEELDE CONTENT (identiek aan PageLayout/PageHeader/PageFooter stories)
 // =============================================================================
-
-const logoSlot = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
 
 function PrimaryNavigation() {
   const [exp1b, setExp1b] = React.useState(false);
@@ -165,55 +161,6 @@ const searchSlot = (
     <SearchInput placeholder="Zoeken…" aria-label="Zoekopdracht" />
     <Button variant="strong">Zoeken</Button>
   </>
-);
-
-const footerSlot1 = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
-
-const footerSlot2 = (
-  <Paragraph>
-    Dit is een voorbeeldorganisatie. <Link href="/about">Meer informatie</Link>.
-  </Paragraph>
-);
-
-const footerSlot3 = (
-  <UnorderedList>
-    <li>
-      <Link href="/nieuws">Nieuws</Link>
-    </li>
-    <li>
-      <Link href="/over-ons">Over ons</Link>
-    </li>
-    <li>
-      <Link href="/werken-bij">Werken bij</Link>
-    </li>
-    <li>
-      <Link href="/klachten">Klachten</Link>
-    </li>
-  </UnorderedList>
-);
-
-const footerSlot4 = (
-  <UnorderedList>
-    <li>
-      <Link href="/privacy">Privacyverklaring</Link>
-    </li>
-    <li>
-      <Link href="/accessibility">Toegankelijkheid</Link>
-    </li>
-    <li>
-      <Link href="/cookies">Cookies</Link>
-    </li>
-    <li>
-      <Link href="/contact">Contact</Link>
-    </li>
-  </UnorderedList>
 );
 
 // Padding op <main>: 64px boven/onder (--dsn-space-block-6xl),

--- a/packages/storybook/src/templates/FormIntroductionPage.stories.tsx
+++ b/packages/storybook/src/templates/FormIntroductionPage.stories.tsx
@@ -6,7 +6,6 @@ import {
   Grid,
   GridItem,
   Heading,
-  Logo,
   PageBody,
   PageFooter,
   PageHeader,
@@ -16,64 +15,17 @@ import {
   Stack,
   UnorderedList,
 } from '@dsn/components-react';
+import {
+  logoSlot,
+  footerSlot1,
+  footerSlot2,
+  footerSlot3,
+  footerSlot4,
+} from './templateSharedContent';
 
 // =============================================================================
 // GEDEELDE CONTENT
 // =============================================================================
-
-const logoSlot = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
-
-const footerSlot1 = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
-
-const footerSlot2 = <Paragraph>Dit is een voorbeeldorganisatie.</Paragraph>;
-
-const footerSlot3 = (
-  <UnorderedList>
-    <li>
-      <a href="/nieuws">Nieuws</a>
-    </li>
-    <li>
-      <a href="/over-ons">Over ons</a>
-    </li>
-    <li>
-      <a href="/werken-bij">Werken bij</a>
-    </li>
-    <li>
-      <a href="/klachten">Klachten</a>
-    </li>
-  </UnorderedList>
-);
-
-const footerSlot4 = (
-  <UnorderedList>
-    <li>
-      <a href="/privacy">Privacyverklaring</a>
-    </li>
-    <li>
-      <a href="/accessibility">Toegankelijkheid</a>
-    </li>
-    <li>
-      <a href="/cookies">Cookies</a>
-    </li>
-    <li>
-      <a href="/contact">Contact</a>
-    </li>
-  </UnorderedList>
-);
 
 const mainStyle: React.CSSProperties = {
   paddingBlock: 'var(--dsn-space-block-6xl)',

--- a/packages/storybook/src/templates/FormStepPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepPage.stories.tsx
@@ -12,7 +12,6 @@ import {
   Icon,
   Link,
   LinkButton,
-  Logo,
   PageBody,
   PageFooter,
   PageHeader,
@@ -24,70 +23,18 @@ import {
   Stack,
   TelephoneInput,
   TextInput,
-  UnorderedList,
 } from '@dsn/components-react';
+import {
+  logoSlot,
+  footerSlot1,
+  footerSlot2,
+  footerSlot3,
+  footerSlot4,
+} from './templateSharedContent';
 
 // =============================================================================
 // GEDEELDE CONTENT
 // =============================================================================
-
-const logoSlot = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
-
-const footerSlot1 = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
-
-const footerSlot2 = (
-  <Paragraph>
-    Dit is een voorbeeldorganisatie. <Link href="/about">Meer informatie</Link>.
-  </Paragraph>
-);
-
-const footerSlot3 = (
-  <UnorderedList>
-    <li>
-      <Link href="/nieuws">Nieuws</Link>
-    </li>
-    <li>
-      <Link href="/over-ons">Over ons</Link>
-    </li>
-    <li>
-      <Link href="/werken-bij">Werken bij</Link>
-    </li>
-    <li>
-      <Link href="/klachten">Klachten</Link>
-    </li>
-  </UnorderedList>
-);
-
-const footerSlot4 = (
-  <UnorderedList>
-    <li>
-      <Link href="/privacy">Privacyverklaring</Link>
-    </li>
-    <li>
-      <Link href="/accessibility">Toegankelijkheid</Link>
-    </li>
-    <li>
-      <Link href="/cookies">Cookies</Link>
-    </li>
-    <li>
-      <Link href="/contact">Contact</Link>
-    </li>
-  </UnorderedList>
-);
 
 const mainStyle: React.CSSProperties = {
   paddingBlock: 'var(--dsn-space-block-6xl)',

--- a/packages/storybook/src/templates/GridPage.stories.tsx
+++ b/packages/storybook/src/templates/GridPage.stories.tsx
@@ -8,8 +8,6 @@ import {
   Grid,
   GridItem,
   Heading,
-  Link,
-  Logo,
   Menu,
   MenuLink,
   PageBody,
@@ -20,21 +18,18 @@ import {
   SearchInput,
   SkipLink,
   Stack,
-  UnorderedList,
 } from '@dsn/components-react';
+import {
+  logoSlot,
+  footerSlot1,
+  footerSlot2,
+  footerSlot3,
+  footerSlot4,
+} from './templateSharedContent';
 
 // =============================================================================
 // GEDEELDE CONTENT (identiek aan BasePage stories)
 // =============================================================================
-
-const logoSlot = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
 
 function PrimaryNavigation() {
   const [exp1b, setExp1b] = React.useState(false);
@@ -123,55 +118,6 @@ const searchSlot = (
     <SearchInput placeholder="Zoeken…" aria-label="Zoekopdracht" />
     <Button variant="strong">Zoeken</Button>
   </>
-);
-
-const footerSlot1 = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
-
-const footerSlot2 = (
-  <Paragraph>
-    Dit is een voorbeeldorganisatie. <Link href="/about">Meer informatie</Link>.
-  </Paragraph>
-);
-
-const footerSlot3 = (
-  <UnorderedList>
-    <li>
-      <Link href="/nieuws">Nieuws</Link>
-    </li>
-    <li>
-      <Link href="/over-ons">Over ons</Link>
-    </li>
-    <li>
-      <Link href="/werken-bij">Werken bij</Link>
-    </li>
-    <li>
-      <Link href="/klachten">Klachten</Link>
-    </li>
-  </UnorderedList>
-);
-
-const footerSlot4 = (
-  <UnorderedList>
-    <li>
-      <Link href="/privacy">Privacyverklaring</Link>
-    </li>
-    <li>
-      <Link href="/accessibility">Toegankelijkheid</Link>
-    </li>
-    <li>
-      <Link href="/cookies">Cookies</Link>
-    </li>
-    <li>
-      <Link href="/contact">Contact</Link>
-    </li>
-  </UnorderedList>
 );
 
 const mainStyle: React.CSSProperties = {

--- a/packages/storybook/src/templates/HomePage.stories.tsx
+++ b/packages/storybook/src/templates/HomePage.stories.tsx
@@ -10,8 +10,6 @@ import {
   GridItem,
   Heading,
   Hero,
-  Link,
-  Logo,
   Menu,
   MenuLink,
   PageBody,
@@ -22,21 +20,18 @@ import {
   SearchInput,
   SkipLink,
   Stack,
-  UnorderedList,
 } from '@dsn/components-react';
+import {
+  logoSlot,
+  footerSlot1,
+  footerSlot2,
+  footerSlot3,
+  footerSlot4,
+} from './templateSharedContent';
 
 // =============================================================================
 // GEDEELDE CONTENT (identiek aan GridPage stories)
 // =============================================================================
-
-const logoSlot = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
 
 function PrimaryNavigation() {
   const [exp1b, setExp1b] = React.useState(false);
@@ -179,55 +174,6 @@ const searchSlot = (
     <SearchInput placeholder="Zoeken…" aria-label="Zoekopdracht" />
     <Button variant="strong">Zoeken</Button>
   </>
-);
-
-const footerSlot1 = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
-
-const footerSlot2 = (
-  <Paragraph>
-    Dit is een voorbeeldorganisatie. <Link href="/about">Meer informatie</Link>.
-  </Paragraph>
-);
-
-const footerSlot3 = (
-  <UnorderedList>
-    <li>
-      <Link href="/nieuws">Nieuws</Link>
-    </li>
-    <li>
-      <Link href="/over-ons">Over ons</Link>
-    </li>
-    <li>
-      <Link href="/werken-bij">Werken bij</Link>
-    </li>
-    <li>
-      <Link href="/klachten">Klachten</Link>
-    </li>
-  </UnorderedList>
-);
-
-const footerSlot4 = (
-  <UnorderedList>
-    <li>
-      <Link href="/privacy">Privacyverklaring</Link>
-    </li>
-    <li>
-      <Link href="/accessibility">Toegankelijkheid</Link>
-    </li>
-    <li>
-      <Link href="/cookies">Cookies</Link>
-    </li>
-    <li>
-      <Link href="/contact">Contact</Link>
-    </li>
-  </UnorderedList>
 );
 
 const IMAGE_URL = 'https://picsum.photos/id/1043/1600/900';

--- a/packages/storybook/src/templates/WithSidebarPage.stories.tsx
+++ b/packages/storybook/src/templates/WithSidebarPage.stories.tsx
@@ -9,8 +9,6 @@ import {
   Grid,
   GridItem,
   Heading,
-  Link,
-  Logo,
   Menu,
   MenuLink,
   PageBody,
@@ -21,8 +19,14 @@ import {
   SearchInput,
   SkipLink,
   Stack,
-  UnorderedList,
 } from '@dsn/components-react';
+import {
+  logoSlot,
+  footerSlot1,
+  footerSlot2,
+  footerSlot3,
+  footerSlot4,
+} from './templateSharedContent';
 
 // =============================================================================
 // TYPES
@@ -38,15 +42,6 @@ type CurrentPage =
 // =============================================================================
 // GEDEELDE CONTENT
 // =============================================================================
-
-const logoSlot = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
 
 function PrimaryNavigation({
   currentPage = 'homepage',
@@ -207,55 +202,6 @@ const searchSlot = (
     <SearchInput placeholder="Zoeken…" aria-label="Zoekopdracht" />
     <Button variant="strong">Zoeken</Button>
   </>
-);
-
-const footerSlot1 = (
-  <a href="/">
-    <Logo aria-hidden={true} />
-    <span className="dsn-visually-hidden">
-      Starter Kit — terug naar homepage
-    </span>
-  </a>
-);
-
-const footerSlot2 = (
-  <Paragraph>
-    Dit is een voorbeeldorganisatie. <Link href="/about">Meer informatie</Link>.
-  </Paragraph>
-);
-
-const footerSlot3 = (
-  <UnorderedList>
-    <li>
-      <Link href="/nieuws">Nieuws</Link>
-    </li>
-    <li>
-      <Link href="/over-ons">Over ons</Link>
-    </li>
-    <li>
-      <Link href="/werken-bij">Werken bij</Link>
-    </li>
-    <li>
-      <Link href="/klachten">Klachten</Link>
-    </li>
-  </UnorderedList>
-);
-
-const footerSlot4 = (
-  <UnorderedList>
-    <li>
-      <Link href="/privacy">Privacyverklaring</Link>
-    </li>
-    <li>
-      <Link href="/accessibility">Toegankelijkheid</Link>
-    </li>
-    <li>
-      <Link href="/cookies">Cookies</Link>
-    </li>
-    <li>
-      <Link href="/contact">Contact</Link>
-    </li>
-  </UnorderedList>
 );
 
 const mainStyle: React.CSSProperties = {

--- a/packages/storybook/src/templates/templateSharedContent.tsx
+++ b/packages/storybook/src/templates/templateSharedContent.tsx
@@ -1,0 +1,59 @@
+import { Link, Logo, Paragraph, UnorderedList } from '@dsn/components-react';
+
+export const logoSlot = (
+  <a href="/">
+    <Logo aria-hidden={true} />
+    <span className="dsn-visually-hidden">
+      Starter Kit — terug naar homepage
+    </span>
+  </a>
+);
+
+export const footerSlot1 = (
+  <a href="/">
+    <Logo aria-hidden={true} />
+    <span className="dsn-visually-hidden">
+      Starter Kit — terug naar homepage
+    </span>
+  </a>
+);
+
+export const footerSlot2 = (
+  <Paragraph>
+    Dit is een voorbeeldorganisatie. <Link href="/about">Meer informatie</Link>.
+  </Paragraph>
+);
+
+export const footerSlot3 = (
+  <UnorderedList>
+    <li>
+      <Link href="/nieuws">Nieuws</Link>
+    </li>
+    <li>
+      <Link href="/over-ons">Over ons</Link>
+    </li>
+    <li>
+      <Link href="/werken-bij">Werken bij</Link>
+    </li>
+    <li>
+      <Link href="/klachten">Klachten</Link>
+    </li>
+  </UnorderedList>
+);
+
+export const footerSlot4 = (
+  <UnorderedList>
+    <li>
+      <Link href="/privacy">Privacyverklaring</Link>
+    </li>
+    <li>
+      <Link href="/accessibility">Toegankelijkheid</Link>
+    </li>
+    <li>
+      <Link href="/cookies">Cookies</Link>
+    </li>
+    <li>
+      <Link href="/contact">Contact</Link>
+    </li>
+  </UnorderedList>
+);


### PR DESCRIPTION
## Samenvatting

- De footer van de Introduction page week af van die op andere templates (plain `<a>` tags, ontbrekende 'Meer informatie' link)
- Alle 6 template stories dupliceerden dezelfde `logoSlot` en `footerSlot1-4` — dat maakte zulke divergentie onvermijdelijk
- Dit PR extraheert die gedeelde content naar `templateSharedContent.tsx`; alle templates importeren er nu uit

## Aanpak

- Nieuw bestand: `packages/storybook/src/templates/templateSharedContent.tsx`
- Alle 6 stories (`BasePage`, `GridPage`, `HomePage`, `WithSidebarPage`, `FormStepPage`, `FormIntroductionPage`) verwijzen nu naar de gedeelde exports
- Ongebruikte imports (`Logo`, `UnorderedList`, en waar van toepassing `Link`) verwijderd uit de individuele bestanden
- `pnpm --filter storybook exec tsc --noEmit` — 0 fouten

## Testplan

- [ ] Storybook: footer op alle template stories ziet er identiek uit
- [ ] TypeScript: geen nieuwe fouten
- [ ] CI groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)