### PR TITLE
feat(ProgressBar): voeg horizontale voortgangsbalk toe voor bepaalde wachttijden

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pnpm --filter @dsn/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (1409 tests across 70 test suites)
+# Run tests (1442 tests across 72 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -192,7 +192,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Paragraph**     | Yes      | Yes   | Yes           |
 | **UnorderedList** | Yes      | Yes   | Yes           |
 
-**Display & Feedback Components (12)**
+**Display & Feedback Components (14)**
 
 | Component       | HTML/CSS | React | Web Component |
 | --------------- | -------- | ----- | ------------- |
@@ -206,6 +206,8 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Note**        | Yes      | Yes   | No            |
 | **NumberBadge** | Yes      | Yes   | No            |
 | **Popover**     | Yes      | Yes   | No            |
+| **ProgressBar** | Yes      | Yes   | No            |
+| **Spinner**     | Yes      | Yes   | No            |
 | **StatusBadge** | Yes      | Yes   | No            |
 | **Table**       | Yes      | Yes   | No            |
 
@@ -405,7 +407,7 @@ Comprehensive documentation is available in the `/docs` folder:
 
 - **Pre-commit hooks** via Husky + lint-staged (ESLint + Prettier)
 - **Type checking** across all packages (`pnpm type-check`)
-- **1409 tests** covering React components, Web Components, and utilities
+- **1442 tests** covering React components, Web Components, and utilities
 - **CI/CD** via GitHub Actions (lint, type-check, test, build)
 
 ## Tech Stack

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -944,7 +944,7 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 
 ## Display & Feedback Components
 
-**Status:** Complete (HTML/CSS, React): 12 components total
+**Status:** Complete (HTML/CSS, React): 14 components total
 
 ### Backdrop
 
@@ -1225,6 +1225,87 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 - Geen eigen afmeting: schaalt mee met de omgevende typografie
 
 **Tests:** React (10 tests)
+
+### Spinner
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-{html|react}/src/spinner/` / `packages/components-react/src/Spinner/`
+
+**Tokens:** `tokens/components/spinner.json`
+
+**Props:** `label`, `hideLabel`, `size`
+
+**Features:**
+
+- SVG-gebaseerde cirkelvormige laadindicator voor onbepaalde wachttijden
+- `role="status"` op de container kondigt de laadtoestand aan bij screenreaders
+- `hideLabel` verbergt het label visueel via `dsn-visually-hidden` maar behoudt toegankelijkheid
+- Twee groottes: `default` (24px, label rechts) en `large` (48px, label gecentreerd onder)
+- `prefers-reduced-motion: reduce`: rotatie vervangen door subtiel pulseren
+
+**HTML klassen:**
+
+```html
+<!-- Standaard -->
+<div class="dsn-spinner" role="status">
+  <svg class="dsn-spinner__circle" viewBox="0 0 24 24" aria-hidden="true">
+    <circle class="dsn-spinner__track" cx="12" cy="12" r="10" />
+    <circle class="dsn-spinner__arc" cx="12" cy="12" r="10" />
+  </svg>
+  <span class="dsn-spinner__label">Laden...</span>
+</div>
+
+<!-- Groot -->
+<div class="dsn-spinner dsn-spinner--large" role="status">...</div>
+
+<!-- Visueel verborgen label -->
+<span class="dsn-spinner__label dsn-visually-hidden">Laden...</span>
+```
+
+**Tests:** React (14 tests)
+
+### ProgressBar
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-{html|react}/src/progress-bar/` / `packages/components-react/src/ProgressBar/`
+
+**Tokens:** `tokens/components/progress-bar.json`
+
+**Props:** `label`, `value`, `max`, `description`, `id`
+
+**Features:**
+
+- Natief `<progress>`-element met impliciete `role="progressbar"`, `aria-valuenow`, `aria-valuemin` en `aria-valuemax`
+- `<label>` gekoppeld via `for`/`id`: robuuster dan `aria-label`
+- Percentage automatisch berekend: `Math.round((value / max) * 100)`, boven de balk getoond met `aria-hidden="true"`
+- Optionele `description` onder de balk
+- Cross-browser CSS: `::-webkit-progress-bar/value` (Chrome/Safari) + `::-moz-progress-bar` (Firefox)
+- Pill-vorm via `border-radius: round`, fill-animatie met `prefers-reduced-motion` support
+- `useId()` voor automatisch gegenereerd ID als geen `id` prop meegegeven
+
+**HTML klassen:**
+
+```html
+<div class="dsn-progress-bar">
+  <label class="dsn-visually-hidden" for="pb-1">Bestand uploaden</label>
+  <div class="dsn-progress-bar__header">
+    <p class="dsn-paragraph dsn-progress-bar__percentage" aria-hidden="true">
+      35%
+    </p>
+  </div>
+  <progress id="pb-1" class="dsn-progress-bar__bar" value="35" max="100">
+    35%
+  </progress>
+  <!-- Optioneel: -->
+  <p class="dsn-paragraph dsn-progress-bar__description">
+    Bestand wordt geüpload...
+  </p>
+</div>
+```
+
+**Tests:** React (19 tests)
 
 ### Alert
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,8 +91,8 @@ Complete documentation voor het Design System Starter Kit.
 
 - **Tokens per configuration:** ~1100 (400 semantic + 700 component)
 - **Configurations:** 8 (2 themes × 2 modes × 2 project types)
