### PR TITLE
fix(Table,SummaryList): gelijktrek verwijderactie + pencil-icoon + ruimere gap

### DIFF
--- a/packages/components-html/assets/icons/pencil.svg
+++ b/packages/components-html/assets/icons/pencil.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 20h4l10.5 -10.5a2.828 2.828 0 1 0 -4 -4l-10.5 10.5v4" />
+  <path d="M13.5 6.5l4 4" />
+</svg>

--- a/packages/design-tokens/src/tokens/components/summary-list.json
+++ b/packages/design-tokens/src/tokens/components/summary-list.json
@@ -49,7 +49,7 @@
       },
       "actions": {
         "gap": {
-          "$value": "{dsn.space.inline.lg}",
+          "$value": "{dsn.space.inline.3xl}",
           "$type": "dimension",
           "$description": "Gap between multiple action links in a single row"
         },

--- a/packages/storybook/src/SummaryList.stories.tsx
+++ b/packages/storybook/src/SummaryList.stories.tsx
@@ -67,7 +67,7 @@ export const WithActions: Story = {
         <SummaryListKey>Naam</SummaryListKey>
         <SummaryListValue>Jeroen van Drouwen</SummaryListValue>
         <SummaryListActions>
-          <Link href="#" iconStart={<Icon name="edit" />}>
+          <Link href="#" iconStart={<Icon name="pencil" />}>
             Wijzig<span className="dsn-visually-hidden"> naam</span>
           </Link>
         </SummaryListActions>
@@ -76,7 +76,7 @@ export const WithActions: Story = {
         <SummaryListKey>Geboortedatum</SummaryListKey>
         <SummaryListValue>9 december 1984</SummaryListValue>
         <SummaryListActions>
-          <Link href="#" iconStart={<Icon name="edit" />}>
+          <Link href="#" iconStart={<Icon name="pencil" />}>
             Wijzig<span className="dsn-visually-hidden"> geboortedatum</span>
           </Link>
         </SummaryListActions>
@@ -87,7 +87,7 @@ export const WithActions: Story = {
           Laan der Voorbeelden, 1440 VP, Westerhaar-Vriezenveensewijk
         </SummaryListValue>
         <SummaryListActions>
-          <Link href="#" iconStart={<Icon name="edit" />}>
+          <Link href="#" iconStart={<Icon name="pencil" />}>
             Wijzig<span className="dsn-visually-hidden"> adres</span>
           </Link>
         </SummaryListActions>
@@ -104,7 +104,7 @@ export const WithMultipleActions: Story = {
         <SummaryListKey>Naam</SummaryListKey>
         <SummaryListValue>Jeroen van Drouwen</SummaryListValue>
         <SummaryListActions>
-          <Link href="#" iconStart={<Icon name="edit" />}>
+          <Link href="#" iconStart={<Icon name="pencil" />}>
             Wijzig<span className="dsn-visually-hidden"> naam</span>
           </Link>
           <LinkButton onClick={() => {}} iconStart={<Icon name="trash" />}>
@@ -116,7 +116,7 @@ export const WithMultipleActions: Story = {
         <SummaryListKey>Geboortedatum</SummaryListKey>
         <SummaryListValue>9 december 1984</SummaryListValue>
         <SummaryListActions>
-          <Link href="#" iconStart={<Icon name="edit" />}>
+          <Link href="#" iconStart={<Icon name="pencil" />}>
             Wijzig<span className="dsn-visually-hidden"> geboortedatum</span>
           </Link>
           <LinkButton onClick={() => {}} iconStart={<Icon name="trash" />}>
@@ -130,7 +130,7 @@ export const WithMultipleActions: Story = {
           Laan der Voorbeelden, 1440 VP, Westerhaar-Vriezenveensewijk
         </SummaryListValue>
         <SummaryListActions>
-          <Link href="#" iconStart={<Icon name="edit" />}>
+          <Link href="#" iconStart={<Icon name="pencil" />}>
             Wijzig<span className="dsn-visually-hidden"> adres</span>
           </Link>
           <LinkButton onClick={() => {}} iconStart={<Icon name="trash" />}>
@@ -150,7 +150,7 @@ export const MixedRows: Story = {
         <SummaryListKey>Naam</SummaryListKey>
         <SummaryListValue>Jeroen van Drouwen</SummaryListValue>
         <SummaryListActions>
-          <Link href="#" iconStart={<Icon name="edit" />}>
+          <Link href="#" iconStart={<Icon name="pencil" />}>
             Wijzig<span className="dsn-visually-hidden"> naam</span>
           </Link>
         </SummaryListActions>
@@ -159,7 +159,7 @@ export const MixedRows: Story = {
         <SummaryListKey>Geboortedatum</SummaryListKey>
         <SummaryListValue>9 december 1984</SummaryListValue>
         <SummaryListActions>
-          <Link href="#" iconStart={<Icon name="edit" />}>
+          <Link href="#" iconStart={<Icon name="pencil" />}>
             Wijzig<span className="dsn-visually-hidden"> geboortedatum</span>
           </Link>
         </SummaryListActions>
@@ -225,7 +225,7 @@ export const AllVariants: Story = {
             <SummaryListKey>Naam</SummaryListKey>
             <SummaryListValue>Jeroen van Drouwen</SummaryListValue>
             <SummaryListActions>
-              <Link href="#" iconStart={<Icon name="edit" />}>
+              <Link href="#" iconStart={<Icon name="pencil" />}>
                 Wijzig<span className="dsn-visually-hidden"> naam</span>
               </Link>
             </SummaryListActions>
@@ -234,7 +234,7 @@ export const AllVariants: Story = {
             <SummaryListKey>Geboortedatum</SummaryListKey>
             <SummaryListValue>9 december 1984</SummaryListValue>
             <SummaryListActions>
-              <Link href="#" iconStart={<Icon name="edit" />}>
+              <Link href="#" iconStart={<Icon name="pencil" />}>
                 Wijzig
                 <span className="dsn-visually-hidden"> geboortedatum</span>
               </Link>
@@ -288,7 +288,7 @@ export const LongText: Story = {
         <SummaryListKey>{VEEL_TEKST}</SummaryListKey>
         <SummaryListValue>{VEEL_TEKST}</SummaryListValue>
         <SummaryListActions>
-          <Link href="#" iconStart={<Icon name="edit" />}>
+          <Link href="#" iconStart={<Icon name="pencil" />}>
             Wijzig<span className="dsn-visually-hidden"> {VEEL_TEKST}</span>
           </Link>
         </SummaryListActions>

--- a/packages/storybook/src/Table.stories.tsx
+++ b/packages/storybook/src/Table.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Table, Icon, Checkbox, Link } from '@dsn/components-react';
+import { Table, Icon, Checkbox, Link, LinkButton } from '@dsn/components-react';
 import type { TableProps } from '@dsn/components-react';
 import DocsPage from './Table.docs.mdx';
 import { rtlDecorator } from './story-helpers';
@@ -572,16 +572,13 @@ export const WithDeleteAction: Story = {
             <td>{product.category}</td>
             <td className="dsn-table__cell--numeric">{product.price}</td>
             <td>
-              <button
-                type="button"
-                className="dsn-button dsn-button--subtle-negative dsn-button--size-small"
+              <LinkButton
+                onClick={() => {}}
+                iconStart={<Icon name="trash" aria-hidden />}
               >
-                <Icon name="trash" aria-hidden />
-                <span className="dsn-button__label">
-                  Verwijder
-                  <span className="dsn-visually-hidden"> {product.name}</span>
-                </span>
-              </button>
+                Verwijder
+                <span className="dsn-visually-hidden"> {product.name}</span>
+              </LinkButton>
             </td>
           </tr>
         ))}


### PR DESCRIPTION
## Summary

- **Table**: `WithDeleteAction`-story gebruikt nu `<LinkButton>` (linkstijl) in plaats van een raw `<button className="dsn-button--subtle-negative">` — zelfde patroon als SummaryList
- **SummaryList**: Wijzig-acties gebruiken het nieuwe `pencil`-icoon (standalone potlood) in plaats van `edit` (potlood-in-vierkant)
- **SummaryList**: `actions.gap` verhoogd van `inline.lg` (12px) naar `inline.3xl` (24px) voor meer ademruimte tussen acties
- Nieuw `pencil.svg` toegevoegd aan icon-assets

## Test plan

- [ ] Storybook: `Components/Table – With delete action` toont LinkButton (blauw, linkstijl) met trash-icoon en "Verwijder"-tekst
- [ ] Storybook: `Components/SummaryList – With Multiple Actions` toont pencil-icoon bij "Wijzig" en ~24px ruimte tussen "Wijzig" en "Verwijder"
- [ ] `pnpm --filter storybook exec tsc --noEmit` geeft 0 fouten
- [ ] Alle tests groen: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)