### PR TITLE
feat(Spinner): cirkelvormige laadindicator voor onbepaalde wachttijden

### DIFF
--- a/packages/components-html/src/spinner/spinner.css
+++ b/packages/components-html/src/spinner/spinner.css
@@ -1,0 +1,100 @@
+/**
+ * Spinner Component
+ * Cirkelvormige laadindicator voor onbepaalde wachttijden.
+ *
+ * role="status" op de container maakt de laadtoestand toegankelijk voor screenreaders.
+ * De SVG-cirkel is decoratief (aria-hidden="true") — het label geeft de toegankelijke naam.
+ *
+ * Usage:
+ * <!-- Standaard (label rechts) -->
+ * <div class="dsn-spinner" role="status">
+ *   <svg class="dsn-spinner__circle" viewBox="0 0 24 24" aria-hidden="true">
+ *     <circle class="dsn-spinner__track" cx="12" cy="12" r="10" />
+ *     <circle class="dsn-spinner__arc" cx="12" cy="12" r="10" />
+ *   </svg>
+ *   <span class="dsn-spinner__label">Laden...</span>
+ * </div>
+ *
+ * <!-- Grote variant (label gecentreerd onder spinner) -->
+ * <div class="dsn-spinner dsn-spinner--large" role="status">
+ *   <svg class="dsn-spinner__circle" viewBox="0 0 24 24" aria-hidden="true">
+ *     <circle class="dsn-spinner__track" cx="12" cy="12" r="10" />
+ *     <circle class="dsn-spinner__arc" cx="12" cy="12" r="10" />
+ *   </svg>
+ *   <span class="dsn-spinner__label">Laden...</span>
+ * </div>
+ *
+ * <!-- Visueel verborgen label (toegankelijk voor screenreaders via dsn-visually-hidden) -->
+ * <div class="dsn-spinner" role="status">
+ *   <svg class="dsn-spinner__circle" viewBox="0 0 24 24" aria-hidden="true">
+ *     <circle class="dsn-spinner__track" cx="12" cy="12" r="10" />
+ *     <circle class="dsn-spinner__arc" cx="12" cy="12" r="10" />
+ *   </svg>
+ *   <span class="dsn-spinner__label dsn-visually-hidden">Laden...</span>
+ * </div>
+ */
+
+.dsn-spinner {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--dsn-spinner-gap-size);
+}
+
+.dsn-spinner--large {
+  flex-direction: column;
+  align-items: center;
+}
+
+.dsn-spinner__circle {
+  flex-shrink: 0;
+  width: var(--dsn-spinner-size);
+  height: var(--dsn-spinner-size);
+  animation: dsn-spinner-rotate var(--dsn-spinner-duration) linear infinite;
+  transform-origin: center;
+}
+
+.dsn-spinner--large .dsn-spinner__circle {
+  width: var(--dsn-spinner-size-large);
+  height: var(--dsn-spinner-size-large);
+}
+
+/* Baan: volledige achtergrondcirkel als visuele rails */
+.dsn-spinner__track {
+  fill: none;
+  stroke: var(--dsn-spinner-track-color);
+  stroke-width: var(--dsn-spinner-stroke-width);
+}
+
+/* Boog: gedeeltelijke cirkel die de animatie zichtbaar maakt */
+.dsn-spinner__arc {
+  fill: none;
+  stroke: var(--dsn-spinner-color);
+  stroke-width: var(--dsn-spinner-stroke-width);
+  stroke-linecap: round;
+  /* 75% zichtbaar (47.12 van 62.83 omtrek), 25% gap — bij r=10 in 24-unit viewBox */
+  stroke-dasharray: 47 16;
+}
+
+@keyframes dsn-spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* prefers-reduced-motion: subtiel pulseren i.p.v. roteren */
+@media (prefers-reduced-motion: reduce) {
+  .dsn-spinner__circle {
+    animation: dsn-spinner-pulse var(--dsn-spinner-duration) ease-in-out
+      infinite alternate;
+  }
+}
+
+@keyframes dsn-spinner-pulse {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0.3;
+  }
+}

