### PR TITLE
fix(Templates): zet h2 Confirmation page op heading-4

### DIFF
--- a/packages/storybook/src/templates/FormConfirmationPage.stories.tsx
+++ b/packages/storybook/src/templates/FormConfirmationPage.stories.tsx
@@ -80,7 +80,7 @@ export const Example: Story = {
                   </Note>
 
                   <Stack space="md">
-                    <h2 className="dsn-heading dsn-heading--heading-2">
+                    <h2 className="dsn-heading dsn-heading--heading-4">
                       Dit gaat er nu gebeuren
                     </h2>
 


### PR DESCRIPTION
## Summary

- Corrigeert de heading-grootte van "Dit gaat er nu gebeuren" van `heading-2` naar `heading-4`

Opvolger van #245.

## Test plan

- [ ] h2 "Dit gaat er nu gebeuren" heeft `dsn-heading--heading-4` klasse
- [ ] CI groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)