### PR TITLE
feat(ActionGroup): voeg role="group" toe als standaard ARIA-rol

### DIFF
--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -168,7 +168,7 @@ Groepeert gerelateerde acties en verzorgt de lay-out van Buttons en Links. Horiz
 
 ```html
 <!-- Horizontaal (default) -->
-<div class="dsn-action-group">
+<div class="dsn-action-group" role="group">
   <button class="dsn-button dsn-button--strong dsn-button--size-default">
     <span class="dsn-button__label">Opslaan</span>
   </button>
@@ -178,7 +178,7 @@ Groepeert gerelateerde acties en verzorgt de lay-out van Buttons en Links. Horiz
 </div>
 
 <!-- Verticaal -->
-<div class="dsn-action-group dsn-action-group--vertical">
+<div class="dsn-action-group dsn-action-group--vertical" role="group">
   <button class="dsn-button dsn-button--strong dsn-button--size-default">
     <span class="dsn-button__label">Primaire actie</span>
   </button>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 5.36.0 (May 8, 2026)
+
+### ActionGroup
+
+#### Changed
+
+- **`ActionGroup`**: voegt `role="group"` toe als standaard ARIA-rol zodat screenreaders de groep als semantische eenheid aankondigen; de rol is overschrijfbaar via de `role` prop
+
+---
+
 ## Version 5.35.0 (May 2, 2026)
 
 ### File + FileList

--- a/packages/components-react/src/ActionGroup/ActionGroup.test.tsx
+++ b/packages/components-react/src/ActionGroup/ActionGroup.test.tsx
@@ -111,4 +111,26 @@ describe('ActionGroup', () => {
     const el = screen.getByTestId('my-group');
     expect(el).toHaveAttribute('id', 'action-group-1');
   });
+
+  // ===========================
+  // Accessibility
+  // ===========================
+
+  it('has role="group" by default', () => {
+    const { container } = render(
+      <ActionGroup>
+        <button>Actie</button>
+      </ActionGroup>
+    );
+    expect(container.firstChild).toHaveAttribute('role', 'group');
+  });
+
+  it('allows role to be overridden', () => {
+    const { container } = render(
+      <ActionGroup role="toolbar">
+        <button>Actie</button>
+      </ActionGroup>
+    );
+    expect(container.firstChild).toHaveAttribute('role', 'toolbar');
+  });
 });

--- a/packages/components-react/src/ActionGroup/ActionGroup.tsx
+++ b/packages/components-react/src/ActionGroup/ActionGroup.tsx
@@ -50,7 +50,7 @@ export const ActionGroup = React.forwardRef<HTMLDivElement, ActionGroupProps>(
     );
 
     return (
-      <div ref={ref} className={classes} {...props}>
+      <div ref={ref} className={classes} role="group" {...props}>
         {children}
       </div>
     );

--- a/packages/storybook/src/ActionGroup.docs.md
+++ b/packages/storybook/src/ActionGroup.docs.md
@@ -47,7 +47,6 @@ ActionGroup is een lay-outprimitief voor het groeperen van één of meer gerelat
 
 ## Accessibility
 
-- ActionGroup heeft geen eigen ARIA-rol: de groepering is puur lay-out, geen semantische eenheid.
+- ActionGroup heeft standaard `role="group"`: screenreaders kondigen de groep aan als semantische eenheid.
 - De volgorde van children bepaalt de lees- en tabvolgorde: primaire actie altijd als eerste child.
 - Icon-only Buttons in een ActionGroup hebben hun label verborgen via `dsn-button__label` + `dsn-button--icon-only`: de ActionGroup zelf hoeft hier niets voor te doen.
-- Gebruik nooit `role="group"` of `aria-label` op de ActionGroup: dit voegt geen waarde toe voor screenreaders.

--- a/packages/storybook/src/ActionGroup.stories.tsx
+++ b/packages/storybook/src/ActionGroup.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof ActionGroup> = {
       htmlTemplate: (args: any) => {
         const modifier =
           args.direction === 'vertical' ? ' dsn-action-group--vertical' : '';
-        return `<div class="dsn-action-group${modifier}">
+        return `<div class="dsn-action-group${modifier}" role="group">
   <button class="dsn-button dsn-button--strong dsn-button--size-default">
     <span class="dsn-button__label">Opslaan</span>
   </button>


### PR DESCRIPTION
## Summary

- Voegt `role="group"` toe als standaard ARIA-rol op de `<div>` van ActionGroup, zodat screenreaders de groep als semantische eenheid aankondigen
- De rol is overschrijfbaar via de `role` prop
- HTML/CSS-voorbeelden in docs en Storybook bijgewerkt

## Test plan

- [x] 2 nieuwe tests: `role="group"` aanwezig by default, override naar `role="toolbar"` werkt
- [x] Alle 1549 tests groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)