### PR TITLE
feat(Grid): voeg row-gap toe voor verticale ruimte bij responsive stapeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pnpm --filter @dsn/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (1495 tests across 73 test suites)
+# Run tests (1549 tests across 75 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -192,7 +192,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Paragraph**     | Yes      | Yes   | Yes           |
 | **UnorderedList** | Yes      | Yes   | Yes           |
 
-**Display & Feedback Components (16)**
+**Display & Feedback Components (17)**
 
 | Component       | HTML/CSS | React | Web Component |
 | --------------- | -------- | ----- | ------------- |
@@ -211,6 +211,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **ProgressBar** | Yes      | Yes   | No            |
 | **Spinner**     | Yes      | Yes   | No            |
 | **StatusBadge** | Yes      | Yes   | No            |
+| **SummaryList** | Yes      | Yes   | No            |
 | **Table**       | Yes      | Yes   | No            |
 
 **Navigation Components (6)**
@@ -236,7 +237,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | ------------ | -------- | ----- | ------------- |
 | **SkipLink** | Yes      | Yes   | No            |
 
-**Form Components (25)**
+**Form Components (26)**
 
 | Component                 | HTML/CSS | React | Web Component |
 | ------------------------- | -------- | ----- | ------------- |
@@ -246,6 +247,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **DateInput**             | Yes      | Yes   | No            |
 | **DateInputGroup**        | Yes      | Yes   | No            |
 | **EmailInput**            | Yes      | Yes   | No            |
+| **FileInput**             | Yes      | Yes   | No            |
 | **FormField**             | Yes      | Yes   | No            |
 | **FormFieldDescription**  | Yes      | Yes   | No            |
 | **FormFieldErrorMessage** | Yes      | Yes   | No            |
@@ -409,7 +411,7 @@ Comprehensive documentation is available in the `/docs` folder:
 
 - **Pre-commit hooks** via Husky + lint-staged (ESLint + Prettier)
 - **Type checking** across all packages (`pnpm type-check`)
-- **1495 tests** covering React components, Web Components, and utilities
+- **1549 tests** covering React components, Web Components, and utilities
 - **CI/CD** via GitHub Actions (lint, type-check, test, build)
 
 ## Tech Stack
@@ -420,7 +422,7 @@ Comprehensive documentation is available in the `/docs` folder:
 - **React:** 18+
 - **TypeScript:** 5.3+
 - **Testing:** Vitest + React Testing Library
-- **Documentation:** Storybook 7.6
+- **Documentation:** Storybook 10.3.6
 - **CI/CD:** GitHub Actions
 - **Package Manager:** PNPM 8+
 - **Code Quality:** Husky, lint-staged, ESLint, Prettier

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1,6 +1,6 @@
 # Components
 
-**Last Updated:** April 23, 2026
+**Last Updated:** May 8, 2026
 
 Complete component specifications and guidelines for the Design System Starter Kit.
 
@@ -1396,6 +1396,71 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 ```
 
 **Tests:** React (6 tests)
+
+### SummaryList
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-react/src/SummaryList/`
+
+**Props:**
+
+- `SummaryList`: `noBorder`, `children`
+- `SummaryListRow`: `noActions`, `children`
+- `SummaryListKey`: `children`
+- `SummaryListValue`: `children`
+- `SummaryListActions`: `children`
+
+**Features:**
+
+- `<dl>` beschrijvingslijst met `<div>` row-wrappers voor elke rij
+- Responsive: gestapeld (mobiel) → CSS Grid + subgrid (tablet+)
+- `noBorder` prop verwijdert rij-scheidingslijnen
+- `noActions` prop op een rij zonder actiecel voor consistente kolomuitlijning in gemengde lijsten
+- `SummaryListActions` wikkelt meerdere acties automatisch in een `<ul>` voor lijstsemantiek
+
+**HTML klassen:**
+
+```html
+<dl class="dsn-summary-list">
+  <div class="dsn-summary-list__row">
+    <dt class="dsn-summary-list__key">Naam</dt>
+    <dd class="dsn-summary-list__value">Sarah Hendricks</dd>
+    <dd class="dsn-summary-list__actions">
+      <a class="dsn-link" href="#">
+        Wijzig
+        <span class="dsn-visually-hidden"> naam</span>
+      </a>
+    </dd>
+  </div>
+</dl>
+
+<!-- Zonder borders -->
+<dl class="dsn-summary-list dsn-summary-list--no-border">...</dl>
+```
+
+**React:**
+
+```tsx
+<SummaryList>
+  <SummaryListRow>
+    <SummaryListKey>Naam</SummaryListKey>
+    <SummaryListValue>Sarah Hendricks</SummaryListValue>
+    <SummaryListActions>
+      <Link href="#">
+        Wijzig
+        <span className="dsn-visually-hidden"> naam</span>
+      </Link>
+    </SummaryListActions>
+  </SummaryListRow>
+</SummaryList>
+```
+
+**Design tokens:** `--dsn-summary-list-row-border-block-end-color`, `--dsn-summary-list-row-border-block-end-width`, `--dsn-summary-list-row-gap`, `--dsn-summary-list-row-padding-block`, `--dsn-summary-list-key-color`, `--dsn-summary-list-key-font-weight`, `--dsn-summary-list-key-basis`, `--dsn-summary-list-value-color`, `--dsn-summary-list-actions-gap`
+
+**Tests:** React (31 tests)
+
+---
 
 ### Alert
 
@@ -2861,7 +2926,7 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 ## Form Components
 
-**Status:** Complete (HTML/CSS, React): 25 components total
+**Status:** Complete (HTML/CSS, React): 26 components total
 
 **Location:** `packages/components-{html|react}/src/`
 
