### PR TITLE
feat(Templates): voeg 'Full Width + Centered Main Content' story toe aan Detailpage

### DIFF
--- a/packages/storybook/src/templates/WithSidebarPage.stories.tsx
+++ b/packages/storybook/src/templates/WithSidebarPage.stories.tsx
@@ -471,6 +471,57 @@ export const FullWidth: Story = {
   ),
 };
 
+export const FullWidthCenteredContent: Story = {
+  name: 'Full Width + Centered Main Content',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout
+        style={{ '--dsn-page-max-inline-size': 'none' } as React.CSSProperties}
+      >
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation currentPage="level-1a" />}
+          primaryNavigationLarge={
+            <PrimaryNavigationLarge currentPage="level-1a" />
+          }
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <div className="dsn-sidebar-layout">
+            <aside className="dsn-sidebar-layout__sidebar">
+              <SidebarNavigation currentPage="level-1a" />
+            </aside>
+            <main
+              id="main-content"
+              tabIndex={-1}
+              className="dsn-sidebar-layout__main"
+              style={mainStyle}
+            >
+              <div
+                style={{
+                  maxInlineSize: '75rem',
+                  marginInline: 'auto',
+                }}
+              >
+                <GridContent />
+              </div>
+            </main>
+          </div>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};
+
 export const WithoutSidebar: Story = {
   name: 'No Sidebar',
   render: () => (


### PR DESCRIPTION
## Summary

- Nieuwe story **Full Width + Centered Main Content** toegevoegd aan `Templates/Detailpage`
- Gebaseerd op de bestaande 'Full Width + Sidebar' story: de `PageLayout` heeft geen `max-inline-size` beperking
- Sidebar blijft volledig links, de main-content wordt horizontaal gecentreerd binnen de beschikbare ruimte rechts van de sidebar via `max-inline-size: 75rem` + `margin-inline: auto`

## Test plan

- [ ] Controleer de nieuwe story in Storybook onder `Templates/Detailpage → Full Width + Centered Main Content`
- [ ] Verifieer dat de sidebar links blijft op brede viewports (≥ 64em)
- [ ] Verifieer dat de main-content gecentreerd staat met max-breedte van 75rem
- [ ] Verifieer dat de bestaande stories ongewijzigd zijn

🤖 Generated with [Claude Code](https://claude.com/claude-code)