### PR TITLE
feat(Templates): Kitchen Sink pagina

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pnpm --filter @dsn/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (1495 tests across 73 test suites)
+# Run tests (1549 tests across 75 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -192,7 +192,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Paragraph**     | Yes      | Yes   | Yes           |
 | **UnorderedList** | Yes      | Yes   | Yes           |
 
-**Display & Feedback Components (16)**
+**Display & Feedback Components (17)**
 
 | Component       | HTML/CSS | React | Web Component |
 | --------------- | -------- | ----- | ------------- |
@@ -211,6 +211,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **ProgressBar** | Yes      | Yes   | No            |
 | **Spinner**     | Yes      | Yes   | No            |
 | **StatusBadge** | Yes      | Yes   | No            |
+| **SummaryList** | Yes      | Yes   | No            |
 | **Table**       | Yes      | Yes   | No            |
 
 **Navigation Components (6)**
@@ -236,7 +237,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | ------------ | -------- | ----- | ------------- |
 | **SkipLink** | Yes      | Yes   | No            |
 
-**Form Components (25)**
+**Form Components (26)**
 
 | Component                 | HTML/CSS | React | Web Component |
 | ------------------------- | -------- | ----- | ------------- |
@@ -246,6 +247,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **DateInput**             | Yes      | Yes   | No            |
 | **DateInputGroup**        | Yes      | Yes   | No            |
 | **EmailInput**            | Yes      | Yes   | No            |
+| **FileInput**             | Yes      | Yes   | No            |
 | **FormField**             | Yes      | Yes   | No            |
 | **FormFieldDescription**  | Yes      | Yes   | No            |
 | **FormFieldErrorMessage** | Yes      | Yes   | No            |
@@ -409,7 +411,7 @@ Comprehensive documentation is available in the `/docs` folder:
 
 - **Pre-commit hooks** via Husky + lint-staged (ESLint + Prettier)
 - **Type checking** across all packages (`pnpm type-check`)
-- **1495 tests** covering React components, Web Components, and utilities
+- **1549 tests** covering React components, Web Components, and utilities
 - **CI/CD** via GitHub Actions (lint, type-check, test, build)
 
 ## Tech Stack
@@ -420,7 +422,7 @@ Comprehensive documentation is available in the `/docs` folder:
 - **React:** 18+
 - **TypeScript:** 5.3+
 - **Testing:** Vitest + React Testing Library
-- **Documentation:** Storybook 7.6
+- **Documentation:** Storybook 10.3.6
 - **CI/CD:** GitHub Actions
 - **Package Manager:** PNPM 8+
 - **Code Quality:** Husky, lint-staged, ESLint, Prettier

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1,6 +1,6 @@
 # Components
 
-**Last Updated:** April 23, 2026
+**Last Updated:** May 8, 2026
 
 Complete component specifications and guidelines for the Design System Starter Kit.
 
@@ -1396,6 +1396,71 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 ```
 
 **Tests:** React (6 tests)
+
+### SummaryList
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-react/src/SummaryList/`
+
+**Props:**
+
+- `SummaryList`: `noBorder`, `children`
+- `SummaryListRow`: `noActions`, `children`
+- `SummaryListKey`: `children`
+- `SummaryListValue`: `children`
+- `SummaryListActions`: `children`
+
+**Features:**
+
+- `<dl>` beschrijvingslijst met `<div>` row-wrappers voor elke rij
+- Responsive: gestapeld (mobiel) → CSS Grid + subgrid (tablet+)
+- `noBorder` prop verwijdert rij-scheidingslijnen
+- `noActions` prop op een rij zonder actiecel voor consistente kolomuitlijning in gemengde lijsten
+- `SummaryListActions` wikkelt meerdere acties automatisch in een `<ul>` voor lijstsemantiek
+
+**HTML klassen:**
+
+```html
+<dl class="dsn-summary-list">
+  <div class="dsn-summary-list__row">
+    <dt class="dsn-summary-list__key">Naam</dt>
+    <dd class="dsn-summary-list__value">Sarah Hendricks</dd>
+    <dd class="dsn-summary-list__actions">
+      <a class="dsn-link" href="#">
+        Wijzig
+        <span class="dsn-visually-hidden"> naam</span>
+      </a>
+    </dd>
+  </div>
+</dl>
+
+<!-- Zonder borders -->
+<dl class="dsn-summary-list dsn-summary-list--no-border">...</dl>
+```
+
+**React:**
+
+```tsx
+<SummaryList>
+  <SummaryListRow>
+    <SummaryListKey>Naam</SummaryListKey>
+    <SummaryListValue>Sarah Hendricks</SummaryListValue>
+    <SummaryListActions>
+      <Link href="#">
+        Wijzig
+        <span className="dsn-visually-hidden"> naam</span>
+      </Link>
+    </SummaryListActions>
+  </SummaryListRow>
+</SummaryList>
+```
+
+**Design tokens:** `--dsn-summary-list-row-border-block-end-color`, `--dsn-summary-list-row-border-block-end-width`, `--dsn-summary-list-row-gap`, `--dsn-summary-list-row-padding-block`, `--dsn-summary-list-key-color`, `--dsn-summary-list-key-font-weight`, `--dsn-summary-list-key-basis`, `--dsn-summary-list-value-color`, `--dsn-summary-list-actions-gap`
+
+**Tests:** React (31 tests)
+
+---
 
 ### Alert
 
@@ -2861,7 +2926,7 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 ## Form Components
 
-**Status:** Complete (HTML/CSS, React): 25 components total
+**Status:** Complete (HTML/CSS, React): 26 components total
 
 **Location:** `packages/components-{html|react}/src/`
 
@@ -2970,6 +3035,22 @@ const [isOpen, setIsOpen] = React.useState(false);
 **Props:** `value` (`{ day, month, year }`), `onChange`, `invalid`, `disabled`, `id`
 
 **Tests:** React (9 tests)
