### PR TITLE
fix(CodeTabs): herstel lege pagina bij klikken op HTML/CSS tab

### DIFF
--- a/packages/storybook/src/components/CodeTabs.tsx
+++ b/packages/storybook/src/components/CodeTabs.tsx
@@ -100,10 +100,10 @@ export function CodeTabs({ of: storyRef, react, html }: CodeTabsProps) {
           // show it as static code. Otherwise, subscribe to STORY_ARGS_UPDATED via `of` so
           // the displayed code updates automatically when the user changes Controls.
           react ? (
-            <Source code={react} language="tsx" dark />
+            <Source key="react-static" code={react} language="tsx" dark />
           ) : (
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            <Source of={storyRef as any} dark />
+            <Source key="react-live" of={storyRef as any} dark />
           )
         ) : (
           // HTML tab: uses `of` for live subscription to STORY_ARGS_UPDATED,
@@ -111,6 +111,7 @@ export function CodeTabs({ of: storyRef, react, html }: CodeTabsProps) {
           // `parameters.dsn.htmlTemplate` function defined in each story file.
           // Falls back to the static `html` prop when no template is defined.
           <Source
+            key="html"
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             of={storyRef as any}
             // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Samenvatting

- In Storybook v10 introduceert de `Source` block een nieuwe interne hook (`useTransformCode`) die conditioneel wordt aangeroepen op basis van de aanwezigheid van de `transform` prop
- Doordat de React-tab en HTML/CSS-tab `Source`-varianten op dezelfde JSX-positie stonden met hetzelfde type, behandelde React ze als één component-instantie
- Bij het wisselen naar de HTML/CSS-tab veranderde `transform` van `undefined` naar een functie — waardoor meer hooks werden aangeroepen dan bij de vorige render — en crashte de volledige docs-pagina met "Rendered more hooks than during the previous render"

## Oplossing

`key` props toegevoegd aan alle drie `Source`-varianten in `CodeTabs.tsx` (`"react-static"`, `"react-live"`, `"html"`), zodat React elke tab-variant altijd als een aparte instantie behandelt en vers monteert bij het wisselen van tab.

## Test

- Docs-pagina openen van een willekeurig component (bijv. Button)
- Op HTML/CSS tab klikken → toont nu de correcte HTML markup
- Terug naar React tab klikken → werkt nog steeds correct
- Geen console-fouten

🤖 Generated with [Claude Code](https://claude.com/claude-code)