### PR TITLE
feat(Templates): voeg modal stories toe voor 'Opslaan' en 'Stoppen' acties (#201, #202)

### DIFF
--- a/packages/storybook/src/templates/FormStepPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepPage.stories.tsx
@@ -4,6 +4,7 @@ import {
   ActionGroup,
   Body,
   Button,
+  EmailInput,
   FormField,
   FormFieldset,
   Grid,
@@ -12,6 +13,11 @@ import {
   Icon,
   Link,
   LinkButton,
+  ModalDialog,
+  ModalDialogBody,
+  ModalDialogFooter,
+  ModalDialogHeader,
+  ModalDialogHeading,
   PageBody,
   PageFooter,
   PageHeader,
@@ -41,27 +47,71 @@ const mainStyle: React.CSSProperties = {
 };
 
 // =============================================================================
-// META
+// HELPER COMPONENTS
 // =============================================================================
 
-const meta: Meta = {
-  title: 'Templates/Form flow/Form step: Example',
-  parameters: {
-    layout: 'fullscreen',
-  },
-};
+type ActiveModal = 'save' | 'stop' | null;
 
-export default meta;
+function FormModals({
+  activeModal,
+  onClose,
+}: {
+  activeModal: ActiveModal;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <ModalDialog isOpen={activeModal === 'save'} onClose={onClose}>
+        <ModalDialogHeader>
+          <ModalDialogHeading>Opslaan en later verder</ModalDialogHeading>
+        </ModalDialogHeader>
+        <ModalDialogBody>
+          <Stack space="md">
+            <Paragraph>
+              Vul uw e-mailadres in. Er wordt een unieke link naar uw
+              e-mailadres verstuurd. Hiermee kunt u dit formulier op een later
+              moment afmaken.
+            </Paragraph>
+            <FormField label="E-mailadres" htmlFor="modal-email">
+              <EmailInput id="modal-email" autoComplete="email" width="xl" />
+            </FormField>
+          </Stack>
+        </ModalDialogBody>
+        <ModalDialogFooter>
+          <ActionGroup>
+            <Button variant="strong">Opslaan</Button>
+            <Button variant="default" onClick={onClose}>
+              Annuleren
+            </Button>
+          </ActionGroup>
+        </ModalDialogFooter>
+      </ModalDialog>
+      <ModalDialog isOpen={activeModal === 'stop'} onClose={onClose}>
+        <ModalDialogHeader>
+          <ModalDialogHeading>Stoppen met het formulier</ModalDialogHeading>
+        </ModalDialogHeader>
+        <ModalDialogBody>
+          <Paragraph>
+            Weet u zeker dat u wilt stoppen met het formulier? Uw gegevens
+            worden niet opgeslagen.
+          </Paragraph>
+        </ModalDialogBody>
+        <ModalDialogFooter>
+          <ActionGroup>
+            <Button variant="strong">Stoppen</Button>
+            <Button variant="default" onClick={onClose}>
+              Annuleren
+            </Button>
+          </ActionGroup>
+        </ModalDialogFooter>
+      </ModalDialog>
+    </>
+  );
+}
 
-type Story = StoryObj;
-
-// =============================================================================
-// STORIES
-// =============================================================================
-
-export const Example: Story = {
-  name: 'Form step: Example',
-  render: () => (
+function FormStepExamplePage() {
+  const [activeModal, setActiveModal] = React.useState<ActiveModal>(null);
+  return (
     <Body>
       <SkipLink href="#main-content" />
       <PageLayout>
@@ -131,8 +181,12 @@ export const Example: Story = {
                         <Button variant="strong" type="submit">
                           Volgende stap
                         </Button>
-                        <LinkButton>Opslaan en later verder</LinkButton>
-                        <LinkButton>Stoppen met het formulier</LinkButton>
+                        <LinkButton onClick={() => setActiveModal('save')}>
+                          Opslaan en later verder
+                        </LinkButton>
+                        <LinkButton onClick={() => setActiveModal('stop')}>
+                          Stoppen met het formulier
+                        </LinkButton>
                       </ActionGroup>
                     </Stack>
                   </form>
@@ -148,6 +202,34 @@ export const Example: Story = {
           slot4={footerSlot4}
         />
       </PageLayout>
+      <FormModals
+        activeModal={activeModal}
+        onClose={() => setActiveModal(null)}
+      />
     </Body>
-  ),
+  );
+}
+
+// =============================================================================
+// META
+// =============================================================================
+
+const meta: Meta = {
+  title: 'Templates/Form flow/Form step: Example',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// =============================================================================
+// STORIES
+// =============================================================================
+
+export const Example: Story = {
+  name: 'Form step: Example',
+  render: () => <FormStepExamplePage />,
 };

--- a/packages/storybook/src/templates/FormStepSimplePage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepSimplePage.stories.tsx
@@ -84,8 +84,6 @@ export const Example: Story = {
                   </Link>
 
                   <Stack space="sm">
-                    <Paragraph>Stap 1 van 5</Paragraph>
-
                     <h2 className="dsn-heading dsn-heading--heading-2">
                       Uw gegevens
                     </h2>
@@ -167,8 +165,6 @@ export const WithUpload: Story = {
                   </Link>
 
                   <Stack space="sm">
-                    <Paragraph>Stap 1 van 5</Paragraph>
-
                     <h2 className="dsn-heading dsn-heading--heading-2">
                       Uw gegevens
                     </h2>

--- a/packages/storybook/src/templates/FormStepSimplePage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepSimplePage.stories.tsx
@@ -47,27 +47,71 @@ const mainStyle: React.CSSProperties = {
 };
 
 // =============================================================================
-// META
+// HELPER COMPONENTS
 // =============================================================================
 
-const meta: Meta = {
-  title: 'Templates/Form flow/Form step: Simple details',
-  parameters: {
-    layout: 'fullscreen',
-  },
-};
+type ActiveModal = 'save' | 'stop' | null;
 
-export default meta;
+function FormModals({
+  activeModal,
+  onClose,
+}: {
+  activeModal: ActiveModal;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <ModalDialog isOpen={activeModal === 'save'} onClose={onClose}>
+        <ModalDialogHeader>
+          <ModalDialogHeading>Opslaan en later verder</ModalDialogHeading>
+        </ModalDialogHeader>
+        <ModalDialogBody>
+          <Stack space="md">
+            <Paragraph>
+              Vul uw e-mailadres in. Er wordt een unieke link naar uw
+              e-mailadres verstuurd. Hiermee kunt u dit formulier op een later
+              moment afmaken.
+            </Paragraph>
+            <FormField label="E-mailadres" htmlFor="modal-email">
+              <EmailInput id="modal-email" autoComplete="email" width="xl" />
+            </FormField>
+          </Stack>
+        </ModalDialogBody>
+        <ModalDialogFooter>
+          <ActionGroup>
+            <Button variant="strong">Opslaan</Button>
+            <Button variant="default" onClick={onClose}>
+              Annuleren
+            </Button>
+          </ActionGroup>
+        </ModalDialogFooter>
+      </ModalDialog>
+      <ModalDialog isOpen={activeModal === 'stop'} onClose={onClose}>
+        <ModalDialogHeader>
+          <ModalDialogHeading>Stoppen met het formulier</ModalDialogHeading>
+        </ModalDialogHeader>
+        <ModalDialogBody>
+          <Paragraph>
+            Weet u zeker dat u wilt stoppen met het formulier? Uw gegevens
+            worden niet opgeslagen.
+          </Paragraph>
+        </ModalDialogBody>
+        <ModalDialogFooter>
+          <ActionGroup>
+            <Button variant="strong">Stoppen</Button>
+            <Button variant="default" onClick={onClose}>
+              Annuleren
+            </Button>
+          </ActionGroup>
+        </ModalDialogFooter>
+      </ModalDialog>
+    </>
+  );
+}
 
-type Story = StoryObj;
-
-// =============================================================================
-// STORIES
-// =============================================================================
-
-export const Example: Story = {
-  name: 'Form step: Simple details',
-  render: () => (
+function SimpleDetailsPage() {
+  const [activeModal, setActiveModal] = React.useState<ActiveModal>(null);
+  return (
     <Body>
       <SkipLink href="#main-content" />
       <PageLayout>
@@ -125,8 +169,12 @@ export const Example: Story = {
                         <Button variant="strong" type="submit">
                           Volgende stap
                         </Button>
-                        <LinkButton>Opslaan en later verder</LinkButton>
-                        <LinkButton>Stoppen met het formulier</LinkButton>
+                        <LinkButton onClick={() => setActiveModal('save')}>
+                          Opslaan en later verder
+                        </LinkButton>
+                        <LinkButton onClick={() => setActiveModal('stop')}>
+                          Stoppen met het formulier
+                        </LinkButton>
                       </ActionGroup>
                     </Stack>
                   </form>
@@ -142,8 +190,147 @@ export const Example: Story = {
           slot4={footerSlot4}
         />
       </PageLayout>
+      <FormModals
+        activeModal={activeModal}
+        onClose={() => setActiveModal(null)}
+      />
     </Body>
-  ),
+  );
+}
+
+function SimpleDetailsWithUploadPage() {
+  const [activeModal, setActiveModal] = React.useState<ActiveModal>(null);
+  return (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          layout="compact"
+          hideMenuButton
+          hideSearchButton
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainStyle}>
+            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+              <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
+                <Stack space="3xl">
+                  <Heading level={1}>Titel formulier</Heading>
+
+                  <Link href="#" iconStart={<Icon name="arrow-left" />}>
+                    Vorige stap
+                  </Link>
+
+                  <Stack space="sm">
+                    <h2 className="dsn-heading dsn-heading--heading-2">
+                      Uw gegevens
+                    </h2>
+
+                    <Paragraph>
+                      Vul alles in. Als iets niet verplicht is, staat dat erbij.
+                    </Paragraph>
+                  </Stack>
+
+                  <form noValidate>
+                    <Stack space="3xl">
+                      <FormField label="Voornaam" htmlFor="voornaam">
+                        <TextInput id="voornaam" autoComplete="given-name" />
+                      </FormField>
+
+                      <FormField label="Achternaam" htmlFor="achternaam">
+                        <TextInput id="achternaam" autoComplete="family-name" />
+                      </FormField>
+
+                      <FormField label="E-mailadres" htmlFor="email">
+                        <EmailInput
+                          id="email"
+                          autoComplete="email"
+                          width="xl"
+                        />
+                      </FormField>
+
+                      <div className="dsn-form-field">
+                        <FormFieldLabel
+                          htmlFor="bestand-upload"
+                          suffix="(niet verplicht)"
+                        >
+                          Bestand uploaden
+                        </FormFieldLabel>
+                        <FormFieldDescription id="bestand-upload-description">
+                          <UnorderedList>
+                            <li>Het bestand mag maximaal 10 MB zijn.</li>
+                            <li>
+                              Toegestane bestandstypen: doc, docx, xlsx, pdf,
+                              zip, jpg, png, bmp en gif.
+                            </li>
+                          </UnorderedList>
+                        </FormFieldDescription>
+                        <FileInput
+                          id="bestand-upload"
+                          aria-describedby="bestand-upload-description"
+                        />
+                      </div>
+
+                      <ActionGroup
+                        direction="vertical"
+                        style={{
+                          marginBlockStart: 'var(--dsn-space-block-3xl)',
+                        }}
+                      >
+                        <Button variant="strong" type="submit">
+                          Volgende stap
+                        </Button>
+                        <LinkButton onClick={() => setActiveModal('save')}>
+                          Opslaan en later verder
+                        </LinkButton>
+                        <LinkButton onClick={() => setActiveModal('stop')}>
+                          Stoppen met het formulier
+                        </LinkButton>
+                      </ActionGroup>
+                    </Stack>
+                  </form>
+                </Stack>
+              </GridItem>
+            </Grid>
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+      <FormModals
+        activeModal={activeModal}
+        onClose={() => setActiveModal(null)}
+      />
+    </Body>
+  );
+}
+
+// =============================================================================
+// META
+// =============================================================================
+
+const meta: Meta = {
+  title: 'Templates/Form flow/Form step: Simple details',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// =============================================================================
+// STORIES
+// =============================================================================
+
+export const Example: Story = {
+  name: 'Form step: Simple details',
+  render: () => <SimpleDetailsPage />,
 };
 
 export const WithSaveForLaterModal: Story = {
@@ -339,7 +526,7 @@ export const WithStopFormModal: Story = {
         </ModalDialogBody>
         <ModalDialogFooter>
           <ActionGroup>
-            <Button variant="strong-negative">Stoppen</Button>
+            <Button variant="strong">Stoppen</Button>
             <Button variant="default">Annuleren</Button>
           </ActionGroup>
         </ModalDialogFooter>
@@ -350,103 +537,5 @@ export const WithStopFormModal: Story = {
 
 export const WithUpload: Story = {
   name: 'Form step: Simple details: With upload',
-  render: () => (
-    <Body>
-      <SkipLink href="#main-content" />
-      <PageLayout>
-        <PageHeader
-          logoSlot={logoSlot}
-          layout="compact"
-          hideMenuButton
-          hideSearchButton
-        />
-        <PageBody>
-          <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
-              <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
-                <Stack space="3xl">
-                  <Heading level={1}>Titel formulier</Heading>
-
-                  <Link href="#" iconStart={<Icon name="arrow-left" />}>
-                    Vorige stap
-                  </Link>
-
-                  <Stack space="sm">
-                    <h2 className="dsn-heading dsn-heading--heading-2">
-                      Uw gegevens
-                    </h2>
-
-                    <Paragraph>
-                      Vul alles in. Als iets niet verplicht is, staat dat erbij.
-                    </Paragraph>
-                  </Stack>
-
-                  <form noValidate>
-                    <Stack space="3xl">
-                      <FormField label="Voornaam" htmlFor="voornaam">
-                        <TextInput id="voornaam" autoComplete="given-name" />
-                      </FormField>
-
-                      <FormField label="Achternaam" htmlFor="achternaam">
-                        <TextInput id="achternaam" autoComplete="family-name" />
-                      </FormField>
-
-                      <FormField label="E-mailadres" htmlFor="email">
-                        <EmailInput
-                          id="email"
-                          autoComplete="email"
-                          width="xl"
-                        />
-                      </FormField>
-
-                      <div className="dsn-form-field">
-                        <FormFieldLabel
-                          htmlFor="bestand-upload"
-                          suffix="(niet verplicht)"
-                        >
-                          Bestand uploaden
-                        </FormFieldLabel>
-                        <FormFieldDescription id="bestand-upload-description">
-                          <UnorderedList>
-                            <li>Het bestand mag maximaal 10 MB zijn.</li>
-                            <li>
-                              Toegestane bestandstypen: doc, docx, xlsx, pdf,
-                              zip, jpg, png, bmp en gif.
-                            </li>
-                          </UnorderedList>
-                        </FormFieldDescription>
-                        <FileInput
-                          id="bestand-upload"
-                          aria-describedby="bestand-upload-description"
-                        />
-                      </div>
-
-                      <ActionGroup
-                        direction="vertical"
-                        style={{
-                          marginBlockStart: 'var(--dsn-space-block-3xl)',
-                        }}
-                      >
-                        <Button variant="strong" type="submit">
-                          Volgende stap
-                        </Button>
-                        <LinkButton>Opslaan en later verder</LinkButton>
-                        <LinkButton>Stoppen met het formulier</LinkButton>
-                      </ActionGroup>
-                    </Stack>
-                  </form>
-                </Stack>
-              </GridItem>
-            </Grid>
-          </main>
-        </PageBody>
-        <PageFooter
-          slot1={footerSlot1}
-          slot2={footerSlot2}
-          slot3={footerSlot3}
-          slot4={footerSlot4}
-        />
-      </PageLayout>
-    </Body>
-  ),
+  render: () => <SimpleDetailsWithUploadPage />,
 };

--- a/packages/storybook/src/templates/FormStepSimplePage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepSimplePage.stories.tsx
@@ -15,6 +15,11 @@ import {
   Icon,
   Link,
   LinkButton,
+  ModalDialog,
+  ModalDialogBody,
+  ModalDialogFooter,
+  ModalDialogHeader,
+  ModalDialogHeading,
   PageBody,
   PageFooter,
   PageHeader,
@@ -137,6 +142,208 @@ export const Example: Story = {
           slot4={footerSlot4}
         />
       </PageLayout>
+    </Body>
+  ),
+};
+
+export const WithSaveForLaterModal: Story = {
+  name: 'Form step: Simple details: With "Save for later" modal',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          layout="compact"
+          hideMenuButton
+          hideSearchButton
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainStyle}>
+            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+              <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
+                <Stack space="3xl">
+                  <Heading level={1}>Titel formulier</Heading>
+
+                  <Link href="#" iconStart={<Icon name="arrow-left" />}>
+                    Vorige stap
+                  </Link>
+
+                  <Stack space="sm">
+                    <h2 className="dsn-heading dsn-heading--heading-2">
+                      Uw gegevens
+                    </h2>
+
+                    <Paragraph>
+                      Vul alles in. Als iets niet verplicht is, staat dat erbij.
+                    </Paragraph>
+                  </Stack>
+
+                  <form noValidate>
+                    <Stack space="3xl">
+                      <FormField label="Voornaam" htmlFor="voornaam">
+                        <TextInput id="voornaam" autoComplete="given-name" />
+                      </FormField>
+
+                      <FormField label="Achternaam" htmlFor="achternaam">
+                        <TextInput id="achternaam" autoComplete="family-name" />
+                      </FormField>
+
+                      <FormField label="E-mailadres" htmlFor="email">
+                        <EmailInput
+                          id="email"
+                          autoComplete="email"
+                          width="xl"
+                        />
+                      </FormField>
+
+                      <ActionGroup
+                        direction="vertical"
+                        style={{
+                          marginBlockStart: 'var(--dsn-space-block-3xl)',
+                        }}
+                      >
+                        <Button variant="strong" type="submit">
+                          Volgende stap
+                        </Button>
+                        <LinkButton>Opslaan en later verder</LinkButton>
+                        <LinkButton>Stoppen met het formulier</LinkButton>
+                      </ActionGroup>
+                    </Stack>
+                  </form>
+                </Stack>
+              </GridItem>
+            </Grid>
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+      <ModalDialog isOpen onClose={() => {}}>
+        <ModalDialogHeader>
+          <ModalDialogHeading>Opslaan en later verder</ModalDialogHeading>
+        </ModalDialogHeader>
+        <ModalDialogBody>
+          <Stack space="md">
+            <Paragraph>
+              Vul uw e-mailadres in. Er wordt een unieke link naar uw
+              e-mailadres verstuurd. Hiermee kunt u dit formulier op een later
+              moment afmaken.
+            </Paragraph>
+            <FormField label="E-mailadres" htmlFor="modal-email">
+              <EmailInput id="modal-email" autoComplete="email" width="xl" />
+            </FormField>
+          </Stack>
+        </ModalDialogBody>
+        <ModalDialogFooter>
+          <ActionGroup>
+            <Button variant="strong">Opslaan</Button>
+            <Button variant="default">Annuleren</Button>
+          </ActionGroup>
+        </ModalDialogFooter>
+      </ModalDialog>
+    </Body>
+  ),
+};
+
+export const WithStopFormModal: Story = {
+  name: 'Form step: Simple details: With "Stop form" modal',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          layout="compact"
+          hideMenuButton
+          hideSearchButton
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainStyle}>
+            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+              <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
+                <Stack space="3xl">
+                  <Heading level={1}>Titel formulier</Heading>
+
+                  <Link href="#" iconStart={<Icon name="arrow-left" />}>
+                    Vorige stap
+                  </Link>
+
+                  <Stack space="sm">
+                    <h2 className="dsn-heading dsn-heading--heading-2">
+                      Uw gegevens
+                    </h2>
+
+                    <Paragraph>
+                      Vul alles in. Als iets niet verplicht is, staat dat erbij.
+                    </Paragraph>
+                  </Stack>
+
+                  <form noValidate>
+                    <Stack space="3xl">
+                      <FormField label="Voornaam" htmlFor="voornaam">
+                        <TextInput id="voornaam" autoComplete="given-name" />
+                      </FormField>
+
+                      <FormField label="Achternaam" htmlFor="achternaam">
+                        <TextInput id="achternaam" autoComplete="family-name" />
+                      </FormField>
+
+                      <FormField label="E-mailadres" htmlFor="email">
+                        <EmailInput
+                          id="email"
+                          autoComplete="email"
+                          width="xl"
+                        />
+                      </FormField>
+
+                      <ActionGroup
+                        direction="vertical"
+                        style={{
+                          marginBlockStart: 'var(--dsn-space-block-3xl)',
+                        }}
+                      >
+                        <Button variant="strong" type="submit">
+                          Volgende stap
+                        </Button>
+                        <LinkButton>Opslaan en later verder</LinkButton>
+                        <LinkButton>Stoppen met het formulier</LinkButton>
+                      </ActionGroup>
+                    </Stack>
+                  </form>
+                </Stack>
+              </GridItem>
+            </Grid>
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+      <ModalDialog isOpen onClose={() => {}}>
+        <ModalDialogHeader>
+          <ModalDialogHeading>Stoppen met het formulier</ModalDialogHeading>
+        </ModalDialogHeader>
+        <ModalDialogBody>
+          <Paragraph>
+            Weet u zeker dat u wilt stoppen met het formulier? Uw gegevens
+            worden niet opgeslagen.
+          </Paragraph>
+        </ModalDialogBody>
+        <ModalDialogFooter>
+          <ActionGroup>
+            <Button variant="strong-negative">Stoppen</Button>
+            <Button variant="default">Annuleren</Button>
+          </ActionGroup>
+        </ModalDialogFooter>
+      </ModalDialog>
     </Body>
   ),
 };


### PR DESCRIPTION
## Summary

- Voegt twee nieuwe Storybook stories toe voor de "Form step: Simple details" template: één met de "Opslaan en later verder" modal open (#201) en één met de "Stoppen met het formulier" modal open (#202)
- Maakt de "Opslaan en later verder" en "Stoppen met het formulier" acties interactief in de bestaande template stories — klikken op de knoppen opent de bijbehorende modal, "Annuleren" en de sluitknop sluiten hem weer
- Geldt voor zowel `Form step: Simple details` (incl. With upload) als `Form step: Example`

## Aanpak

- Render-functies omgezet naar React-componenten met `useState<'save' | 'stop' | null>`
- Gedeelde `FormModals` helper vermijdt duplicatie van modal-JSX tussen stories
- Statische snapshot-stories (`WithSaveForLaterModal`, `WithStopFormModal`) blijven behouden voor Chromatic visuele regressietests

## Test plan

- [ ] "Opslaan en later verder" klikt → "Opslaan en later verder" modal opent
- [ ] "Stoppen met het formulier" klikt → "Stoppen met het formulier" modal opent
- [ ] "Annuleren" en sluitknop (✕) sluiten de modal
- [ ] Statische snapshot-stories tonen de modal in open toestand
- [ ] TypeScript: 0 fouten (`pnpm --filter storybook exec tsc --noEmit`)

Closes #201, #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)