-- **Components:** 53 (7 layout + 10 content + 9 display/feedback + 1 branding + 5 navigation + 25 form + 1 accessibility; HTML/CSS + React)
-- **Tests:** 1409 across 70 test suites
+- **Components:** 63 (7 layout + 10 content + 14 display/feedback + 1 branding + 5 navigation + 25 form + 1 accessibility; HTML/CSS + React)
+- **Tests:** 1442 across 72 test suites
 - **Storybook stories:** 130+
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,29 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 5.33.0 (May 1, 2026)
+
+### Spinner + ProgressBar
+
+#### Added
+
+- **Spinner** (issue #220, PR #222): cirkelvormige laadindicator voor onbepaalde wachttijden
+  - SVG arc-animatie met track en boog; `role="status"` op de container
+  - `label` prop altijd vereist; `hideLabel` verbergt visueel via `dsn-visually-hidden`
+  - Twee groottes: `default` (24px, label rechts) en `large` (48px, label onder)
+  - `prefers-reduced-motion`: rotatie vervangen door subtiel pulseren
+  - 7 component tokens: `size`, `size-large`, `stroke-width`, `color`, `track-color`, `duration`, `gap-size`
+- **ProgressBar** (issue #221, PR #224): horizontale voortgangsbalk voor bepaalde wachttijden
+  - Natief `<progress>`-element met impliciete `role="progressbar"`; `<label>` via `for`/`id`
+  - Percentage automatisch berekend via `Math.round((value / max) * 100)`, zichtbaar boven de balk
+  - Optionele `description` prop voor tekst onder de balk
+  - `max` prop voor stapsgewijze processen (bijv. `value=3 max=7` → 43%)
+  - Cross-browser CSS: `::-webkit-progress-bar/value` + `::-moz-progress-bar`; pill-vorm + fill-animatie
+  - `prefers-reduced-motion`: fill-overgang uitgeschakeld
+  - 6 component tokens: `color.track`, `color.fill`, `block-size`, `border-radius`, `gap.header`, `gap.footer`
+
+---
+
 ## Version 5.32.0 (April 30, 2026)
 
 ### Design Tokens: overzichtspagina uitgebreid met ontbrekende semantische tokens

--- a/packages/components-html/src/progress-bar/progress-bar.css
+++ b/packages/components-html/src/progress-bar/progress-bar.css
@@ -1,0 +1,90 @@
+/**
+ * ProgressBar Component
+ * Horizontale voortgangsbalk voor bepaalde wachttijden.
+ *
+ * Het native <progress>-element heeft impliciete role="progressbar", aria-valuenow,
+ * aria-valuemin en aria-valuemax. Een visueel verborgen <label> koppelt de toegankelijke
+ * naam via for/id. De percentage-tekst heeft aria-hidden="true" om dubbele aankondiging
+ * te vermijden.
+ *
+ * Usage:
+ * <!-- Basis -->
+ * <div class="dsn-progress-bar">
+ *   <label class="dsn-visually-hidden" for="pb-1">Bestand uploaden</label>
+ *   <div class="dsn-progress-bar__header">
+ *     <p class="dsn-paragraph dsn-progress-bar__percentage" aria-hidden="true">35%</p>
+ *   </div>
+ *   <progress id="pb-1" class="dsn-progress-bar__bar" value="35" max="100">35%</progress>
+ * </div>
+ *
+ * <!-- Met beschrijving -->
+ * <div class="dsn-progress-bar">
+ *   <label class="dsn-visually-hidden" for="pb-2">Bestand uploaden</label>
+ *   <div class="dsn-progress-bar__header">
+ *     <p class="dsn-paragraph dsn-progress-bar__percentage" aria-hidden="true">35%</p>
+ *   </div>
+ *   <progress id="pb-2" class="dsn-progress-bar__bar" value="35" max="100">35%</progress>
+ *   <p class="dsn-paragraph dsn-progress-bar__description">Bestand wordt geüpload...</p>
+ * </div>
+ */
+
+.dsn-progress-bar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--dsn-progress-bar-gap-header);
+}
+
+.dsn-progress-bar__header {
+  display: flex;
+  align-items: baseline;
+}
+
+/* Paragraph margin-reset: voorkomen dat dsn-paragraph zijn eigen margin-block-end toepast */
+.dsn-progress-bar .dsn-paragraph {
+  margin-block-end: 0;
+}
+
+.dsn-progress-bar__bar {
+  appearance: none;
+  display: block;
+  inline-size: 100%;
+  block-size: var(--dsn-progress-bar-block-size);
+  border: none;
+  border-radius: var(--dsn-progress-bar-border-radius);
+  /* Firefox: track-kleur via element background */
+  background-color: var(--dsn-progress-bar-color-track);
+  color: var(--dsn-progress-bar-color-fill);
+}
+
+/* Chrome/Safari: track */
+.dsn-progress-bar__bar::-webkit-progress-bar {
+  background-color: var(--dsn-progress-bar-color-track);
+  border-radius: var(--dsn-progress-bar-border-radius);
+}
+
+/* Chrome/Safari: fill */
+.dsn-progress-bar__bar::-webkit-progress-value {
+  background-color: var(--dsn-progress-bar-color-fill);
+  border-radius: var(--dsn-progress-bar-border-radius);
+  transition: inline-size var(--dsn-transition-duration-slow)
+    var(--dsn-transition-easing-linear);
+}
+
+/* Firefox: fill */
+.dsn-progress-bar__bar::-moz-progress-bar {
+  background-color: var(--dsn-progress-bar-color-fill);
+  border-radius: var(--dsn-progress-bar-border-radius);
+  transition: inline-size var(--dsn-transition-duration-slow)
+    var(--dsn-transition-easing-linear);
+}
+
+.dsn-progress-bar__description {
+  margin-block-start: var(--dsn-progress-bar-gap-footer);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dsn-progress-bar__bar::-webkit-progress-value,
+  .dsn-progress-bar__bar::-moz-progress-bar {
+    transition: none;
+  }
+}