@@ -2970,6 +3035,22 @@ const [isOpen, setIsOpen] = React.useState(false);
 **Props:** `value` (`{ day, month, year }`), `onChange`, `invalid`, `disabled`, `id`
 
 **Tests:** React (9 tests)
+
+#### FileInput
+
+**Tokens:** `tokens/components/file-input.json`
+
+**Features:** Gestyled `<input type="file">` via `::file-selector-button` CSS pseudo-element. Knopstijl volgt `dsn-button--default` automatisch. Ondersteunt `multiple` en `accept` attributen. Geen wrapper element — de component is het `<input>` zelf.
+
+**Props:** `invalid`, en alle native `<input type="file">` attributen (behalve `type`)
+
+**HTML:**
+
+```html
+<input type="file" class="dsn-file-input" id="bijlage" />
+```
+
+**Tests:** React (14 tests)
 
 ### Selection Components
 
@@ -3170,15 +3251,15 @@ defineButton('my-custom-button');
 
 ## Component Statistics
 
-**Total Components:** 67
+**Total Components:** 71
 
 **Implementations:**
 
-- **HTML/CSS:** 67 components
-- **React:** 67 components (1495 tests total, 73 test suites)
+- **HTML/CSS:** 71 components
+- **React:** 71 components (1549 tests total, 75 test suites)
 - **Web Component:** 7 components (Button, Heading, Icon, Link, OrderedList, Paragraph, UnorderedList)
 
-**Test Coverage:** 1409 tests across 70 test suites
+**Test Coverage:** 1549 tests across 75 test suites
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 5.37.0 (May 8, 2026)
+
+### Storybook upgrade
+
+#### Changed
+
+- **Storybook** geüpgraded van v7.6.21 naar **v10.3.6** (PR #249)
+  - Vite v4 → v6 en `vite-plugin-svgr` v4 → v5
+  - Imports bijgewerkt naar `@storybook/addon-docs/blocks` (vervangt `@storybook/blocks`)
+  - Storybook-configuratie (`main.ts`, `preview.ts`) gemigreerd naar v10-API
+
+---
+
 ## Version 5.36.0 (May 8, 2026)
 
 ### ActionGroup

--- a/packages/components-html/src/grid/grid.css
+++ b/packages/components-html/src/grid/grid.css
@@ -40,6 +40,7 @@
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   column-gap: var(--dsn-grid-gutter);
+  row-gap: var(--dsn-grid-row-gap);
   padding-inline: var(--dsn-grid-margin);
 }
 

--- a/packages/design-tokens/src/tokens/components/grid.json
+++ b/packages/design-tokens/src/tokens/components/grid.json
@@ -6,6 +6,11 @@
         "$type": "dimension",
         "$description": "Horizontal gap between grid columns (overridden to column.md in information-dense)"
       },
+      "row-gap": {
+        "$value": "{dsn.space.column.xl}",
+        "$type": "dimension",
+        "$description": "Vertical gap between grid rows (overridden to column.md in information-dense)"
+      },
       "margin": {
         "$value": "{dsn.space.column.3xl}",
         "$type": "dimension",

--- a/packages/design-tokens/src/tokens/project-types/information-dense/grid.json
+++ b/packages/design-tokens/src/tokens/project-types/information-dense/grid.json
@@ -5,6 +5,11 @@
         "$value": "calc(0.5rem * 1)",
         "$type": "dimension",
         "$description": "Compactere kolomafstand voor information-dense project types (8px = space.column.md)"
+      },
+      "row-gap": {
+        "$value": "calc(0.5rem * 1)",
+        "$type": "dimension",
+        "$description": "Compactere rij-afstand voor information-dense project types (8px = space.column.md)"
       }
     }
   }

--- a/packages/storybook/src/Grid.docs.md
+++ b/packages/storybook/src/Grid.docs.md
@@ -117,6 +117,7 @@ Grid en GridItem zijn puur visuele layout utilities. Ze voegen geen ARIA-attribu
 | Token                  | Standaard waarde                     | Omschrijving                                                        |
 | ---------------------- | ------------------------------------ | ------------------------------------------------------------------- |
 | `--dsn-grid-gutter`    | `var(--dsn-space-column-xl)` (16px)  | Horizontale ruimte tussen kolommen; 8px in information-dense        |
+| `--dsn-grid-row-gap`   | `var(--dsn-space-column-xl)` (16px)  | Verticale ruimte tussen rijen; 8px in information-dense             |
 | `--dsn-grid-margin`    | `var(--dsn-space-column-3xl)` (24px) | Outer padding aan weerszijden van de grid container                 |
 | `--dsn-grid-max-width` | `74rem` (~1184px)                    | Maximale breedte bij `contained` variant                            |
 | `--dsn-breakpoint-sm`  | `36em`                               | Referentiewaarde small breakpoint (niet te gebruiken in CSS @media) |


### PR DESCRIPTION
## Summary

- Voegt `--dsn-grid-row-gap` token toe (standaard 16px = `{dsn.space.column.xl}`, gelijk aan de gutter)
- Information-dense override op 8px, zelfde logica als de bestaande gutter override
- `row-gap: var(--dsn-grid-row-gap)` toegevoegd aan `.dsn-grid` in CSS
- Token gedocumenteerd in de Grid design tokens tabel

## Test plan

- [ ] Grid responsive story toont witruimte tussen gestapelde items op mobiel
- [ ] Information-dense theme heeft compactere row-gap (8px)
- [ ] Desktop: items naast elkaar zijn ongewijzigd

🤖 Generated with [Claude Code](https://claude.com/claude-code)