### PR TITLE
feat(design-tokens): semantische none-waarden en z-index tokens (v5.34.0)

### DIFF
--- a/docs/02-design-tokens-reference.md
+++ b/docs/02-design-tokens-reference.md
@@ -1,6 +1,6 @@
 # Design Tokens Reference
 
-**Last Updated:** April 30, 2026
+**Last Updated:** May 1, 2026
 
 Complete reference for all design tokens in the Design System Starter Kit.
 
@@ -14,8 +14,10 @@ Complete reference for all design tokens in the Design System Starter Kit.
 4. [Colors](#colors)
 5. [Borders](#borders)
 6. [Focus States](#focus-states)
-7. [Motion](#motion)
-8. [Breakpoints](#breakpoints)
+7. [Box Shadows](#box-shadows)
+8. [Z-Index](#z-index)
+9. [Motion](#motion)
+10. [Breakpoints](#breakpoints)
 
 ---
 
@@ -111,6 +113,10 @@ Complete reference for all design tokens in the Design System Starter Kit.
 
 - **Value:** 0.5rem (8px)
 - **Purpose:** Base unit for 8pt grid system
+
+### None
+
+- `none`: 0px — Explicitly no spacing; use instead of hardcoded `0` in component tokens.
 
 ### Spacing Concepts
 
@@ -271,6 +277,7 @@ color: var(--dsn-color-neutral-color-default);
 
 #### Start Theme
 
+- `square`: 0px — Explicitly no border radius; used for alerts, checkboxes, form controls
 - `sm`: 4px
 - `md`: 8px
 - `lg`: 16px
@@ -278,6 +285,7 @@ color: var(--dsn-color-neutral-color-default);
 
 #### Wireframe Theme
 
+- `square`: 0px
 - `sm`: 2px
 - `md`: 4px
 - `lg`: 8px
@@ -285,6 +293,7 @@ color: var(--dsn-color-neutral-color-default);
 
 ### Border Width
 
+- `none`: 0px — Explicitly no border; used to reset fieldset borders (checkbox-group, radio-group)
 - `thin`: 1px
 - `medium`: 2px
 - `thick`: 4px
@@ -330,6 +339,37 @@ Focus indicators use a dual-outline technique: a primary `outline` for the main 
 - `outline-offset`: 2px
 - `outline-style`: solid
 - `outline-width`: 2px
+
+---
+
+## Box Shadows
+
+Elevation shadows communicate depth. Each shadow is composed of two drop shadow layers (direct + ambient) and a spread-only outline layer (highlight). Only the color tokens differ between light and dark mode.
+
+| Token                 | CSS Variable            | Start Theme                  | Wireframe Theme |
+| --------------------- | ----------------------- | ---------------------------- | --------------- |
+| `dsn.box-shadow.none` | `--dsn-box-shadow-none` | `none`                       | `none`          |
+| `dsn.box-shadow.sm`   | `--dsn-box-shadow-sm`   | 2-layer shadow + 1px outline | `none` (flat)   |
+| `dsn.box-shadow.md`   | `--dsn-box-shadow-md`   | 2-layer shadow + 1px outline | `none` (flat)   |
+| `dsn.box-shadow.lg`   | `--dsn-box-shadow-lg`   | 2-layer shadow + 1px outline | `none` (flat)   |
+
+**Usage:** `sm` for cards/chips, `md` for dropdowns/tooltips, `lg` for modals/dialogs. The wireframe theme intentionally flattens all elevation to `none`.
+
+---
+
+## Z-Index
+
+Z-index tokens define the stacking order of UI layers. The token name matches its numeric value, leaving room to insert intermediate levels.
+
+| Token             | CSS Variable        | Value | Used by                          |
+| ----------------- | ------------------- | ----- | -------------------------------- |
+| `dsn.z-index.300` | `--dsn-z-index-300` | 300   | PageHeader (sticky/auto-hide)    |
+| `dsn.z-index.350` | `--dsn-z-index-350` | 350   | Popover, tooltips, dropdowns     |
+| `dsn.z-index.400` | `--dsn-z-index-400` | 400   | Backdrop (behind modals/drawers) |
+| `dsn.z-index.500` | `--dsn-z-index-500` | 500   | ModalDialog, Drawer              |
+| `dsn.z-index.600` | `--dsn-z-index-600` | 600   | SkipLink (always on top — a11y)  |
+
+Z-index tokens are identical across all themes and modes.
 
 ---
 
@@ -379,11 +419,11 @@ Five semantic easing curves for consistent motion feel.
 
 ## Token Statistics
 
-**Total Tokens (as of v5.32.0):**
+**Total Tokens (as of v5.34.0):**
 
-- Semantic tokens: ~420 per configuration (incl. content sizing, form control sizing, breakpoints)
+- Semantic tokens: ~435 per configuration (incl. content sizing, form control sizing, box shadows, z-index, breakpoints)
 - Component tokens: ~700 (component JSON files per categorie: layout, content, display/feedback, navigation, branding, form)
-- **Total: ~1100+ tokens per full configuration**
+- **Total: ~1135+ tokens per full configuration**
 - **Total configurations: 8** (2 themes × 2 modes × 2 project types)
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,33 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 5.34.0 (May 1, 2026)
+
+### Semantische design tokens: none-waarden en z-index
+
+#### Added
+
+- **`dsn.border.radius.square`** (`0px`): expliciete nul-waarde voor vierkante hoeken; gebruikt door Alert, Checkbox en form-control border-radius
+- **`dsn.border.width.none`** (`0px`): expliciete nul-waarde voor border-width; gebruikt door CheckboxGroup en RadioGroup fieldset-reset
+- **`dsn.space.none`** (`0px`): expliciete nul-waarde voor spacing; gebruikt door CheckboxGroup, RadioGroup, FormField, NumberBadge en BreadcrumbNavigation
+- **`dsn.box-shadow.none`** (`none`): expliciete nul-waarde voor box-shadow; semantische aanvulling voor themes die elevatie willen uitzetten
+- **`dsn.z-index.300`** (`300`): PageHeader sticky/auto-hide
+- **`dsn.z-index.350`** (`350`): Popover, tooltips, dropdowns — boven sticky headers
+- **`dsn.z-index.400`** (`400`): Backdrop achter modals en drawers
+- **`dsn.z-index.500`** (`500`): ModalDialog, Drawer
+- **`dsn.z-index.600`** (`600`): SkipLink — altijd bovenaan (toegankelijkheid)
+
+#### Changed
+
+- 10 component tokens bijgewerkt van hardcoded `"0px"` naar semantische token-referenties (`{dsn.border.radius.square}`, `{dsn.border.width.none}`, `{dsn.space.none}`)
+- 6 component tokens bijgewerkt van hardcoded z-index waarden naar `{dsn.z-index.*}` referenties: PageHeader, Popover, Backdrop, ModalDialog, Drawer, SkipLink
+- Popover z-index gecorrigeerd van 300 naar 350 — garandeert nu daadwerkelijk positionering boven sticky headers
+- `dsn.form-control.border-radius` in beide themes bijgewerkt naar `{dsn.border.radius.square}`
+- Alle nieuwe tokens toegevoegd aan `wireframe/base.json` (thema-agnostische waarden identiek aan `start/base.json`)
+- DesignTokens.mdx in Storybook bijgewerkt met nieuwe rijen in Border Width, Border Radius, Spacing, Box Shadows en nieuw Z-Index onderdeel
+
+---
+
 ## Version 5.33.0 (May 1, 2026)
 
 ### Spinner + ProgressBar

--- a/packages/design-tokens/src/tokens/components/alert.json
+++ b/packages/design-tokens/src/tokens/components/alert.json
@@ -2,9 +2,9 @@
   "dsn": {
     "alert": {
       "border-radius": {
-        "$value": "0px",
+        "$value": "{dsn.border.radius.square}",
         "$type": "dimension",
-        "$description": "Alert border radius (0px by default; themes can override to add rounded corners)"
+        "$description": "Alert border radius (square by default; themes can override to add rounded corners)"
       },
       "border-width": {
         "$value": "{dsn.border.width.medium}",

--- a/packages/design-tokens/src/tokens/components/backdrop.json
+++ b/packages/design-tokens/src/tokens/components/backdrop.json
@@ -12,9 +12,9 @@
         "$description": "backdrop-filter: blur() op de overlay — valt gracefully weg zonder support"
       },
       "z-index": {
-        "$value": "400",
+        "$value": "{dsn.z-index.400}",
         "$type": "number",
-        "$description": "Z-index schaal: backdrop (400) → modal-dialog/drawer (500) → skip-link (600)"
+        "$description": "Z-index schaal: backdrop ({dsn.z-index.400}) → modal-dialog/drawer ({dsn.z-index.500}) → skip-link ({dsn.z-index.600})"
       }
     }
   }

--- a/packages/design-tokens/src/tokens/components/breadcrumb-navigation.json
+++ b/packages/design-tokens/src/tokens/components/breadcrumb-navigation.json
@@ -40,7 +40,7 @@
           "$description": "Vertical padding to reach min-block-size"
         },
         "padding-inline": {
-          "$value": "0px",
+          "$value": "{dsn.space.none}",
           "$type": "dimension",
           "$description": "No horizontal padding on items"
         }

--- a/packages/design-tokens/src/tokens/components/checkbox-group.json
+++ b/packages/design-tokens/src/tokens/components/checkbox-group.json
@@ -2,7 +2,7 @@
   "dsn": {
     "checkbox-group": {
       "border-width": {
-        "$value": "0px",
+        "$value": "{dsn.border.width.none}",
         "$type": "dimension",
         "$description": "No border by default for fieldset"
       },
@@ -12,12 +12,12 @@
         "$description": "Space between checkbox options in the group"
       },
       "margin": {
-        "$value": "0px",
+        "$value": "{dsn.space.none}",
         "$type": "dimension",
         "$description": "No margin by default for fieldset"
       },
       "padding": {
-        "$value": "0px",
+        "$value": "{dsn.space.none}",
         "$type": "dimension",
         "$description": "No padding by default for fieldset"
       },

--- a/packages/design-tokens/src/tokens/components/checkbox.json
+++ b/packages/design-tokens/src/tokens/components/checkbox.json
@@ -10,7 +10,7 @@
         "$type": "color"
       },
       "border-radius": {
-        "$value": "0px",
+        "$value": "{dsn.border.radius.square}",
         "$type": "dimension",
         "$description": "Square corners for checkbox"
       },

--- a/packages/design-tokens/src/tokens/components/drawer.json
+++ b/packages/design-tokens/src/tokens/components/drawer.json
@@ -2,9 +2,9 @@
   "dsn": {
     "drawer": {
       "z-index": {
-        "$value": "500",
+        "$value": "{dsn.z-index.500}",
         "$type": "number",
-        "$description": "Positionering boven de backdrop (400) en onder de skip-link (600)"
+        "$description": "Positionering boven de backdrop ({dsn.z-index.400}) en onder de skip-link ({dsn.z-index.600})"
       },
       "background-color": {
         "$value": "{dsn.color.neutral.bg-elevated}",

--- a/packages/design-tokens/src/tokens/components/form-field.json
+++ b/packages/design-tokens/src/tokens/components/form-field.json
@@ -2,12 +2,12 @@
   "dsn": {
     "form-field": {
       "margin-block-end": {
-        "$value": "0px",
+        "$value": "{dsn.space.none}",
         "$type": "dimension",
         "$description": "Bottom margin of form field container"
       },
       "margin-block-start": {
-        "$value": "0px",
+        "$value": "{dsn.space.none}",
         "$type": "dimension",
         "$description": "Top margin of form field container"
       },

--- a/packages/design-tokens/src/tokens/components/modal-dialog.json
+++ b/packages/design-tokens/src/tokens/components/modal-dialog.json
@@ -2,9 +2,9 @@
   "dsn": {
     "modal-dialog": {
       "z-index": {
-        "$value": "500",
+        "$value": "{dsn.z-index.500}",
         "$type": "number",
-        "$description": "Positionering boven de backdrop (400) en onder de skip-link (600)"
+        "$description": "Positionering boven de backdrop ({dsn.z-index.400}) en onder de skip-link ({dsn.z-index.600})"
       },
       "background-color": {
         "$value": "{dsn.color.neutral.bg-elevated}",

--- a/packages/design-tokens/src/tokens/components/number-badge.json
+++ b/packages/design-tokens/src/tokens/components/number-badge.json
@@ -16,7 +16,7 @@
         "$description": "NumberBadge font weight — bold voor leesbaarheid op kleine afmeting"
       },
       "padding-block": {
-        "$value": "0px",
+        "$value": "{dsn.space.none}",
         "$type": "dimension",
         "$description": "Verticale padding"
       },

--- a/packages/design-tokens/src/tokens/components/page-header.json
+++ b/packages/design-tokens/src/tokens/components/page-header.json
@@ -27,9 +27,9 @@
         "$description": "Horizontale padding van de header-binnenbalk — zelfde schaal als masthead en navbar"
       },
       "z-index": {
-        "$value": "300",
+        "$value": "{dsn.z-index.300}",
         "$type": "number",
-        "$description": "Z-index voor sticky/auto-hide gedrag — bewust lager dan backdrop (400) zodat Drawer/Modal-backdrop over de header schuift"
+        "$description": "Z-index voor sticky/auto-hide gedrag — bewust lager dan backdrop ({dsn.z-index.400}) zodat Drawer/Modal-backdrop over de header schuift"
       },
       "logo": {
         "max-block-size": {

--- a/packages/design-tokens/src/tokens/components/popover.json
+++ b/packages/design-tokens/src/tokens/components/popover.json
@@ -37,9 +37,9 @@
         "$description": "Minimale breedte van de popover (200px)"
       },
       "z-index": {
-        "$value": "300",
+        "$value": "{dsn.z-index.350}",
         "$type": "number",
-        "$description": "Z-index van de popover — lager dan ModalDialog/Drawer (500), hoger dan sticky headers (200)"
+        "$description": "Z-index van de popover — boven sticky headers ({dsn.z-index.300}), lager dan backdrop ({dsn.z-index.400})"
       },
       "heading": {
         "font-family": {

--- a/packages/design-tokens/src/tokens/components/radio-group.json
+++ b/packages/design-tokens/src/tokens/components/radio-group.json
@@ -2,7 +2,7 @@
   "dsn": {
     "radio-group": {
       "border-width": {
-        "$value": "0px",
+        "$value": "{dsn.border.width.none}",
         "$type": "dimension",
         "$description": "No border by default for fieldset"
       },
@@ -12,12 +12,12 @@
         "$description": "Space between radio options in the group"
       },
       "margin": {
-        "$value": "0px",
+        "$value": "{dsn.space.none}",
         "$type": "dimension",
         "$description": "No margin by default for fieldset"
       },
       "padding": {
-        "$value": "0px",
+        "$value": "{dsn.space.none}",
         "$type": "dimension",
         "$description": "No padding by default for fieldset"
       },

--- a/packages/design-tokens/src/tokens/components/skip-link.json
+++ b/packages/design-tokens/src/tokens/components/skip-link.json
@@ -2,9 +2,9 @@
   "dsn": {
     "skip-link": {
       "z-index": {
-        "$value": "600",
+        "$value": "{dsn.z-index.600}",
         "$type": "number",
-        "$description": "Hoogste z-index — boven modals (500) en backdrop (400), zodat de skip-link altijd zichtbaar is bij focus"
+        "$description": "Hoogste z-index — boven modals ({dsn.z-index.500}) en backdrop ({dsn.z-index.400}), zodat de skip-link altijd zichtbaar is bij focus"
       },
       "padding-block": {
         "$value": "{dsn.space.block.md}",

--- a/packages/design-tokens/src/tokens/themes/start/base.json
+++ b/packages/design-tokens/src/tokens/themes/start/base.json
@@ -68,6 +68,10 @@
       }
     },
     "space": {
+      "none": {
+        "$value": "0px",
+        "$description": "No spacing"
+      },
       "base": {
         "$value": "0.5rem",
         "$description": "8px - Base unit for 8pt grid system"
@@ -341,6 +345,10 @@
     },
     "border": {
       "radius": {
+        "square": {
+          "$value": "0px",
+          "$description": "No border radius — square corners"
+        },
         "sm": {
           "$value": "4px",
           "$description": "Small border radius"
@@ -359,6 +367,10 @@
         }
       },
       "width": {
+        "none": {
+          "$value": "0px",
+          "$description": "No border width"
+        },
         "thin": {
           "$value": "1px",
           "$description": "Thin border"
@@ -434,7 +446,7 @@
         "$description": "Form control maximum width"
       },
       "border-radius": {
-        "$value": "0px",
+        "$value": "{dsn.border.radius.square}",
         "$type": "dimension",
         "$description": "Form control border radius"
       },
@@ -523,6 +535,10 @@
       }
     },
     "box-shadow": {
+      "none": {
+        "$value": "none",
+        "$description": "Geen elevatie — vlak oppervlak zonder schaduw"
+      },
       "sm": {
         "$value": "0 1px 2px 0 {dsn.color.shadow.direct}, 0 2px 4px 0 {dsn.color.shadow.ambient}, 0 0 0 1px {dsn.color.shadow.highlight}",
         "$description": "Kleine elevatie — cards, chips, kleine floating elementen"
@@ -534,6 +550,33 @@
       "lg": {
         "$value": "0 4px 8px 0 {dsn.color.shadow.direct}, 0 16px 32px 0 {dsn.color.shadow.ambient}, 0 0 0 1px {dsn.color.shadow.highlight}",
         "$description": "Grote elevatie — modals, dialogen, side panels"
+      }
+    },
+    "z-index": {
+      "300": {
+        "$value": "300",
+        "$type": "number",
+        "$description": "Sticky navigatie-elementen — PageHeader sticky/auto-hide"
+      },
+      "350": {
+        "$value": "350",
+        "$type": "number",
+        "$description": "Floating UI-elementen — Popover, tooltips, dropdowns"
+      },
+      "400": {
+        "$value": "400",
+        "$type": "number",
+        "$description": "Verduisterende laag — Backdrop achter modals en drawers"
+      },
+      "500": {
+        "$value": "500",
+        "$type": "number",
+        "$description": "Modale lagen — ModalDialog, Drawer"
+      },
+      "600": {
+        "$value": "600",
+        "$type": "number",
+        "$description": "Altijd bovenaan — SkipLink (toegankelijkheid)"
       }
     },
     "transition": {

--- a/packages/design-tokens/src/tokens/themes/wireframe/base.json
+++ b/packages/design-tokens/src/tokens/themes/wireframe/base.json
@@ -68,6 +68,10 @@
       }
     },
     "space": {
+      "none": {
+        "$value": "0px",
+        "$description": "No spacing"
+      },
       "base": {
         "$value": "0.5rem",
         "$description": "8px - Base unit for 8pt grid system"
@@ -341,6 +345,10 @@
     },
     "border": {
       "radius": {
+        "square": {
+          "$value": "0px",
+          "$description": "No border radius — square corners"
+        },
         "sm": {
           "$value": "2px",
           "$description": "Small border radius - minimal for wireframe"
@@ -359,6 +367,10 @@
         }
       },
       "width": {
+        "none": {
+          "$value": "0px",
+          "$description": "No border width"
+        },
         "thin": {
           "$value": "2px",
           "$description": "Thin border"
@@ -523,6 +535,10 @@
       }
     },
     "box-shadow": {
+      "none": {
+        "$value": "none",
+        "$description": "Geen elevatie — vlak oppervlak zonder schaduw"
+      },
       "sm": {
         "$value": "none",
         "$description": "Small elevation — flat in wireframe theme"
@@ -534,6 +550,33 @@
       "lg": {
         "$value": "none",
         "$description": "Large elevation — flat in wireframe theme"
+      }
+    },
+    "z-index": {
+      "300": {
+        "$value": "300",
+        "$type": "number",
+        "$description": "Sticky navigatie-elementen — PageHeader sticky/auto-hide"
+      },
+      "350": {
+        "$value": "350",
+        "$type": "number",
+        "$description": "Floating UI-elementen — Popover, tooltips, dropdowns"
+      },
+      "400": {
+        "$value": "400",
+        "$type": "number",
+        "$description": "Verduisterende laag — Backdrop achter modals en drawers"
+      },
+      "500": {
+        "$value": "500",
+        "$type": "number",
+        "$description": "Modale lagen — ModalDialog, Drawer"
+      },
+      "600": {
+        "$value": "600",
+        "$type": "number",
+        "$description": "Altijd bovenaan — SkipLink (toegankelijkheid)"
       }
     },
     "transition": {

--- a/packages/storybook/src/DesignTokens.mdx
+++ b/packages/storybook/src/DesignTokens.mdx
@@ -26,6 +26,7 @@ Design tokens are the single source of truth for colors, typography, spacing, bo
   <li><TocLink targetId="content-sizing">Content Sizing</TocLink></li>
   <li><TocLink targetId="form-control-sizing">Form Control Sizing</TocLink></li>
   <li><TocLink targetId="box-shadows">Box Shadows</TocLink></li>
+  <li><TocLink targetId="z-index">Z-Index</TocLink></li>
   <li><TocLink targetId="motion">Motion</TocLink></li>
   <li><TocLink targetId="breakpoints">Breakpoints</TocLink></li>
 </OrderedList>
@@ -491,6 +492,15 @@ All alias accent-1-inverse by default. Available CSS variables:
 All spacing is based on a `0.5rem` (8px) base unit, following an 8-point grid system.
 The system defines five spacing concepts: **row** (vertical between components), **column** (horizontal between components), **inline** (horizontal within components), **block** (vertical within components), and **text** (between text and icons).
 
+### None
+
+<TokenTable
+  previewType="spacing"
+  tokens={[
+    { name: 'none', cssVar: '--dsn-space-none', value: '0px' },
+  ]}
+/>
+
 ### Row Spacing (vertical between components)
 
 <TokenTable
@@ -592,6 +602,7 @@ The system defines five spacing concepts: **row** (vertical between components),
 
 <TokenTable
   tokens={[
+    { name: 'None', cssVar: '--dsn-border-width-none', value: '0px' },
     { name: 'Thin', cssVar: '--dsn-border-width-thin', value: '1px' },
     { name: 'Medium', cssVar: '--dsn-border-width-medium', value: '2px' },
     { name: 'Thick', cssVar: '--dsn-border-width-thick', value: '4px' },
@@ -603,6 +614,7 @@ The system defines five spacing concepts: **row** (vertical between components),
 <TokenTable
   previewType="border-radius"
   tokens={[
+    { name: 'square', cssVar: '--dsn-border-radius-square', value: '0px' },
     { name: 'sm', cssVar: '--dsn-border-radius-sm', value: '4px' },
     { name: 'md', cssVar: '--dsn-border-radius-md', value: '8px' },
     { name: 'lg', cssVar: '--dsn-border-radius-lg', value: '16px' },
@@ -721,9 +733,26 @@ The three primitives that power all elevation shadows. In light mode `highlight`
 <TokenTable
   previewType="shadow"
   tokens={[
+    { name: 'none: Flat, no elevation', cssVar: '--dsn-box-shadow-none', value: 'none' },
     { name: 'sm: Cards, chips', cssVar: '--dsn-box-shadow-sm' },
     { name: 'md: Dropdowns, tooltips', cssVar: '--dsn-box-shadow-md' },
     { name: 'lg: Modals, dialogs', cssVar: '--dsn-box-shadow-lg' },
+  ]}
+/>
+
+---
+
+## Z-Index
+
+Z-index tokens definiëren de stapelvolgorde van UI-lagen. De tokennaam is gelijk aan de waarde, zodat er altijd ruimte is om tussenliggende niveaus toe te voegen.
+
+<TokenTable
+  tokens={[
+    { name: '300 — PageHeader (sticky/auto-hide)', cssVar: '--dsn-z-index-300', value: '300' },
+    { name: '350 — Popover, tooltips, dropdowns', cssVar: '--dsn-z-index-350', value: '350' },
+    { name: '400 — Backdrop (achter modals/drawers)', cssVar: '--dsn-z-index-400', value: '400' },
+    { name: '500 — ModalDialog, Drawer', cssVar: '--dsn-z-index-500', value: '500' },
+    { name: '600 — SkipLink (altijd bovenaan)', cssVar: '--dsn-z-index-600', value: '600' },
   ]}
 />
 


### PR DESCRIPTION
## Summary

- Vier nieuwe `none`-tokens zodat component tokens niet langer hardcoded `0px` bevatten: `border.radius.square`, `border.width.none`, `space.none`, `box-shadow.none`
- Negen nieuwe `z-index` tokens (300/350/400/500/600) — tokennaam is gelijk aan de waarde zodat er altijd ruimte is voor tussenliggende niveaus
- 16 component tokens bijgewerkt van hardcoded waarden naar semantische token-referenties
- Bugfix: Popover z-index gecorrigeerd van 300 → 350 (was gelijk aan PageHeader, nu daadwerkelijk erboven)
- Beide themes (`start` + `wireframe`) gesynchroniseerd
- Storybook DesignTokens.mdx bijgewerkt met nieuwe rijen en Z-Index sectie
- `docs/02-design-tokens-reference.md` bijgewerkt met Box Shadows, Z-Index secties en nieuwe token-waarden

## Test plan

- [x] `node src/config/build.js` — alle 8 configuraties bouwen succesvol
- [x] 1442 tests, 72 suites — allemaal groen
- [x] TypeScript clean: `pnpm --filter storybook exec tsc --noEmit`
- [x] Visuele check in Storybook: Foundations → Design Tokens → Borders, Spacing, Box Shadows, Z-Index

🤖 Generated with [Claude Code](https://claude.com/claude-code)