--- a/packages/components-react/src/ProgressBar/ProgressBar.css
+++ b/packages/components-react/src/ProgressBar/ProgressBar.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/progress-bar/progress-bar.css';

--- a/packages/components-react/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/components-react/src/ProgressBar/ProgressBar.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { ProgressBar } from './ProgressBar';
+
+describe('ProgressBar', () => {
+  it('renders as a <div> element', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={35} />);
+    expect(container.firstChild?.nodeName).toBe('DIV');
+  });
+
+  it('always has base dsn-progress-bar class', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={35} />);
+    expect(container.firstChild).toHaveClass('dsn-progress-bar');
+  });
+
+  it('renders a visually hidden label', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={35} />);
+    const label = container.querySelector('label');
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveClass('dsn-visually-hidden');
+    expect(label).toHaveTextContent('Uploaden');
+  });
+
+  it('renders a <progress> element', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={35} />);
+    const progress = container.querySelector('progress');
+    expect(progress).toBeInTheDocument();
+    expect(progress).toHaveClass('dsn-progress-bar__bar');
+  });
+
+  it('links label to progress via id', () => {
+    const { container } = render(
+      <ProgressBar label="Uploaden" value={35} id="pb-test" />
+    );
+    const label = container.querySelector('label');
+    const progress = container.querySelector('progress');
+    expect(label).toHaveAttribute('for', 'pb-test');
+    expect(progress).toHaveAttribute('id', 'pb-test');
+  });
+
+  it('generates an id automatically when no id prop is given', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={35} />);
+    const label = container.querySelector('label');
+    const progress = container.querySelector('progress');
+    const labelFor = label?.getAttribute('for');
+    expect(labelFor).toBeTruthy();
+    expect(progress).toHaveAttribute('id', labelFor);
+  });
+
+  it('sets value and max on the progress element', () => {
+    const { container } = render(
+      <ProgressBar label="Uploaden" value={35} max={100} />
+    );
+    const progress = container.querySelector('progress');
+    expect(progress).toHaveAttribute('value', '35');
+    expect(progress).toHaveAttribute('max', '100');
+  });
+
+  it('defaults max to 100', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={50} />);
+    const progress = container.querySelector('progress');
+    expect(progress).toHaveAttribute('max', '100');
+  });
+
+  it('calculates percentage correctly', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={35} />);
+    const percentage = container.querySelector('.dsn-progress-bar__percentage');
+    expect(percentage).toHaveTextContent('35%');
+  });
+
+  it('rounds percentage for custom max', () => {
+    const { container } = render(
+      <ProgressBar label="Uploaden" value={3} max={7} />
+    );
+    const percentage = container.querySelector('.dsn-progress-bar__percentage');
+    expect(percentage).toHaveTextContent('43%');
+  });
+
+  it('percentage has aria-hidden="true"', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={35} />);
+    const percentage = container.querySelector('.dsn-progress-bar__percentage');
+    expect(percentage).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('does not render description when not provided', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={35} />);
+    expect(
+      container.querySelector('.dsn-progress-bar__description')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    const { container } = render(
+      <ProgressBar
+        label="Uploaden"
+        value={35}
+        description="Bestand wordt geüpload..."
+      />
+    );
+    const description = container.querySelector(
+      '.dsn-progress-bar__description'
+    );
+    expect(description).toBeInTheDocument();
+    expect(description).toHaveTextContent('Bestand wordt geüpload...');
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <ProgressBar label="Uploaden" value={35} className="custom" />
+    );
+    expect(container.firstChild).toHaveClass('dsn-progress-bar');
+    expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('forwards ref', () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(<ProgressBar label="Uploaden" value={35} ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('spreads additional HTML attributes', () => {
+    const { container } = render(
+      <ProgressBar label="Uploaden" value={35} data-testid="pb" />
+    );
+    expect(container.firstChild).toHaveAttribute('data-testid', 'pb');
+  });
+
+  it('renders header div', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={35} />);
+    expect(
+      container.querySelector('.dsn-progress-bar__header')
+    ).toBeInTheDocument();
+  });
+
+  it('shows 0% at start', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={0} />);
+    const percentage = container.querySelector('.dsn-progress-bar__percentage');
+    expect(percentage).toHaveTextContent('0%');
+  });
+
+  it('shows 100% at end', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={100} />);
+    const percentage = container.querySelector('.dsn-progress-bar__percentage');
+    expect(percentage).toHaveTextContent('100%');
+  });
+});

