### PR TITLE
fix(Templates): verwijder stapindicator uit Simple details stories

### DIFF
--- a/packages/storybook/src/templates/FormStepSimplePage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepSimplePage.stories.tsx
@@ -84,8 +84,6 @@ export const Example: Story = {
                   </Link>
 
                   <Stack space="sm">
-                    <Paragraph>Stap 1 van 5</Paragraph>
-
                     <h2 className="dsn-heading dsn-heading--heading-2">
                       Uw gegevens
                     </h2>
@@ -167,8 +165,6 @@ export const WithUpload: Story = {
                   </Link>
 
                   <Stack space="sm">
-                    <Paragraph>Stap 1 van 5</Paragraph>
-
                     <h2 className="dsn-heading dsn-heading--heading-2">
                       Uw gegevens
                     </h2>


### PR DESCRIPTION
## Summary

- Verwijdert 'Stap 1 van 5' uit beide Simple details stories
- Voortgang wordt later apart getoond via een dedicated story voor meerstappenformulieren

## Test plan

- [ ] Beide stories tonen geen stapindicator meer

🤖 Generated with [Claude Code](https://claude.com/claude-code)