--- a/packages/components-react/src/Spinner/Spinner.css
+++ b/packages/components-react/src/Spinner/Spinner.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/spinner/spinner.css';

--- a/packages/components-react/src/Spinner/Spinner.test.tsx
+++ b/packages/components-react/src/Spinner/Spinner.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Spinner } from './Spinner';
+
+describe('Spinner', () => {
+  it('renders as a <div> element', () => {
+    const { container } = render(<Spinner label="Laden..." />);
+    expect(container.firstChild?.nodeName).toBe('DIV');
+  });
+
+  it('always has base dsn-spinner class', () => {
+    const { container } = render(<Spinner label="Laden..." />);
+    expect(container.firstChild).toHaveClass('dsn-spinner');
+  });
+
+  it('always has role="status"', () => {
+    const { container } = render(<Spinner label="Laden..." />);
+    expect(container.firstChild).toHaveAttribute('role', 'status');
+  });
+
+  it('renders an SVG with aria-hidden="true"', () => {
+    const { container } = render(<Spinner label="Laden..." />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders track and arc circles', () => {
+    const { container } = render(<Spinner label="Laden..." />);
+    const circles = container.querySelectorAll('circle');
+    expect(circles).toHaveLength(2);
+    expect(circles[0]).toHaveClass('dsn-spinner__track');
+    expect(circles[1]).toHaveClass('dsn-spinner__arc');
+  });
+
+  it('renders the label text', () => {
+    const { getByText } = render(<Spinner label="Laden..." />);
+    expect(getByText('Laden...')).toBeInTheDocument();
+  });
+
+  it('does not apply large class by default', () => {
+    const { container } = render(<Spinner label="Laden..." />);
+    expect(container.firstChild).not.toHaveClass('dsn-spinner--large');
+  });
+
+  it('applies large modifier class when size is large', () => {
+    const { container } = render(<Spinner label="Laden..." size="large" />);
+    expect(container.firstChild).toHaveClass('dsn-spinner--large');
+  });
+
+  it('does not apply dsn-visually-hidden to label by default', () => {
+    const { container } = render(<Spinner label="Laden..." />);
+    const label = container.querySelector('.dsn-spinner__label');
+    expect(label).not.toHaveClass('dsn-visually-hidden');
+  });
+
+  it('applies dsn-visually-hidden to label when hideLabel is true', () => {
+    const { container } = render(<Spinner label="Laden..." hideLabel />);
+    const label = container.querySelector('.dsn-spinner__label');
+    expect(label).toHaveClass('dsn-visually-hidden');
+  });
+
+  it('label always present in DOM when hideLabel is true', () => {
+    const { getByText } = render(<Spinner label="Laden..." hideLabel />);
+    expect(getByText('Laden...')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <Spinner label="Laden..." className="custom" />
+    );
+    expect(container.firstChild).toHaveClass('dsn-spinner');
+    expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('forwards ref', () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(<Spinner label="Laden..." ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('spreads additional HTML attributes', () => {
+    const { container } = render(
+      <Spinner label="Laden..." data-testid="spinner" />
+    );
+    expect(container.firstChild).toHaveAttribute('data-testid', 'spinner');
+  });
+});

--- a/packages/components-react/src/Spinner/Spinner.tsx
+++ b/packages/components-react/src/Spinner/Spinner.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { classNames } from '@dsn/core';
+import './Spinner.css';
+
+export type SpinnerSize = 'default' | 'large';
+
+export interface SpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Tekstlabel dat de laadtoestand beschrijft voor alle gebruikers.
+   * Altijd vereist — ook bij hideLabel wordt het label doorgegeven aan screenreaders.
+   */
+  label: string;
+
+  /**
+   * Verbergt het label visueel maar behoudt het voor screenreaders via dsn-visually-hidden
+   * @default false
+   */
+  hideLabel?: boolean;
+
+  /**
+   * Grootte van de spinner.
+   * default: 24×24px, label rechts.
+   * large: 48×48px, label gecentreerd onder de spinner.
+   * @default 'default'
+   */
+  size?: SpinnerSize;
+}
+
+/**
+ * Spinner component
+ * Cirkelvormige laadindicator voor onbepaalde wachttijden.
+ *
+ * role="status" op de container kondigt de laadtoestand aan bij screenreaders.
+ * Het label is altijd aanwezig — visueel verbergen via hideLabel behoudt toegankelijkheid.
+ *
+ * @example
+ * ```tsx
+ * // Standaard met zichtbaar label
+ * <Spinner label="Laden..." />
+ *
+ * // Grote variant met label onder de spinner
+ * <Spinner size="large" label="Pagina wordt geladen" />
+ *
+ * // Enkel visueel verborgen label (toegankelijk voor screenreaders)
+ * <Spinner label="Laden..." hideLabel />
+ * ```
+ */
+export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
+  (
+    { className, label, hideLabel = false, size = 'default', ...props },
+    ref
+  ) => {
+    const classes = classNames(
+      'dsn-spinner',
+      size === 'large' && 'dsn-spinner--large',
+      className
+    );
+
+    const labelClasses = classNames(
+      'dsn-spinner__label',
+      hideLabel && 'dsn-visually-hidden'
+    );
+
+    return (
+      <div ref={ref} className={classes} role="status" {...props}>
+        <svg
+          className="dsn-spinner__circle"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <circle className="dsn-spinner__track" cx="12" cy="12" r="10" />
+          <circle className="dsn-spinner__arc" cx="12" cy="12" r="10" />
+        </svg>
+        <span className={labelClasses}>{label}</span>
+      </div>
+    );
+  }
+);
+
+Spinner.displayName = 'Spinner';

--- a/packages/components-react/src/Spinner/index.ts
+++ b/packages/components-react/src/Spinner/index.ts
@@ -1,0 +1,1 @@
+export * from './Spinner';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -52,6 +52,7 @@ export * from './OptionLabel';
 // Display & Feedback Components
 export * from './Backdrop';
 export * from './DotBadge';
+export * from './Spinner';
 export * from './NumberBadge';
 export * from './StatusBadge';
 export * from './Alert';

--- a/packages/design-tokens/src/tokens/components/spinner.json
+++ b/packages/design-tokens/src/tokens/components/spinner.json
@@ -1,0 +1,38 @@
+{
+  "dsn": {
+    "spinner": {
+      "size": {
+        "$value": "1.5rem",
+        "$type": "dimension",
+        "$description": "Diameter van de spinner (24px)"
+      },
+      "size-large": {
+        "$value": "3rem",
+        "$type": "dimension",
+        "$description": "Grote variant — diameter van de spinner (48px)"
+      },
+      "stroke-width": {
+        "$value": "{dsn.border.width.medium}",
+        "$type": "dimension",
+        "$description": "Lijndikte van de boog — identiek aan border.width.medium voor visuele consistentie"
+      },
+      "color": {
+        "$value": "{dsn.color.accent-1.color-default}",
+        "$description": "Kleur van de draaiende boog"
+      },
+      "track-color": {
+        "$value": "{dsn.color.neutral.bg-subtle}",
+        "$description": "Achtergrondkleur van de cirkelbaan"
+      },
+      "duration": {
+        "$value": "800ms",
+        "$type": "duration",
+        "$description": "Duur van één rotatie — bewust sneller dan transition.duration.slower (500ms): dit is een herhalende ambient animatie"
+      },
+      "gap-size": {
+        "$value": "{dsn.space.inline.md}",
+        "$description": "Ruimte tussen spinner en label"
+      }
+    }
+  }
+}

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -87,7 +87,7 @@ function App() {
 - **Link**: Hyperlinks met icon ondersteuning en externe link handling
 - **Lists**: OrderedList en UnorderedList
 
-### Display & Feedback Components (11)
+### Display & Feedback Components (12)
 
 - **Backdrop**: Vaste, volledig-scherm overlay die de achtergrondinhoud verhult achter een Modal Dialog of Drawer: puur decoratief (`aria-hidden="true"`)
 - **DotBadge**: Kleine gekleurde stip bij een Button of Link die zonder label de aandacht trekt bij een statuswijziging (met optioneel pulse-effect)
@@ -100,6 +100,7 @@ function App() {
 - **Image**: Performante, toegankelijke wrapper rond het native `<img>` element met ingebakken lazy loading, vaste beeldverhoudingen en LCP-prioriteit
 - **Card**: Configureerbare container voor gestructureerde content (afbeelding, heading, beschrijving, actie) met stretched-link techniek en CardGroup voor gelijke hoogte
 - **ModalDialog**: Modaal dialoogvenster voor korte, gefocuste acties (bevestigen, kleine keuze): blokkeert achtergrond via native `<dialog>` met focus-trap
+- **Spinner**: Cirkelvormige laadindicator voor onbepaalde wachttijden, met `role="status"` en altijd een toegankelijk label
 - **Popover**: Lichtgewicht contextgebonden overlay verankerd aan een triggerelement: niet-modaal, light-dismiss via HTML Popover API, composable met PopoverHeader/Body/Footer
 
 ### Branding Components (1)

--- a/packages/storybook/src/Spinner.docs.md
+++ b/packages/storybook/src/Spinner.docs.md
@@ -1,0 +1,102 @@
+# Spinner
+
+Cirkelvormige laadindicator voor onbepaalde wachttijden.
+
+## Doel
+
+Spinner geeft aan dat een actie in uitvoering is waarvan de duur niet van tevoren bekend is. De component bestaat uit een animerende boog en een tekstlabel dat de laadtoestand beschrijft. De standaardvariant plaatst het label rechts van de spinner; de grote variant centreert het label eronder.
+
+De spinner heeft `role="status"` zodat screenreaders de laadtoestand aankondigen. Het label is altijd aanwezig in de DOM: ook bij `hideLabel` blijft het beschikbaar voor screenreaders.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Een actie loopt en de gebruiker moet wachten, maar de voortgang kan niet worden gemeten.
+- Korte laadacties na een gebruikersinteractie: een formulier dat wordt verstuurd, een zoekopdracht die wordt uitgevoerd.
+- Een sectie van een pagina laadt asynchroon.
+
+## Don't use when
+
+- De voortgang wel meetbaar is: gebruik dan een voortgangsbalk.
+- De wachttijd langer dan een paar seconden duurt: geef dan extra context over wat er gebeurt.
+- De spinner enkel decoratief is zonder betekenis voor de gebruiker: gebruik dan een loading skeleton.
+
+## Best practices
+
+### Labelkeuze
+
+Het label beschrijft altijd wat er geladen wordt, niet alleen "Laden...". Geef de gebruiker zoveel mogelijk context:
+
+```html
+<!-- Minder informatief -->
+<div class="dsn-spinner" role="status">
+  <svg class="dsn-spinner__circle" viewBox="0 0 24 24" aria-hidden="true">
+    <circle class="dsn-spinner__track" cx="12" cy="12" r="10" />
+    <circle class="dsn-spinner__arc" cx="12" cy="12" r="10" />
+  </svg>
+  <span class="dsn-spinner__label">Laden...</span>
+</div>
+
+<!-- Meer informatief -->
+<div class="dsn-spinner" role="status">
+  <svg class="dsn-spinner__circle" viewBox="0 0 24 24" aria-hidden="true">
+    <circle class="dsn-spinner__track" cx="12" cy="12" r="10" />
+    <circle class="dsn-spinner__arc" cx="12" cy="12" r="10" />
+  </svg>
+  <span class="dsn-spinner__label">Zoekresultaten worden geladen</span>
+</div>
+```
+
+### Visueel verborgen label
+
+Gebruik `hideLabel` (of de CSS-klasse `dsn-visually-hidden` op het label) wanneer de context al duidelijk maakt dat er geladen wordt, maar het label visueel storend zou zijn:
+
+```html
+<div class="dsn-spinner" role="status">
+  <svg class="dsn-spinner__circle" viewBox="0 0 24 24" aria-hidden="true">
+    <circle class="dsn-spinner__track" cx="12" cy="12" r="10" />
+    <circle class="dsn-spinner__arc" cx="12" cy="12" r="10" />
+  </svg>
+  <span class="dsn-spinner__label dsn-visually-hidden">Laden...</span>
+</div>
+```
+
+### Groottekeuze
+
+- Gebruik de standaardgrootte (24px) voor inline laadstates, zoals na knoppen of binnen formulieren.
+- Gebruik de grote variant (48px) voor het laden van een volledige pagina of een groot inhoudsgebied.
+
+```html
+<!-- Groot — label onder spinner, gecentreerd -->
+<div class="dsn-spinner dsn-spinner--large" role="status">
+  <svg class="dsn-spinner__circle" viewBox="0 0 24 24" aria-hidden="true">
+    <circle class="dsn-spinner__track" cx="12" cy="12" r="10" />
+    <circle class="dsn-spinner__arc" cx="12" cy="12" r="10" />
+  </svg>
+  <span class="dsn-spinner__label">Pagina wordt geladen</span>
+</div>
+```
+
+### Animatie en bewegingsvoorkeur
+
+De rotatie-animatie respecteert `prefers-reduced-motion: reduce`. Bij verminderde bewegingsvoorkeur wordt de rotatie vervangen door een subtiel pulserende opaciteitsanimatie. De spinner blijft zichtbaar en toegankelijk.
+
+## Design tokens
+
+| Token                        | Beschrijving                                                             |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| `--dsn-spinner-size`         | Diameter van de standaard spinner (24px)                                 |
+| `--dsn-spinner-size-large`   | Diameter van de grote variant (48px)                                     |
+| `--dsn-spinner-stroke-width` | Lijndikte van de boog — delegeert naar `--dsn-border-width-medium` (2px) |
+| `--dsn-spinner-color`        | Kleur van de draaiende boog (accent-1)                                   |
+| `--dsn-spinner-track-color`  | Achtergrondkleur van de cirkelbaan (neutral-bg-subtle)                   |
+| `--dsn-spinner-duration`     | Duur van één rotatie (800ms)                                             |
+| `--dsn-spinner-gap-size`     | Ruimte tussen spinner en label                                           |
+
+## Accessibility
+
+- De container heeft altijd `role="status"` zodat screenreaders de laadtoestand aankondigen.
+- De SVG-cirkel heeft altijd `aria-hidden="true"`: puur decoratief, geen semantische waarde.
+- Het label is altijd aanwezig in de DOM: `hideLabel` verbergt het visueel via `dsn-visually-hidden`, maar houdt het beschikbaar voor screenreaders.
+- De rotatie-animatie respecteert `prefers-reduced-motion: reduce`: bij verminderde bewegingsvoorkeur wordt de rotatie vervangen door een subtiel pulseren.

--- a/packages/storybook/src/Spinner.docs.mdx
+++ b/packages/storybook/src/Spinner.docs.mdx
@@ -1,0 +1,31 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as SpinnerStories from './Spinner.stories';
+import docs from './Spinner.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={SpinnerStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={SpinnerStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={SpinnerStories.Default}
+  html={`<div class="dsn-spinner" role="status">
+  <svg class="dsn-spinner__circle" viewBox="0 0 24 24" aria-hidden="true">
+    <circle class="dsn-spinner__track" cx="12" cy="12" r="10" />
+    <circle class="dsn-spinner__arc" cx="12" cy="12" r="10" />
+  </svg>
+  <span class="dsn-spinner__label">Laden...</span>
+</div>`}
+/>
+
+<Controls of={SpinnerStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/Spinner.stories.tsx
+++ b/packages/storybook/src/Spinner.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Spinner } from '@dsn/components-react';
+import DocsPage from './Spinner.docs.mdx';
+
+const meta: Meta<typeof Spinner> = {
+  title: 'Components/Spinner',
+  component: Spinner,
+  parameters: {
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const large = args.size === 'large' ? ' dsn-spinner--large' : '';
+        const labelClass = args.hideLabel
+          ? ' dsn-spinner__label dsn-visually-hidden'
+          : ' dsn-spinner__label';
+        const label = args.label ?? 'Laden...';
+        return `<div class="dsn-spinner${large}" role="status">
+  <svg class="dsn-spinner__circle" viewBox="0 0 24 24" aria-hidden="true">
+    <circle class="dsn-spinner__track" cx="12" cy="12" r="10" />
+    <circle class="dsn-spinner__arc" cx="12" cy="12" r="10" />
+  </svg>
+  <span class="${labelClass}">${label}</span>
+</div>`;
+      },
+    },
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['default', 'large'],
+    },
+    hideLabel: { control: 'boolean' },
+    label: { control: 'text' },
+  },
+  args: {
+    label: 'Laden...',
+    size: 'default',
+    hideLabel: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Spinner>;
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {};
+
+// =============================================================================
+// GROOTTEN
+// =============================================================================
+
+export const Large: Story = {
+  name: 'Large',
+  args: {
+    size: 'large',
+    label: 'Pagina wordt geladen',
+  },
+};
+
+export const AllSizes: Story = {
+  name: 'All sizes',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '3rem',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      {(['default', 'large'] as const).map((size) => (
+        <div
+          key={size}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '0.75rem',
+          }}
+        >
+          <Spinner size={size} label="Laden..." />
+          <span
+            style={{
+              fontSize: '0.75rem',
+              color: 'var(--dsn-color-neutral-color-default)',
+            }}
+          >
+            {size}
+          </span>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+// =============================================================================
+// LABEL VARIANTEN
+// =============================================================================
+
+export const ReducedMotion: Story = {
+  name: 'Reduced motion',
+  decorators: [
+    (Story) => (
+      <>
+        <style>{`
+          .dsn-spinner-reduced-motion-demo .dsn-spinner__circle {
+            animation: dsn-spinner-pulse var(--dsn-spinner-duration) ease-in-out infinite alternate !important;
+          }
+        `}</style>
+        <div className="dsn-spinner-reduced-motion-demo">
+          <Story />
+        </div>
+      </>
+    ),
+  ],
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '3rem',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      <Spinner label="Laden..." />
+      <Spinner size="large" label="Pagina wordt geladen" />
+    </div>
+  ),
+};
+
+export const HiddenLabel: Story = {
+  name: 'Hidden label',
+  args: {
+    hideLabel: true,
+    label: 'Laden...',
+  },
+};
+
+// =============================================================================
+// GEBRUIK
+// =============================================================================
+
+export const InlineUse: Story = {
+  name: 'Inline gebruik',
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+        <Spinner label="Zoekresultaten laden" hideLabel />
+        <span>Zoekresultaten worden geladen...</span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+        <Spinner label="Opslaan" />
+      </div>
+    </div>
+  ),
+};
+
+export const PageLoading: Story = {
+  name: 'Pagina laden',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: '4rem',
+      }}
+    >
+      <Spinner size="large" label="Pagina wordt geladen" />
+    </div>
+  ),
+};


### PR DESCRIPTION
Sluit #220.

## Summary

- SVG arc-animatie met `role="status"` en altijd aanwezig toegankelijk label (`hideLabel` → `dsn-visually-hidden`)
- Twee groottes: default (24×24px, label rechts) en large (48×48px, label gecentreerd onder)
- `prefers-reduced-motion: reduce` wisselt rotatie naar subtiele opacity-pulse; Storybook story demonstreert dit gedrag
- `--dsn-spinner-stroke-width` delegeert naar `{dsn.border.width.medium}` (2px) voor visuele consistentie met borders

## Test plan

- [ ] 14 nieuwe tests groen (`pnpm test`)
- [ ] TypeScript schoon (`pnpm --filter storybook exec tsc --noEmit`)
- [ ] Lint schoon (`pnpm lint`)
- [ ] Storybook stories: Default, Large, All sizes, Reduced motion, Hidden label, Inline gebruik, Pagina laden
- [ ] Light en dark mode visueel gecontroleerd

🤖 Generated with [Claude Code](https://claude.com/claude-code)