### PR TITLE
feat(Templates): voeg Form step: Edit from review story toe

### DIFF
--- a/packages/storybook/src/templates/FormStepEditFromReviewPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepEditFromReviewPage.stories.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  ActionGroup,
+  Body,
+  Button,
+  FormField,
+  Grid,
+  GridItem,
+  Heading,
+  Icon,
+  Link,
+  PageBody,
+  PageFooter,
+  PageHeader,
+  PageLayout,
+  Paragraph,
+  SkipLink,
+  Stack,
+  TextInput,
+} from '@dsn/components-react';
+import {
+  logoSlot,
+  footerSlot1,
+  footerSlot2,
+  footerSlot3,
+  footerSlot4,
+} from './templateSharedContent';
+
+// =============================================================================
+// GEDEELDE CONTENT
+// =============================================================================
+
+const mainStyle: React.CSSProperties = {
+  paddingBlock: 'var(--dsn-space-block-6xl)',
+};
+
+// =============================================================================
+// META
+// =============================================================================
+
+const meta: Meta = {
+  title: 'Templates/Form flow/Form step: Edit from review',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// =============================================================================
+// STORIES
+// =============================================================================
+
+export const Example: Story = {
+  name: 'Form step: Edit from review',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          layout="compact"
+          hideMenuButton
+          hideSearchButton
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainStyle}>
+            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+              <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
+                <Stack space="3xl">
+                  <Heading level={1}>Titel formulier</Heading>
+
+                  <Link href="#" iconStart={<Icon name="arrow-left" />}>
+                    Terug naar controle
+                  </Link>
+
+                  <Stack space="sm">
+                    <h2 className="dsn-heading dsn-heading--heading-2">
+                      Uw gegevens wijzigen
+                    </h2>
+
+                    <Paragraph>
+                      Pas het gegeven aan en sla het op om terug te gaan naar de
+                      controlepagina.
+                    </Paragraph>
+                  </Stack>
+
+                  <form noValidate>
+                    <Stack space="3xl">
+                      <FormField label="Voornaam" htmlFor="voornaam">
+                        <TextInput
+                          id="voornaam"
+                          autoComplete="given-name"
+                          defaultValue="Jeroen"
+                        />
+                      </FormField>
+
+                      <ActionGroup
+                        direction="vertical"
+                        style={{
+                          marginBlockStart: 'var(--dsn-space-block-3xl)',
+                        }}
+                      >
+                        <Button variant="strong" type="submit">
+                          Opslaan en terug naar controle
+                        </Button>
+                        <Button variant="default" type="button">
+                          Annuleren
+                        </Button>
+                      </ActionGroup>
+                    </Stack>
+                  </form>
+                </Stack>
+              </GridItem>
+            </Grid>
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};

--- a/packages/storybook/src/templates/FormStepEditFromReviewPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepEditFromReviewPage.stories.tsx
@@ -75,7 +75,7 @@ export const Example: Story = {
                   <Heading level={1}>Titel formulier</Heading>
 
                   <Link href="#" iconStart={<Icon name="arrow-left" />}>
-                    Terug naar controle
+                    Terug
                   </Link>
 
                   <Stack space="sm">
@@ -114,7 +114,7 @@ export const Example: Story = {
                         }}
                       >
                         <Button variant="strong" type="submit">
-                          Opslaan en terug naar controle
+                          Opslaan en terug
                         </Button>
                         <Button variant="default" type="button">
                           Annuleren

--- a/packages/storybook/src/templates/FormStepEditFromReviewPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepEditFromReviewPage.stories.tsx
@@ -4,6 +4,7 @@ import {
   ActionGroup,
   Body,
   Button,
+  EmailInput,
   FormField,
   Grid,
   GridItem,
@@ -79,22 +80,30 @@ export const Example: Story = {
 
                   <Stack space="sm">
                     <h2 className="dsn-heading dsn-heading--heading-2">
-                      Uw gegevens wijzigen
+                      Uw gegevens
                     </h2>
 
                     <Paragraph>
-                      Pas het gegeven aan en sla het op om terug te gaan naar de
-                      controlepagina.
+                      Vul alles in. Als iets niet verplicht is, staat dat erbij.
                     </Paragraph>
                   </Stack>
 
                   <form noValidate>
                     <Stack space="3xl">
-                      <FormField label="Voornaam" htmlFor="voornaam">
+                      <FormField label="Naam" htmlFor="naam">
                         <TextInput
-                          id="voornaam"
-                          autoComplete="given-name"
-                          defaultValue="Jeroen"
+                          id="naam"
+                          autoComplete="name"
+                          defaultValue="Jeroen van Drouwen"
+                        />
+                      </FormField>
+
+                      <FormField label="E-mailadres" htmlFor="email">
+                        <EmailInput
+                          id="email"
+                          autoComplete="email"
+                          width="xl"
+                          defaultValue="jeroenvandrouwen@gmail.com"
                         />
                       </FormField>
 


### PR DESCRIPTION
Closes #208

## Summary

- Voegt `FormStepEditFromReviewPage.stories.tsx` toe met Storybook title `'Templates/Form flow/Form step: Edit from review'`
- Toont "Terug naar controle" teruglink (met pijl-links icoon) in plaats van "Vorige stap"
- Veld "Voornaam" is vooringevuld met eerder ingevoerde waarde ("Jeroen")
- ActionGroup met "Opslaan en terug naar controle" (primary) en "Annuleren" (secondary) — geen modals

## Test plan

- [ ] Story zichtbaar onder `Templates/Form flow/Form step: Edit from review` in Storybook
- [ ] Teruglink toont "Terug naar controle" met arrow-left icoon
- [ ] Voornaamveld is vooringevuld met "Jeroen"
- [ ] ActionGroup toont twee knoppen: "Opslaan en terug naar controle" (primary) en "Annuleren" (secondary)
- [ ] Geen TypeScript-fouten

🤖 Generated with [Claude Code](https://claude.com/claude-code)