+
+#### FileInput
+
+**Tokens:** `tokens/components/file-input.json`
+
+**Features:** Gestyled `<input type="file">` via `::file-selector-button` CSS pseudo-element. Knopstijl volgt `dsn-button--default` automatisch. Ondersteunt `multiple` en `accept` attributen. Geen wrapper element — de component is het `<input>` zelf.
+
+**Props:** `invalid`, en alle native `<input type="file">` attributen (behalve `type`)
+
+**HTML:**
+
+```html
+<input type="file" class="dsn-file-input" id="bijlage" />
+```
+
+**Tests:** React (14 tests)
 
 ### Selection Components
 
@@ -3170,15 +3251,15 @@ defineButton('my-custom-button');
 
 ## Component Statistics
 
-**Total Components:** 67
+**Total Components:** 71
 
 **Implementations:**
 
-- **HTML/CSS:** 67 components
-- **React:** 67 components (1495 tests total, 73 test suites)
+- **HTML/CSS:** 71 components
+- **React:** 71 components (1549 tests total, 75 test suites)
 - **Web Component:** 7 components (Button, Heading, Icon, Link, OrderedList, Paragraph, UnorderedList)
 
-**Test Coverage:** 1409 tests across 70 test suites
+**Test Coverage:** 1549 tests across 75 test suites
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 5.37.0 (May 8, 2026)
+
+### Storybook upgrade
+
+#### Changed
+
+- **Storybook** geüpgraded van v7.6.21 naar **v10.3.6** (PR #249)
+  - Vite v4 → v6 en `vite-plugin-svgr` v4 → v5
+  - Imports bijgewerkt naar `@storybook/addon-docs/blocks` (vervangt `@storybook/blocks`)
+  - Storybook-configuratie (`main.ts`, `preview.ts`) gemigreerd naar v10-API
+
+---
+
 ## Version 5.36.0 (May 8, 2026)
 
 ### ActionGroup

--- a/packages/components-html/src/grid/grid.css
+++ b/packages/components-html/src/grid/grid.css
@@ -40,6 +40,7 @@
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   column-gap: var(--dsn-grid-gutter);
+  row-gap: var(--dsn-grid-row-gap);
   padding-inline: var(--dsn-grid-margin);
 }
 

--- a/packages/design-tokens/src/tokens/components/grid.json
+++ b/packages/design-tokens/src/tokens/components/grid.json
@@ -6,6 +6,11 @@
         "$type": "dimension",
         "$description": "Horizontal gap between grid columns (overridden to column.md in information-dense)"
       },
+      "row-gap": {
+        "$value": "{dsn.space.column.xl}",
+        "$type": "dimension",
+        "$description": "Vertical gap between grid rows (overridden to column.md in information-dense)"
+      },
       "margin": {
         "$value": "{dsn.space.column.3xl}",
         "$type": "dimension",

--- a/packages/design-tokens/src/tokens/project-types/information-dense/grid.json
+++ b/packages/design-tokens/src/tokens/project-types/information-dense/grid.json
@@ -5,6 +5,11 @@
         "$value": "calc(0.5rem * 1)",
         "$type": "dimension",
         "$description": "Compactere kolomafstand voor information-dense project types (8px = space.column.md)"
+      },
+      "row-gap": {
+        "$value": "calc(0.5rem * 1)",
+        "$type": "dimension",
+        "$description": "Compactere rij-afstand voor information-dense project types (8px = space.column.md)"
       }
     }
   }

--- a/packages/storybook/src/Grid.docs.md
+++ b/packages/storybook/src/Grid.docs.md
@@ -117,6 +117,7 @@ Grid en GridItem zijn puur visuele layout utilities. Ze voegen geen ARIA-attribu
 | Token                  | Standaard waarde                     | Omschrijving                                                        |
 | ---------------------- | ------------------------------------ | ------------------------------------------------------------------- |
 | `--dsn-grid-gutter`    | `var(--dsn-space-column-xl)` (16px)  | Horizontale ruimte tussen kolommen; 8px in information-dense        |
+| `--dsn-grid-row-gap`   | `var(--dsn-space-column-xl)` (16px)  | Verticale ruimte tussen rijen; 8px in information-dense             |
 | `--dsn-grid-margin`    | `var(--dsn-space-column-3xl)` (24px) | Outer padding aan weerszijden van de grid container                 |
 | `--dsn-grid-max-width` | `74rem` (~1184px)                    | Maximale breedte bij `contained` variant                            |
 | `--dsn-breakpoint-sm`  | `36em`                               | Referentiewaarde small breakpoint (niet te gebruiken in CSS @media) |