--- a/packages/components-react/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components-react/src/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,100 @@
+import React, { useId } from 'react';
+import { classNames } from '@dsn/core';
+import './ProgressBar.css';
+
+export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Visueel verborgen label dat de voortgangsbalk beschrijft voor screenreaders.
+   * Altijd vereist — gekoppeld via <label for> aan het <progress>-element.
+   */
+  label: string;
+
+  /**
+   * Huidige voortgang (0 t/m max).
+   */
+  value: number;
+
+  /**
+   * Maximale waarde. Percentage wordt berekend als Math.round((value / max) * 100).
+   * @default 100
+   */
+  max?: number;
+
+  /**
+   * Optionele beschrijvende tekst onder de balk.
+   */
+  description?: React.ReactNode;
+
+  /**
+   * ID voor het <progress>-element en de bijbehorende <label>.
+   * Automatisch gegenereerd via useId() indien weggelaten.
+   */
+  id?: string;
+}
+
+/**
+ * ProgressBar component
+ * Horizontale voortgangsbalk voor bepaalde wachttijden.
+ *
+ * Het native <progress>-element biedt impliciete role="progressbar" met
+ * aria-valuenow, aria-valuemin en aria-valuemax. Een visueel verborgen
+ * <label> koppelt de toegankelijke naam via for/id.
+ *
+ * @example
+ * ```tsx
+ * // Basis
+ * <ProgressBar label="Bestand uploaden" value={35} />
+ *
+ * // Met beschrijving
+ * <ProgressBar
+ *   label="Bestand uploaden"
+ *   value={35}
+ *   description="Bestand wordt geüpload, even geduld..."
+ * />
+ *
+ * // Stappen (stap 3 van 7)
+ * <ProgressBar label="Stap voortgang" value={3} max={7} />
+ * ```
+ */
+export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
+  ({ className, label, value, max = 100, description, id, ...props }, ref) => {
+    const generatedId = useId();
+    const progressId = id ?? generatedId;
+    const percentage = Math.round((value / max) * 100);
+
+    return (
+      <div
+        ref={ref}
+        className={classNames('dsn-progress-bar', className)}
+        {...props}
+      >
+        <label className="dsn-visually-hidden" htmlFor={progressId}>
+          {label}
+        </label>
+        <div className="dsn-progress-bar__header">
+          <p
+            className="dsn-paragraph dsn-progress-bar__percentage"
+            aria-hidden="true"
+          >
+            {percentage}%
+          </p>
+        </div>
+        <progress
+          id={progressId}
+          className="dsn-progress-bar__bar"
+          value={value}
+          max={max}
+        >
+          {percentage}%
+        </progress>
+        {description && (
+          <p className="dsn-paragraph dsn-progress-bar__description">
+            {description}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+
+ProgressBar.displayName = 'ProgressBar';

--- a/packages/components-react/src/ProgressBar/index.ts
+++ b/packages/components-react/src/ProgressBar/index.ts
@@ -1,0 +1,1 @@
+export * from './ProgressBar';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -53,6 +53,7 @@ export * from './OptionLabel';
 export * from './Backdrop';
 export * from './DotBadge';
 export * from './Spinner';
+export * from './ProgressBar';
 export * from './NumberBadge';
 export * from './StatusBadge';
 export * from './Alert';

--- a/packages/design-tokens/src/tokens/components/progress-bar.json
+++ b/packages/design-tokens/src/tokens/components/progress-bar.json
@@ -1,0 +1,40 @@
+{
+  "dsn": {
+    "progress-bar": {
+      "color": {
+        "track": {
+          "$value": "{dsn.color.neutral.bg-default}",
+          "$type": "color",
+          "$description": "Grijze achtergrondtrack"
+        },
+        "fill": {
+          "$value": "{dsn.color.accent-1.color-default}",
+          "$type": "color",
+          "$description": "Blauwe vulbalk — zelfde primaire accentkleur als Spinner"
+        }
+      },
+      "block-size": {
+        "$value": "8px",
+        "$type": "dimension",
+        "$description": "Hoogte van de balk — gangbare dikte voor voortgangsbalken"
+      },
+      "border-radius": {
+        "$value": "{dsn.border.radius.round}",
+        "$type": "borderRadius",
+        "$description": "Volledig afgerond (pill-vorm) voor zowel track als fill"
+      },
+      "gap": {
+        "header": {
+          "$value": "{dsn.space.block.xs}",
+          "$type": "spacing",
+          "$description": "Ruimte tussen percentage-tekst en balk"
+        },
+        "footer": {
+          "$value": "{dsn.space.block.xs}",
+          "$type": "spacing",
+          "$description": "Ruimte tussen balk en beschrijving"
+        }
+      }
+    }
+  }
+}

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -87,7 +87,7 @@ function App() {
 - **Link**: Hyperlinks met icon ondersteuning en externe link handling
 - **Lists**: OrderedList en UnorderedList
 
-### Display & Feedback Components (12)
+### Display & Feedback Components (13)
 
 - **Backdrop**: Vaste, volledig-scherm overlay die de achtergrondinhoud verhult achter een Modal Dialog of Drawer: puur decoratief (`aria-hidden="true"`)
 - **DotBadge**: Kleine gekleurde stip bij een Button of Link die zonder label de aandacht trekt bij een statuswijziging (met optioneel pulse-effect)
@@ -101,6 +101,7 @@ function App() {
 - **Card**: Configureerbare container voor gestructureerde content (afbeelding, heading, beschrijving, actie) met stretched-link techniek en CardGroup voor gelijke hoogte
 - **ModalDialog**: Modaal dialoogvenster voor korte, gefocuste acties (bevestigen, kleine keuze): blokkeert achtergrond via native `<dialog>` met focus-trap
 - **Spinner**: Cirkelvormige laadindicator voor onbepaalde wachttijden, met `role="status"` en altijd een toegankelijk label
+- **ProgressBar**: Horizontale voortgangsbalk voor bepaalde wachttijden, met native `<progress>`, visueel percentage en optionele beschrijving
 - **Popover**: Lichtgewicht contextgebonden overlay verankerd aan een triggerelement: niet-modaal, light-dismiss via HTML Popover API, composable met PopoverHeader/Body/Footer
 
 ### Branding Components (1)
@@ -187,4 +188,4 @@ MIT License: zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.30.0 | **Laatste update:** 26 april 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.31.0 | **Laatste update:** 1 mei 2026 | **Auteur:** Jeffrey Lauwers

--- a/packages/storybook/src/ProgressBar.docs.md
+++ b/packages/storybook/src/ProgressBar.docs.md
@@ -1,0 +1,93 @@
+# ProgressBar
+
+Horizontale voortgangsbalk voor bepaalde wachttijden.
+
+## Doel
+
+ProgressBar toont de voortgang van een taak als percentage. Het component is bedoeld voor laadacties waarbij de voortgang meetbaar is, zoals bestandsuploads of stapsgewijze processen. Het toont altijd een procentuele waarde boven de balk, en heeft optioneel een beschrijvende tekst eronder.
+
+Het native `<progress>`-element biedt impliciete `role="progressbar"` zodat screenreaders de voortgang automatisch aankondigen. Een visueel verborgen `<label>` koppelt de toegankelijke naam via `for`/`id`.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- De voortgang van een actie meetbaar is (bestandsupload, export, stapsgewijs proces).
+- Het totaal aantal stappen of de bestandsgrootte van tevoren bekend is.
+- Achtergrondtaken met een bekende duur worden uitgevoerd.
+
+## Don't use when
+
+- De duur van de actie niet van tevoren bekend is: gebruik dan een **Spinner**.
+- De voortgang geen getal oplevert maar een kwalitatieve status: gebruik dan een **StatusBadge**.
+
+## Best practices
+
+### Label
+
+Geef altijd een beschrijvend label mee dat de actie omschrijft, niet het percentage:
+
+```html
+<!-- Goed -->
+<label class="dsn-visually-hidden" for="pb-1">Bestand uploaden</label>
+
+<!-- Te generiek -->
+<label class="dsn-visually-hidden" for="pb-1">Voortgang</label>
+```
+
+### Beschrijving
+
+Gebruik de optionele beschrijving voor extra context over de lopende actie:
+
+```html
+<p class="dsn-paragraph dsn-progress-bar__description">
+  Bestand wordt geüpload, even geduld...
+</p>
+```
+
+### Aangepast maximum
+
+Gebruik `max` voor stapsgewijze processen waarbij het totaal niet 100 is. Het percentage wordt automatisch berekend:
+
+```tsx
+// Stap 3 van 7 — toont 43%
+<ProgressBar label="Stap voortgang" value={3} max={7} />
+```
+
+In HTML:
+
+```html
+<progress class="dsn-progress-bar__bar" value="3" max="7">43%</progress>
+```
+
+### Voltooiing
+
+Toon een beschrijving wanneer de balk 100% bereikt:
+
+```tsx
+<ProgressBar
+  label="Bestand uploaden"
+  value={100}
+  description="Upload voltooid."
+/>
+```
+
+## Design tokens
+
+| Token                              | Beschrijving                                                    |
+| ---------------------------------- | --------------------------------------------------------------- |
+| `--dsn-progress-bar-color-track`   | Achtergrondkleur van de track (neutraal grijs)                  |
+| `--dsn-progress-bar-color-fill`    | Kleur van de vulbalk (primaire accentkleur, zelfde als Spinner) |
+| `--dsn-progress-bar-block-size`    | Hoogte van de balk (8px)                                        |
+| `--dsn-progress-bar-border-radius` | Afronding van track en fill (pill-vorm)                         |
+| `--dsn-progress-bar-gap-header`    | Ruimte tussen percentage-tekst en balk                          |
+| `--dsn-progress-bar-gap-footer`    | Ruimte tussen balk en beschrijving                              |
+
+## Accessibility
+
+- Het native `<progress>`-element heeft impliciete `role="progressbar"`, `aria-valuenow`, `aria-valuemin` (0) en `aria-valuemax`.
+- Een `<label>` is gekoppeld via `for`/`id` — robuuster dan `aria-label`.
+- De percentage-tekst heeft `aria-hidden="true"`: screenreaders lezen de native voortgangswaarde al voor via `<progress>`.
+- De fallback-tekst binnen `<progress>` (bijv. `35%`) dient als tekstalternatief voor browsers zonder HTML5-ondersteuning.
+- Bij dynamische `value`-wijzigingen kondigt de screenreader de nieuwe waarde aan via de ingebouwde live-regiofunctionaliteit van `role="progressbar"`.
+- De fill-animatie respecteert `prefers-reduced-motion: reduce`: bij verminderde bewegingsvoorkeur wordt de overgangsanimatie uitgeschakeld.

--- a/packages/storybook/src/ProgressBar.docs.mdx
+++ b/packages/storybook/src/ProgressBar.docs.mdx
@@ -1,0 +1,31 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/blocks';
+import * as ProgressBarStories from './ProgressBar.stories';
+import docs from './ProgressBar.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={ProgressBarStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={ProgressBarStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={ProgressBarStories.Default}
+  html={`<div class="dsn-progress-bar">
+  <label class="dsn-visually-hidden" for="pb-1">Bestand uploaden</label>
+  <div class="dsn-progress-bar__header">
+    <p class="dsn-paragraph dsn-progress-bar__percentage" aria-hidden="true">35%</p>
+  </div>
+  <progress id="pb-1" class="dsn-progress-bar__bar" value="35" max="100">35%</progress>
+</div>`}
+/>
+
+<Controls of={ProgressBarStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/ProgressBar.stories.tsx
+++ b/packages/storybook/src/ProgressBar.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProgressBar } from '@dsn/components-react';
+import DocsPage from './ProgressBar.docs.mdx';
+
+const meta: Meta<typeof ProgressBar> = {
+  title: 'Components/ProgressBar',
+  component: ProgressBar,
+  parameters: {
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const value = args.value ?? 35;
+        const max = args.max ?? 100;
+        const percentage = Math.round((value / max) * 100);
+        const label = args.label ?? 'Bestand uploaden';
+        const description = args.description
+          ? `\n  <p class="dsn-paragraph dsn-progress-bar__description">${args.description}</p>`
+          : '';
+        return `<div class="dsn-progress-bar">
+  <label class="dsn-visually-hidden" for="pb-example">${label}</label>
+  <div class="dsn-progress-bar__header">
+    <p class="dsn-paragraph dsn-progress-bar__percentage" aria-hidden="true">${percentage}%</p>
+  </div>
+  <progress id="pb-example" class="dsn-progress-bar__bar" value="${value}" max="${max}">${percentage}%</progress>${description}
+</div>`;
+      },
+    },
+  },
+  argTypes: {
+    value: { control: { type: 'range', min: 0, max: 100, step: 1 } },
+    max: { control: { type: 'number', min: 1 } },
+    label: { control: 'text' },
+    description: { control: 'text' },
+  },
+  args: {
+    label: 'Bestand uploaden',
+    value: 35,
+    max: 100,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ProgressBar>;
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {};
+
+// =============================================================================
+// VARIANTEN
+// =============================================================================
+
+export const WithDescription: Story = {
+  name: 'Met beschrijving',
+  args: {
+    value: 35,
+    description: 'Bestand wordt geüpload, even geduld...',
+  },
+};
+
+export const AtStart: Story = {
+  name: 'Begin (0%)',
+  args: {
+    value: 0,
+  },
+};
+
+export const AtEnd: Story = {
+  name: 'Voltooid (100%)',
+  args: {
+    value: 100,
+    description: 'Upload voltooid.',
+  },
+};
+
+export const CustomMax: Story = {
+  name: 'Aangepast maximum (stap 3 van 7)',
+  args: {
+    label: 'Stap voortgang',
+    value: 3,
+    max: 7,
+    description: 'Stap 3 van 7: Gegevens verwerken',
+  },
+};
+
+// =============================================================================
+// OVERZICHTSSTORIES
+// =============================================================================
+
+export const AllStates: Story = {
+  name: 'Alle stappen',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '2rem',
+        maxWidth: '480px',
+      }}
+    >
+      {[0, 25, 50, 75, 100].map((value) => (
+        <ProgressBar
+          key={value}
+          label={`Voortgang ${value}%`}
+          value={value}
+          description={value === 100 ? 'Upload voltooid.' : undefined}
+        />
+      ))}
+    </div>
+  ),
+};


### PR DESCRIPTION
Closes #221

## Summary

- Native `<progress>`-element met impliciete `role="progressbar"`, gekoppeld via `<label for>`/`id`
- Percentage automatisch berekend via `Math.round((value / max) * 100)`, ook zichtbaar als tekst boven de balk
- Optionele `description` prop voor tekst onder de balk
- CSS met cross-browser pseudo-elementen (`::-webkit-progress-bar/value`, `::-moz-progress-bar`), pill-border-radius en `prefers-reduced-motion` support
- 19 tests, alle groen — TypeScript schoon, lint schoon

## Test plan

- [ ] Default story: 35% blauwe fill op grijze track
- [ ] Alle stappen story: 0%–100% correct
- [ ] Met beschrijving story: tekst onder de balk
- [ ] Aangepast maximum: `value=3 max=7` toont 43%
- [ ] Docs pagina volledig ingeladen
- [ ] CI groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)