--- a/packages/storybook/src/templates/KitchenSinkPage.stories.tsx
+++ b/packages/storybook/src/templates/KitchenSinkPage.stories.tsx
@@ -1,0 +1,1329 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  ActionGroup,
+  Alert,
+  Backdrop,
+  Body,
+  BreadcrumbNavigation,
+  BreadcrumbNavigationItem,
+  BreakoutSection,
+  Button,
+  ButtonLink,
+  Card,
+  CardBody,
+  CardFooter,
+  CardGroup,
+  CardHeader,
+  CardHeading,
+  Checkbox,
+  CheckboxGroup,
+  CheckboxOption,
+  Container,
+  DateInput,
+  DateInputGroup,
+  type DateInputGroupValue,
+  Details,
+  DotBadge,
+  Drawer,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerHeading,
+  EmailInput,
+  File,
+  FileList,
+  FileInput,
+  FormField,
+  FormFieldDescription,
+  FormFieldErrorMessage,
+  FormFieldLabel,
+  FormFieldset,
+  FormFieldStatus,
+  Grid,
+  GridItem,
+  Heading,
+  Hero,
+  Icon,
+  Image,
+  Link,
+  LinkButton,
+  Logo,
+  Menu,
+  MenuButton,
+  MenuLink,
+  ModalDialog,
+  ModalDialogBody,
+  ModalDialogFooter,
+  ModalDialogHeader,
+  ModalDialogHeading,
+  Note,
+  NumberBadge,
+  NumberInput,
+  OptionLabel,
+  OrderedList,
+  PageBody,
+  PageFooter,
+  PageHeader,
+  PageLayout,
+  Paragraph,
+  PasswordInput,
+  Popover,
+  PopoverBody,
+  ProgressBar,
+  Radio,
+  RadioGroup,
+  RadioOption,
+  SearchInput,
+  Select,
+  SkipLink,
+  Spinner,
+  Stack,
+  StatusBadge,
+  SummaryList,
+  SummaryListActions,
+  SummaryListKey,
+  SummaryListRow,
+  SummaryListValue,
+  Table,
+  TelephoneInput,
+  TextArea,
+  TextInput,
+  TimeInput,
+  UnorderedList,
+} from '@dsn/components-react';
+import {
+  logoSlot,
+  footerSlot1,
+  footerSlot2,
+  footerSlot3,
+  footerSlot4,
+} from './templateSharedContent';
+
+// =============================================================================
+// NAVIGATIE
+// =============================================================================
+
+function PrimaryNavigation() {
+  const [exp1b, setExp1b] = React.useState(false);
+  const [exp2b, setExp2b] = React.useState(false);
+
+  return (
+    <Menu orientation="vertical">
+      <MenuLink href="/" level={1}>
+        Homepage
+      </MenuLink>
+      <MenuLink href="/level-1a" level={1} current>
+        Kitchen Sink
+      </MenuLink>
+      <MenuLink
+        href="/level-1b"
+        level={1}
+        subItems
+        expanded={exp1b}
+        onExpandToggle={() => setExp1b((v) => !v)}
+      >
+        Level 1b
+      </MenuLink>
+      {exp1b && (
+        <>
+          <MenuLink href="/level-2a" level={2}>
+            Level 2a
+          </MenuLink>
+          <MenuLink
+            href="/level-2b"
+            level={2}
+            subItems
+            expanded={exp2b}
+            onExpandToggle={() => setExp2b((v) => !v)}
+          >
+            Level 2b
+          </MenuLink>
+          {exp2b && (
+            <MenuLink href="/level-3a" level={3}>
+              Level 3a
+            </MenuLink>
+          )}
+        </>
+      )}
+      <MenuLink href="/level-1c" level={1}>
+        Level 1c
+      </MenuLink>
+    </Menu>
+  );
+}
+
+const primaryNavigationLarge = (
+  <Menu orientation="horizontal">
+    <MenuLink href="/" level={1}>
+      Homepage
+    </MenuLink>
+    <MenuLink href="/kitchen-sink" level={1} current>
+      Kitchen Sink
+    </MenuLink>
+    <MenuLink href="/level-1b" level={1}>
+      Level 1b
+    </MenuLink>
+    <MenuLink href="/level-1c" level={1}>
+      Level 1c
+    </MenuLink>
+  </Menu>
+);
+
+const secondaryNavigation = (
+  <Menu orientation="vertical">
+    <MenuLink href="/english" level={1}>
+      English
+    </MenuLink>
+    <MenuLink href="/mijn-omgeving" level={1}>
+      Mijn omgeving
+    </MenuLink>
+  </Menu>
+);
+
+const secondaryNavigationLarge = (
+  <Menu orientation="horizontal">
+    <MenuLink href="/english" level={1}>
+      English
+    </MenuLink>
+    <MenuLink href="/mijn-omgeving" level={1}>
+      Mijn omgeving
+    </MenuLink>
+  </Menu>
+);
+
+const searchSlot = (
+  <>
+    <SearchInput placeholder="Zoeken…" aria-label="Zoekopdracht" />
+    <Button variant="strong">Zoeken</Button>
+  </>
+);
+
+// =============================================================================
+// OVERLAY HELPERS
+// =============================================================================
+
+function ModalDialogDemo() {
+  const [isOpen, setIsOpen] = React.useState(false);
+  return (
+    <>
+      <Button variant="default" onClick={() => setIsOpen(true)}>
+        Open Modal Dialog
+      </Button>
+      <ModalDialog isOpen={isOpen} onClose={() => setIsOpen(false)}>
+        <ModalDialogHeader>
+          <ModalDialogHeading>Titel</ModalDialogHeading>
+        </ModalDialogHeader>
+        <ModalDialogBody>
+          <Paragraph>Tekst</Paragraph>
+        </ModalDialogBody>
+        <ModalDialogFooter>
+          <ActionGroup>
+            <Button variant="strong" onClick={() => setIsOpen(false)}>
+              Tekst
+            </Button>
+            <Button variant="default" onClick={() => setIsOpen(false)}>
+              Tekst
+            </Button>
+          </ActionGroup>
+        </ModalDialogFooter>
+      </ModalDialog>
+    </>
+  );
+}
+
+function DrawerDemo() {
+  const [isOpen, setIsOpen] = React.useState(false);
+  return (
+    <>
+      <Button variant="default" onClick={() => setIsOpen(true)}>
+        Open Drawer
+      </Button>
+      <Drawer isOpen={isOpen} onClose={() => setIsOpen(false)} side="right">
+        <DrawerHeader>
+          <DrawerHeading>Titel</DrawerHeading>
+        </DrawerHeader>
+        <DrawerBody>
+          <Paragraph>Tekst</Paragraph>
+        </DrawerBody>
+        <DrawerFooter>
+          <ActionGroup>
+            <Button variant="strong" onClick={() => setIsOpen(false)}>
+              Tekst
+            </Button>
+            <Button variant="default" onClick={() => setIsOpen(false)}>
+              Tekst
+            </Button>
+          </ActionGroup>
+        </DrawerFooter>
+      </Drawer>
+    </>
+  );
+}
+
+function DateInputGroupDemo() {
+  const [value, setValue] = useState<DateInputGroupValue>({
+    day: '',
+    month: '',
+    year: '',
+  });
+  return (
+    <DateInputGroup
+      id="dateinputgroup-kitchen"
+      value={value}
+      onChange={setValue}
+    />
+  );
+}
+
+function PopoverDemo() {
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  return (
+    <>
+      <Button
+        ref={triggerRef}
+        variant="subtle"
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        Open Popover
+      </Button>
+      <Popover
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        triggerRef={triggerRef}
+        label="Tekst"
+      >
+        <PopoverBody>
+          <Menu>
+            <MenuButton onClick={() => setIsOpen(false)}>Tekst</MenuButton>
+            <MenuButton onClick={() => setIsOpen(false)}>Tekst</MenuButton>
+            <MenuButton onClick={() => setIsOpen(false)}>Tekst</MenuButton>
+          </Menu>
+        </PopoverBody>
+      </Popover>
+    </>
+  );
+}
+
+// =============================================================================
+// SECTION HELPER
+// =============================================================================
+
+function Section({
+  name,
+  docPath,
+  children,
+}: {
+  name: string;
+  docPath: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <Heading level={2}>{name}</Heading>
+      <Link href={docPath}>Bekijk de documentatie voor {name}</Link>
+      <div style={{ marginBlockStart: 'var(--dsn-space-block-3xl)' }}>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+// =============================================================================
+// STIJLEN
+// =============================================================================
+
+const mainStyle: React.CSSProperties = {
+  paddingBlock: 'var(--dsn-space-block-6xl)',
+};
+
+const rowStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '0.5rem',
+  alignItems: 'center',
+  flexWrap: 'wrap' as const,
+};
+
+// =============================================================================
+// META
+// =============================================================================
+
+const meta: Meta = {
+  title: 'Templates/KitchenSinkPage',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+// =============================================================================
+// STORY
+// =============================================================================
+
+export const Default: Story = {
+  name: 'Kitchen Sink',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation />}
+          primaryNavigationLarge={primaryNavigationLarge}
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainStyle}>
+            <Stack space="6xl">
+              {/* Intro */}
+              <div>
+                <Heading level={1}>Kitchen sink</Heading>
+                <Paragraph>Alle componenten op een rijtje.</Paragraph>
+              </div>
+
+              {/* ActionGroup */}
+              <Section
+                name="ActionGroup"
+                docPath="?path=/docs/components-actiongroup--docs"
+              >
+                <ActionGroup>
+                  <Button variant="strong">Tekst</Button>
+                  <Button variant="default">Tekst</Button>
+                  <Button variant="subtle">Tekst</Button>
+                </ActionGroup>
+              </Section>
+
+              {/* Alert */}
+              <Section
+                name="Alert"
+                docPath="?path=/docs/components-alert--docs"
+              >
+                <Stack space="md">
+                  <Alert variant="info" heading="Heading">
+                    <Paragraph>Tekst</Paragraph>
+                  </Alert>
+                  <Alert variant="warning" heading="Heading">
+                    <Paragraph>Tekst</Paragraph>
+                  </Alert>
+                  <Alert variant="negative" heading="Heading">
+                    <Paragraph>Tekst</Paragraph>
+                  </Alert>
+                  <Alert variant="positive" heading="Heading">
+                    <Paragraph>Tekst</Paragraph>
+                  </Alert>
+                </Stack>
+              </Section>
+
+              {/* Backdrop */}
+              <Section
+                name="Backdrop"
+                docPath="?path=/docs/components-backdrop--docs"
+              >
+                <div
+                  style={{
+                    position: 'relative',
+                    height: '200px',
+                    background: 'var(--dsn-color-neutral-bg-subtle)',
+                    borderRadius: '4px',
+                    transform: 'translateZ(0)',
+                  }}
+                >
+                  <div style={{ padding: '1rem' }}>
+                    <Paragraph>Tekst</Paragraph>
+                  </div>
+                  <Backdrop />
+                </div>
+              </Section>
+
+              {/* BreadcrumbNavigation */}
+              <Section
+                name="BreadcrumbNavigation"
+                docPath="?path=/docs/components-breadcrumbnavigation--docs"
+              >
+                <BreadcrumbNavigation aria-label="Broodkruimelpad">
+                  <BreadcrumbNavigationItem href="#">
+                    Tekst
+                  </BreadcrumbNavigationItem>
+                  <BreadcrumbNavigationItem href="#">
+                    Tekst
+                  </BreadcrumbNavigationItem>
+                  <BreadcrumbNavigationItem href="#" current>
+                    Tekst
+                  </BreadcrumbNavigationItem>
+                </BreadcrumbNavigation>
+              </Section>
+
+              {/* BreakoutSection */}
+              <Section
+                name="BreakoutSection"
+                docPath="?path=/docs/layout-components-breakoutsection--docs"
+              >
+                <BreakoutSection
+                  style={{
+                    backgroundColor: 'var(--dsn-color-accent-1-bg-subtle)',
+                    padding: 'var(--dsn-space-block-xl)',
+                  }}
+                >
+                  <Paragraph>Tekst</Paragraph>
+                </BreakoutSection>
+              </Section>
+
+              {/* Button */}
+              <Section
+                name="Button"
+                docPath="?path=/docs/components-button--docs"
+              >
+                <Stack space="md">
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: '1rem',
+                    }}
+                  >
+                    <div style={rowStyle}>
+                      <Button variant="strong">Tekst</Button>
+                      <Button variant="default">Tekst</Button>
+                      <Button variant="subtle">Tekst</Button>
+                    </div>
+                    <div style={rowStyle}>
+                      <Button variant="strong-negative">Tekst</Button>
+                      <Button variant="default-negative">Tekst</Button>
+                      <Button variant="subtle-negative">Tekst</Button>
+                    </div>
+                    <div style={rowStyle}>
+                      <Button variant="strong-positive">Tekst</Button>
+                      <Button variant="default-positive">Tekst</Button>
+                      <Button variant="subtle-positive">Tekst</Button>
+                    </div>
+                  </div>
+                  <div style={rowStyle}>
+                    <Button size="small">Tekst</Button>
+                    <Button size="default">Tekst</Button>
+                    <Button size="large">Tekst</Button>
+                  </div>
+                  <div style={rowStyle}>
+                    <Button variant="strong" iconStart={<Icon name="check" />}>
+                      Tekst
+                    </Button>
+                    <Button
+                      variant="default"
+                      iconStart={<Icon name="pencil" />}
+                    >
+                      Tekst
+                    </Button>
+                    <Button
+                      variant="subtle"
+                      iconStart={<Icon name="download" />}
+                    >
+                      Tekst
+                    </Button>
+                    <Button
+                      variant="strong-negative"
+                      iconStart={<Icon name="trash" />}
+                    >
+                      Tekst
+                    </Button>
+                  </div>
+                  <div style={rowStyle}>
+                    <Button
+                      variant="strong"
+                      iconEnd={<Icon name="arrow-right" />}
+                    >
+                      Tekst
+                    </Button>
+                    <Button
+                      variant="default"
+                      iconEnd={<Icon name="arrow-right" />}
+                    >
+                      Tekst
+                    </Button>
+                    <Button
+                      variant="subtle"
+                      iconEnd={<Icon name="chevron-down" />}
+                    >
+                      Tekst
+                    </Button>
+                  </div>
+                  <div style={rowStyle}>
+                    <Button
+                      variant="strong"
+                      iconOnly
+                      iconStart={<Icon name="plus" aria-hidden />}
+                    >
+                      Toevoegen
+                    </Button>
+                    <Button
+                      variant="default"
+                      iconOnly
+                      iconStart={<Icon name="settings" aria-hidden />}
+                    >
+                      Instellingen
+                    </Button>
+                    <Button
+                      variant="subtle"
+                      iconOnly
+                      iconStart={<Icon name="x" aria-hidden />}
+                    >
+                      Sluiten
+                    </Button>
+                    <Button
+                      variant="strong-negative"
+                      iconOnly
+                      iconStart={<Icon name="trash" aria-hidden />}
+                    >
+                      Verwijderen
+                    </Button>
+                  </div>
+                </Stack>
+              </Section>
+
+              {/* ButtonLink */}
+              <Section
+                name="ButtonLink"
+                docPath="?path=/docs/components-buttonlink--docs"
+              >
+                <div style={rowStyle}>
+                  <ButtonLink href="#" variant="strong">
+                    Tekst
+                  </ButtonLink>
+                  <ButtonLink href="#" variant="default">
+                    Tekst
+                  </ButtonLink>
+                  <ButtonLink href="#" variant="subtle">
+                    Tekst
+                  </ButtonLink>
+                </div>
+              </Section>
+
+              {/* Card */}
+              <Section name="Card" docPath="?path=/docs/components-card--docs">
+                <CardGroup>
+                  <li>
+                    <Card href="#">
+                      <CardHeader>
+                        <Image
+                          src="https://picsum.photos/seed/card1/800/450"
+                          alt=""
+                          width={800}
+                          height={450}
+                          ratio="16:9"
+                        />
+                      </CardHeader>
+                      <CardBody>
+                        <CardHeading level={2}>Titel</CardHeading>
+                        <Paragraph>Tekst</Paragraph>
+                      </CardBody>
+                      <CardFooter>
+                        <Link href="#" aria-hidden tabIndex={-1}>
+                          Lees meer
+                        </Link>
+                      </CardFooter>
+                    </Card>
+                  </li>
+                  <li>
+                    <Card href="#">
+                      <CardHeader />
+                      <CardBody>
+                        <CardHeading level={2}>
+                          Titel met een langere tekst die over meerdere regels
+                          loopt
+                        </CardHeading>
+                        <Paragraph>Tekst</Paragraph>
+                      </CardBody>
+                      <CardFooter>
+                        <Link href="#" aria-hidden tabIndex={-1}>
+                          Lees meer
+                        </Link>
+                      </CardFooter>
+                    </Card>
+                  </li>
+                  <li>
+                    <Card href="#">
+                      <CardBody>
+                        <CardHeading level={2}>Titel</CardHeading>
+                        <Paragraph>Tekst</Paragraph>
+                      </CardBody>
+                      <CardFooter>
+                        <Link href="#" aria-hidden tabIndex={-1}>
+                          Lees meer
+                        </Link>
+                      </CardFooter>
+                    </Card>
+                  </li>
+                </CardGroup>
+              </Section>
+
+              {/* Checkbox */}
+              <Section
+                name="Checkbox"
+                docPath="?path=/docs/components-checkbox--docs"
+              >
+                <Checkbox aria-label="Checkbox" />
+              </Section>
+
+              {/* CheckboxGroup */}
+              <Section
+                name="CheckboxGroup"
+                docPath="?path=/docs/components-checkboxgroup--docs"
+              >
+                <CheckboxGroup>
+                  <CheckboxOption label="Optie A" defaultChecked />
+                  <CheckboxOption label="Optie B" />
+                  <CheckboxOption label="Optie C" />
+                </CheckboxGroup>
+              </Section>
+
+              {/* CheckboxOption */}
+              <Section
+                name="CheckboxOption"
+                docPath="?path=/docs/components-checkboxoption--docs"
+              >
+                <CheckboxOption label="Optie A" />
+              </Section>
+
+              {/* Container */}
+              <Section
+                name="Container"
+                docPath="?path=/docs/layout-components-container--docs"
+              >
+                <Container>Tekst</Container>
+              </Section>
+
+              {/* DateInput */}
+              <Section
+                name="DateInput"
+                docPath="?path=/docs/components-dateinput--docs"
+              >
+                <DateInput />
+              </Section>
+
+              {/* DateInputGroup */}
+              <Section
+                name="DateInputGroup"
+                docPath="?path=/docs/components-dateinputgroup--docs"
+              >
+                <DateInputGroupDemo />
+              </Section>
+
+              {/* Details */}
+              <Section
+                name="Details"
+                docPath="?path=/docs/components-details--docs"
+              >
+                <Details summary="Tekst">
+                  <Paragraph>Tekst</Paragraph>
+                </Details>
+              </Section>
+
+              {/* DotBadge */}
+              <Section
+                name="DotBadge"
+                docPath="?path=/docs/components-dotbadge--docs"
+              >
+                <div style={rowStyle}>
+                  <span
+                    style={{ position: 'relative', display: 'inline-flex' }}
+                  >
+                    <Button
+                      variant="subtle"
+                      iconOnly
+                      iconStart={<Icon name="bell" aria-hidden />}
+                    >
+                      Notificaties
+                    </Button>
+                    <DotBadge variant="negative" aria-hidden />
+                  </span>
+                  <span
+                    style={{ position: 'relative', display: 'inline-flex' }}
+                  >
+                    <Button
+                      variant="subtle"
+                      iconOnly
+                      iconStart={<Icon name="bell" aria-hidden />}
+                    >
+                      Notificaties
+                    </Button>
+                    <DotBadge variant="positive" pulse aria-hidden />
+                  </span>
+                  <span
+                    style={{ position: 'relative', display: 'inline-flex' }}
+                  >
+                    <Button
+                      variant="subtle"
+                      iconOnly
+                      iconStart={<Icon name="bell" aria-hidden />}
+                    >
+                      Notificaties
+                    </Button>
+                    <DotBadge variant="warning" aria-hidden />
+                  </span>
+                </div>
+              </Section>
+
+              {/* Drawer */}
+              <Section
+                name="Drawer"
+                docPath="?path=/docs/components-drawer--docs"
+              >
+                <DrawerDemo />
+              </Section>
+
+              {/* EmailInput */}
+              <Section
+                name="EmailInput"
+                docPath="?path=/docs/components-emailinput--docs"
+              >
+                <EmailInput />
+              </Section>
+
+              {/* File */}
+              <Section name="File" docPath="?path=/docs/components-file--docs">
+                <File
+                  fileName="document.pdf"
+                  fileType="PDF"
+                  fileSize="1,2 MB"
+                  href="#"
+                />
+              </Section>
+
+              {/* FileInput */}
+              <Section
+                name="FileInput"
+                docPath="?path=/docs/components-fileinput--docs"
+              >
+                <FileInput />
+              </Section>
+
+              {/* FormField */}
+              <Section
+                name="FormField"
+                docPath="?path=/docs/components-formfield--docs"
+              >
+                <FormField label="Tekst" htmlFor="ff-kitchen">
+                  <TextInput id="ff-kitchen" />
+                </FormField>
+              </Section>
+
+              {/* FormFieldDescription */}
+              <Section
+                name="FormFieldDescription"
+                docPath="?path=/docs/components-formfielddescription--docs"
+              >
+                <FormFieldDescription>Tekst</FormFieldDescription>
+              </Section>
+
+              {/* FormFieldErrorMessage */}
+              <Section
+                name="FormFieldErrorMessage"
+                docPath="?path=/docs/components-formfielderrormessage--docs"
+              >
+                <FormFieldErrorMessage>Tekst</FormFieldErrorMessage>
+              </Section>
+
+              {/* FormFieldLabel */}
+              <Section
+                name="FormFieldLabel"
+                docPath="?path=/docs/components-formfieldlabel--docs"
+              >
+                <FormFieldLabel htmlFor="ffl-kitchen">Tekst</FormFieldLabel>
+              </Section>
+
+              {/* FormFieldset */}
+              <Section
+                name="FormFieldset"
+                docPath="?path=/docs/components-formfieldset--docs"
+              >
+                <FormFieldset legend="Tekst">
+                  <CheckboxGroup>
+                    <CheckboxOption label="Optie A" defaultChecked />
+                    <CheckboxOption label="Optie B" />
+                    <CheckboxOption label="Optie C" />
+                  </CheckboxGroup>
+                </FormFieldset>
+              </Section>
+
+              {/* FormFieldStatus */}
+              <Section
+                name="FormFieldStatus"
+                docPath="?path=/docs/components-formfieldstatus--docs"
+              >
+                <Stack space="sm">
+                  <FormFieldStatus>Tekst</FormFieldStatus>
+                  <FormFieldStatus variant="positive">Tekst</FormFieldStatus>
+                  <FormFieldStatus variant="warning">Tekst</FormFieldStatus>
+                </Stack>
+              </Section>
+
+              {/* Grid */}
+              <Section
+                name="Grid"
+                docPath="?path=/docs/layout-components-grid--docs"
+              >
+                <Grid>
+                  <GridItem colSpan={8}>
+                    <Container>dsn-col-8 — Hoofdinhoud</Container>
+                  </GridItem>
+                  <GridItem colSpan={4}>
+                    <Container>dsn-col-4 — Sidebar</Container>
+                  </GridItem>
+                </Grid>
+              </Section>
+
+              {/* Heading */}
+              <Section
+                name="Heading"
+                docPath="?path=/docs/components-heading--docs"
+              >
+                <Stack space="sm">
+                  <Heading level={1}>Tekst</Heading>
+                  <Heading level={2}>Tekst</Heading>
+                  <Heading level={3}>Tekst</Heading>
+                  <Heading level={4}>Tekst</Heading>
+                  <Heading level={5}>Tekst</Heading>
+                  <Heading level={6}>Tekst</Heading>
+                </Stack>
+              </Section>
+
+              {/* Hero */}
+              <Section name="Hero" docPath="?path=/docs/components-hero--docs">
+                <Hero aria-labelledby="hero-kitchen-heading">
+                  <Stack space="lg">
+                    <Heading level={3} id="hero-kitchen-heading">
+                      Titel
+                    </Heading>
+                    <Paragraph variant="lead">Tekst</Paragraph>
+                    <ActionGroup>
+                      <ButtonLink href="#" variant="strong" size="large">
+                        Tekst
+                      </ButtonLink>
+                      <ButtonLink href="#" variant="subtle" size="large">
+                        Tekst
+                      </ButtonLink>
+                    </ActionGroup>
+                  </Stack>
+                </Hero>
+              </Section>
+
+              {/* Icon */}
+              <Section name="Icon" docPath="?path=/docs/components-icon--docs">
+                <div style={rowStyle}>
+                  <Icon name="home" />
+                  <Icon name="user" />
+                  <Icon name="bell" />
+                  <Icon name="search" />
+                  <Icon name="check" />
+                  <Icon name="x" />
+                  <Icon name="pencil" />
+                  <Icon name="trash" />
+                  <Icon name="chevron-right" />
+                  <Icon name="arrow-right" />
+                  <Icon name="plus" />
+                  <Icon name="dots-vertical" />
+                </div>
+              </Section>
+
+              {/* Image */}
+              <Section
+                name="Image"
+                docPath="?path=/docs/components-image--docs"
+              >
+                <Image
+                  src="https://picsum.photos/seed/kitchen1/800/450"
+                  alt="Tekst"
+                  width={800}
+                  height={450}
+                  ratio="16:9"
+                />
+              </Section>
+
+              {/* Link */}
+              <Section name="Link" docPath="?path=/docs/components-link--docs">
+                <Link href="#">Tekst</Link>
+              </Section>
+
+              {/* LinkButton */}
+              <Section
+                name="LinkButton"
+                docPath="?path=/docs/components-linkbutton--docs"
+              >
+                <LinkButton onClick={() => undefined}>Tekst</LinkButton>
+              </Section>
+
+              {/* Logo */}
+              <Section name="Logo" docPath="?path=/docs/components-logo--docs">
+                <Logo title="Starter Kit" />
+              </Section>
+
+              {/* Menu */}
+              <Section name="Menu" docPath="?path=/docs/components-menu--docs">
+                <Menu orientation="vertical">
+                  <MenuLink href="#" level={1} current>
+                    Tekst
+                  </MenuLink>
+                  <MenuLink href="#" level={1}>
+                    Tekst
+                  </MenuLink>
+                  <MenuLink href="#" level={1}>
+                    Tekst
+                  </MenuLink>
+                </Menu>
+              </Section>
+
+              {/* MenuButton */}
+              <Section
+                name="MenuButton"
+                docPath="?path=/docs/components-menubutton--docs"
+              >
+                <Menu orientation="vertical">
+                  <MenuButton onClick={() => undefined}>Tekst</MenuButton>
+                  <MenuButton onClick={() => undefined}>Tekst</MenuButton>
+                  <MenuButton onClick={() => undefined}>Tekst</MenuButton>
+                </Menu>
+              </Section>
+
+              {/* MenuLink */}
+              <Section
+                name="MenuLink"
+                docPath="?path=/docs/components-menulink--docs"
+              >
+                <Menu orientation="vertical">
+                  <MenuLink href="#" level={1} current>
+                    Tekst
+                  </MenuLink>
+                  <MenuLink href="#" level={2}>
+                    Tekst
+                  </MenuLink>
+                  <MenuLink href="#" level={3}>
+                    Tekst
+                  </MenuLink>
+                </Menu>
+              </Section>
+
+              {/* ModalDialog */}
+              <Section
+                name="ModalDialog"
+                docPath="?path=/docs/components-modaldialog--docs"
+              >
+                <ModalDialogDemo />
+              </Section>
+
+              {/* Note */}
+              <Section name="Note" docPath="?path=/docs/components-note--docs">
+                <Stack space="md">
+                  <Note variant="neutral" heading="Heading">
+                    <Paragraph>Tekst</Paragraph>
+                  </Note>
+                  <Note variant="info" heading="Informatie">
+                    <Paragraph>Tekst</Paragraph>
+                  </Note>
+                  <Note variant="warning" heading="Waarschuwing">
+                    <Paragraph>Tekst</Paragraph>
+                  </Note>
+                  <Note variant="negative" heading="Let op">
+                    <Paragraph>Tekst</Paragraph>
+                  </Note>
+                  <Note variant="positive" heading="Tip">
+                    <Paragraph>Tekst</Paragraph>
+                  </Note>
+                </Stack>
+              </Section>
+
+              {/* NumberBadge */}
+              <Section
+                name="NumberBadge"
+                docPath="?path=/docs/components-numberbadge--docs"
+              >
+                <div style={rowStyle}>
+                  <NumberBadge variant="negative" aria-hidden>
+                    5
+                  </NumberBadge>
+                  <NumberBadge variant="positive" aria-hidden>
+                    5
+                  </NumberBadge>
+                  <NumberBadge variant="warning" aria-hidden>
+                    5
+                  </NumberBadge>
+                  <NumberBadge variant="info" aria-hidden>
+                    5
+                  </NumberBadge>
+                  <NumberBadge variant="neutral" aria-hidden>
+                    5
+                  </NumberBadge>
+                </div>
+              </Section>
+
+              {/* NumberInput */}
+              <Section
+                name="NumberInput"
+                docPath="?path=/docs/components-numberinput--docs"
+              >
+                <NumberInput />
+              </Section>
+
+              {/* OptionLabel */}
+              <Section
+                name="OptionLabel"
+                docPath="?path=/docs/components-optionlabel--docs"
+              >
+                <OptionLabel>Tekst</OptionLabel>
+              </Section>
+
+              {/* OrderedList */}
+              <Section
+                name="OrderedList"
+                docPath="?path=/docs/components-orderedlist--docs"
+              >
+                <OrderedList>
+                  <li>Tekst</li>
+                  <li>Tekst</li>
+                  <li>Tekst</li>
+                </OrderedList>
+              </Section>
+
+              {/* Paragraph */}
+              <Section
+                name="Paragraph"
+                docPath="?path=/docs/components-paragraph--docs"
+              >
+                <Stack space="sm">
+                  <Paragraph>Tekst</Paragraph>
+                  <Paragraph variant="lead">Tekst</Paragraph>
+                  <Paragraph variant="small-print">Tekst</Paragraph>
+                </Stack>
+              </Section>
+
+              {/* PasswordInput */}
+              <Section
+                name="PasswordInput"
+                docPath="?path=/docs/components-passwordinput--docs"
+              >
+                <PasswordInput passwordAutocomplete="current-password" />
+              </Section>
+
+              {/* Popover */}
+              <Section
+                name="Popover"
+                docPath="?path=/docs/components-popover--docs"
+              >
+                <PopoverDemo />
+              </Section>
+
+              {/* ProgressBar */}
+              <Section
+                name="ProgressBar"
+                docPath="?path=/docs/components-progressbar--docs"
+              >
+                <ProgressBar label="Tekst" value={35} max={100} />
+              </Section>
+
+              {/* Radio */}
+              <Section
+                name="Radio"
+                docPath="?path=/docs/components-radio--docs"
+              >
+                <Radio name="radio-kitchen-single" aria-label="Radio" />
+              </Section>
+
+              {/* RadioGroup */}
+              <Section
+                name="RadioGroup"
+                docPath="?path=/docs/components-radiogroup--docs"
+              >
+                <RadioGroup>
+                  <RadioOption
+                    label="Optie A"
+                    name="rg-kitchen"
+                    defaultChecked
+                  />
+                  <RadioOption label="Optie B" name="rg-kitchen" />
+                  <RadioOption label="Optie C" name="rg-kitchen" />
+                </RadioGroup>
+              </Section>
+
+              {/* RadioOption */}
+              <Section
+                name="RadioOption"
+                docPath="?path=/docs/components-radiooption--docs"
+              >
+                <RadioOption label="Optie A" name="ro-kitchen-single" />
+              </Section>
+
+              {/* SearchInput */}
+              <Section
+                name="SearchInput"
+                docPath="?path=/docs/components-searchinput--docs"
+              >
+                <SearchInput />
+              </Section>
+
+              {/* Select */}
+              <Section
+                name="Select"
+                docPath="?path=/docs/components-select--docs"
+              >
+                <Select>
+                  <option value="">Tekst</option>
+                  <option value="a">Tekst</option>
+                  <option value="b">Tekst</option>
+                </Select>
+              </Section>
+
+              {/* Spinner */}
+              <Section
+                name="Spinner"
+                docPath="?path=/docs/components-spinner--docs"
+              >
+                <Spinner label="Tekst" />
+              </Section>
+
+              {/* Stack */}
+              <Section
+                name="Stack"
+                docPath="?path=/docs/layout-components-stack--docs"
+              >
+                <Stack space="md">
+                  <Paragraph>Tekst</Paragraph>
+                  <Paragraph>Tekst</Paragraph>
+                  <Paragraph>Tekst</Paragraph>
+                </Stack>
+              </Section>
+
+              {/* StatusBadge */}
+              <Section
+                name="StatusBadge"
+                docPath="?path=/docs/components-statusbadge--docs"
+              >
+                <div style={rowStyle}>
+                  <StatusBadge variant="neutral">Tekst</StatusBadge>
+                  <StatusBadge variant="info">Tekst</StatusBadge>
+                  <StatusBadge variant="positive">Tekst</StatusBadge>
+                  <StatusBadge variant="negative">Tekst</StatusBadge>
+                  <StatusBadge variant="warning">Tekst</StatusBadge>
+                </div>
+              </Section>
+
+              {/* SummaryList */}
+              <Section
+                name="SummaryList"
+                docPath="?path=/docs/components-summarylist--docs"
+              >
+                <SummaryList>
+                  <SummaryListRow>
+                    <SummaryListKey>Tekst</SummaryListKey>
+                    <SummaryListValue>Tekst</SummaryListValue>
+                    <SummaryListActions>
+                      <Link href="#" iconStart={<Icon name="pencil" />}>
+                        Tekst
+                      </Link>
+                    </SummaryListActions>
+                  </SummaryListRow>
+                  <SummaryListRow>
+                    <SummaryListKey>Tekst</SummaryListKey>
+                    <SummaryListValue>Tekst</SummaryListValue>
+                    <SummaryListActions>
+                      <Link href="#" iconStart={<Icon name="pencil" />}>
+                        Tekst
+                      </Link>
+                    </SummaryListActions>
+                  </SummaryListRow>
+                  <SummaryListRow>
+                    <SummaryListKey>Tekst</SummaryListKey>
+                    <SummaryListValue>Tekst</SummaryListValue>
+                  </SummaryListRow>
+                </SummaryList>
+              </Section>
+
+              {/* Table */}
+              <Section
+                name="Table"
+                docPath="?path=/docs/components-table--docs"
+              >
+                <Table caption="Tekst">
+                  <thead>
+                    <tr>
+                      <th scope="col">Tekst</th>
+                      <th scope="col" className="dsn-table__cell--numeric">
+                        Tekst
+                      </th>
+                      <th scope="col" className="dsn-table__cell--numeric">
+                        Tekst
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Tekst</td>
+                      <td className="dsn-table__cell--numeric">Tekst</td>
+                      <td className="dsn-table__cell--numeric">Tekst</td>
+                    </tr>
+                    <tr>
+                      <td>Tekst</td>
+                      <td className="dsn-table__cell--numeric">Tekst</td>
+                      <td className="dsn-table__cell--numeric">Tekst</td>
+                    </tr>
+                  </tbody>
+                </Table>
+              </Section>
+
+              {/* TelephoneInput */}
+              <Section
+                name="TelephoneInput"
+                docPath="?path=/docs/components-telephoneinput--docs"
+              >
+                <TelephoneInput />
+              </Section>
+
+              {/* TextArea */}
+              <Section
+                name="TextArea"
+                docPath="?path=/docs/components-textarea--docs"
+              >
+                <TextArea />
+              </Section>
+
+              {/* TextInput */}
+              <Section
+                name="TextInput"
+                docPath="?path=/docs/components-textinput--docs"
+              >
+                <TextInput />
+              </Section>
+
+              {/* TimeInput */}
+              <Section
+                name="TimeInput"
+                docPath="?path=/docs/components-timeinput--docs"
+              >
+                <TimeInput />
+              </Section>
+
+              {/* UnorderedList */}
+              <Section
+                name="UnorderedList"
+                docPath="?path=/docs/components-unorderedlist--docs"
+              >
+                <UnorderedList>
+                  <li>Tekst</li>
+                  <li>Tekst</li>
+                  <li>Tekst</li>
+                </UnorderedList>
+              </Section>
+            </Stack>
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};


### PR DESCRIPTION
## Summary

- Voegt een nieuwe `KitchenSinkPage` template story toe (`Templates/KitchenSinkPage`)
- Toont alle componenten in alphabetische volgorde op één pagina, gebaseerd op de BasePage-structuur
- Elk component heeft een H2-kop, een link naar de Storybook-documentatie en een visueel voorbeeld
- Overlay-componenten (ModalDialog, Drawer, Popover) zijn activeerbaar via een knop

## Test plan

- [ ] Storybook: **Templates → KitchenSinkPage → Kitchen Sink** laadt zonder fouten
- [ ] Alle componenten zijn zichtbaar en correct weergegeven
- [ ] "Open Modal Dialog", "Open Drawer" en "Open Popover" knoppen openen de respectieve overlays
- [ ] TypeScript: `pnpm --filter storybook exec tsc --noEmit` geeft 0 fouten

🤖 Generated with [Claude Code](https://claude.com/claude-code)