### PR TITLE
docs: update scope naar @dsn-starter-kit en voeg npm publish info toe

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,30 @@ A production-ready, white-label design system starter kit built with design toke
 
 This monorepo contains the following packages:
 
-- **[@dsn/design-tokens](./packages/design-tokens)** - Design tokens (colors, typography, spacing, etc.)
-- **[@dsn/core](./packages/core)** - Core utilities and global styles (CSS reset, utility classes)
-- **[@dsn/components-html](./packages/components-html)** - Pure HTML/CSS components
-- **[@dsn/components-react](./packages/components-react)** - React components with TypeScript
-- **[@dsn/components-web](./packages/components-web)** - Web Components (vanilla TypeScript)
-- **[@dsn/storybook](./packages/storybook)** - Documentation and component showcase
+- **[@dsn-starter-kit/design-tokens](./packages/design-tokens)** - Design tokens (colors, typography, spacing, etc.)
+- **[@dsn-starter-kit/core](./packages/core)** - Core utilities and global styles (CSS reset, utility classes)
+- **[@dsn-starter-kit/components-html](./packages/components-html)** - Pure HTML/CSS components
+- **[@dsn-starter-kit/components-react](./packages/components-react)** - React components with TypeScript
+- **[@dsn-starter-kit/components-web](./packages/components-web)** - Web Components (vanilla TypeScript)
+- **[@dsn-starter-kit/storybook](./packages/storybook)** - Documentation and component showcase
 
 ## Quick Start
+
+### Option A: Install from npm (recommended for consumers)
+
+All packages are published to npm under the `@dsn-starter-kit` scope:
+
+```bash
+pnpm add @dsn-starter-kit/components-react @dsn-starter-kit/core
+```
+
+```tsx
+import '@dsn-starter-kit/core/css'; // design tokens + reset
+import '@dsn-starter-kit/components-react/css'; // all component styles
+import { Button, Stack, Heading } from '@dsn-starter-kit/components-react';
+```
+
+### Option B: Clone the repository (for contributors and forks)
 
 ### Prerequisites
 
@@ -60,7 +76,7 @@ pnpm build:components  # All component packages
 pnpm build:storybook   # Storybook static site
 
 # Watch design tokens for changes
-pnpm --filter @dsn/design-tokens watch
+pnpm --filter @dsn-starter-kit/design-tokens watch
 
 # Start Storybook in development mode
 pnpm dev
@@ -94,10 +110,10 @@ pnpm clean
 
 The build system ensures packages are built in the correct dependency order:
 
-1. **Design Tokens** (`@dsn/design-tokens`) - Generates CSS, SCSS, JS, and JSON files
-2. **Core** (`@dsn/core`) - Builds utilities and base styles
-3. **Components** (`@dsn/components-html`, `@dsn/components-react`, `@dsn/components-web`) - Builds all component packages
-4. **Storybook** (`@dsn/storybook`) - Generates static documentation site
+1. **Design Tokens** (`@dsn-starter-kit/design-tokens`) - Generates CSS, SCSS, JS, and JSON files
+2. **Core** (`@dsn-starter-kit/core`) - Builds utilities and base styles
+3. **Components** (`@dsn-starter-kit/components-html`, `@dsn-starter-kit/components-react`, `@dsn-starter-kit/components-web`) - Builds all component packages
+4. **Storybook** (`@dsn-starter-kit/storybook`) - Generates static documentation site
 
 Icon generation is automatically included in the React components build step.
 
@@ -105,10 +121,10 @@ Icon generation is automatically included in the React components build step.
 
 ```bash
 # Build a specific package
-pnpm --filter @dsn/design-tokens build
+pnpm --filter @dsn-starter-kit/design-tokens build
 
 # Add dependency to a package
-pnpm --filter @dsn/components-react add react
+pnpm --filter @dsn-starter-kit/components-react add react
 
 # Add dev dependency to root
 pnpm add -Dw eslint
@@ -152,10 +168,15 @@ The React component package provides a convenient barrel export for easy importi
 
 ```tsx
 // Import multiple components at once
-import { Button, TextInput, Heading, Icon } from '@dsn/components-react';
+import {
+  Button,
+  TextInput,
+  Heading,
+  Icon,
+} from '@dsn-starter-kit/components-react';
 
 // Or import individually (if preferred)
-import { Button } from '@dsn/components-react/Button';
+import { Button } from '@dsn-starter-kit/components-react/Button';
 ```
 
 All components are fully typed with TypeScript and include comprehensive JSDoc documentation.
@@ -381,16 +402,16 @@ Full dark mode support out of the box:
 
 ```css
 /* Light theme (default) */
-@import '@dsn/design-tokens/css';
+@import '@dsn-starter-kit/design-tokens/css';
 
 /* Dark theme */
-@import '@dsn/design-tokens/css/dark';
+@import '@dsn-starter-kit/design-tokens/css/dark';
 ```
 
 ```ts
 // JavaScript (typed exports)
-import { DsnColorNeutralBgDocument } from '@dsn/design-tokens';
-import { DsnColorNeutralBgDocument as Dark } from '@dsn/design-tokens/dark';
+import { DsnColorNeutralBgDocument } from '@dsn-starter-kit/design-tokens';
+import { DsnColorNeutralBgDocument as Dark } from '@dsn-starter-kit/design-tokens/dark';
 ```
 
 Toggle themes by switching CSS files or using CSS custom properties.

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -22,7 +22,7 @@ This document describes the architecture of the Design System Starter Kit, inclu
 ### Repository Details
 
 - **Name:** `design-system-starter-kit`
-- **Package Scope:** `@dsn/*` (Design System Name - customizable per organization)
+- **Package Scope:** `@dsn-starter-kit/*` (customizable per organization when forking)
 - **Package Manager:** PNPM (with workspaces)
 - **License:** MIT
 - **Purpose:** Production-ready design system starter kit for organizations
@@ -49,7 +49,7 @@ design-system-starter-kit/
 ├── .husky/
 │   └── pre-commit               # Runs lint-staged
 ├── packages/
-│   ├── design-tokens/           # @dsn/design-tokens
+│   ├── design-tokens/           # @dsn-starter-kit/design-tokens
 │   │   └── src/
 │   │       ├── config/
 │   │       │   ├── build.js     # Multi-config build script
@@ -100,12 +100,12 @@ design-system-starter-kit/
 │   │               ├── text-input.json
 │   │               ├── time-input.json
 │   │               └── unordered-list.json
-│   ├── core/                    # @dsn/core
-│   ├── components-html/         # @dsn/components-html
-│   ├── components-react/        # @dsn/components-react
+│   ├── core/                    # @dsn-starter-kit/core
+│   ├── components-html/         # @dsn-starter-kit/components-html
+│   ├── components-react/        # @dsn-starter-kit/components-react
 │   │   └── scripts/
 │   │       └── generate-icons.js # Icon registry generator
-│   ├── components-web/          # @dsn/components-web
+│   ├── components-web/          # @dsn-starter-kit/components-web
 │   └── storybook/               # Documentation site
 │       ├── .storybook/
 │       │   ├── main.ts          # Storybook config + multilevel-sort
@@ -323,7 +323,7 @@ A minimal theme for prototyping and development.
 
 5. Build:
    ```bash
-   pnpm --filter @dsn/design-tokens build
+   pnpm --filter @dsn-starter-kit/design-tokens build
    ```
 
 ### Adding a New Project Type

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -34,10 +34,10 @@ import {
   Heading,
   FormField,
   Icon,
-} from '@dsn/components-react';
+} from '@dsn-starter-kit/components-react';
 
 // Also supported: Import individually
-import { Button } from '@dsn/components-react/Button';
+import { Button } from '@dsn-starter-kit/components-react/Button';
 ```
 
 **All React components are fully typed** and include JSDoc documentation with usage examples.
@@ -3217,16 +3217,16 @@ Web Components are **NOT** auto-registered on import to avoid side effects. You 
 
 ```ts
 // Option 1: Register all components at once
-import { defineAllComponents } from '@dsn/components-web';
+import { defineAllComponents } from '@dsn-starter-kit/components-web';
 defineAllComponents();
 
 // Option 2: Register specific components
-import { defineButton, defineIcon } from '@dsn/components-web';
+import { defineButton, defineIcon } from '@dsn-starter-kit/components-web';
 defineButton();
 defineIcon();
 
 // Option 3: Register with custom tag names
-import { defineButton } from '@dsn/components-web';
+import { defineButton } from '@dsn-starter-kit/components-web';
 defineButton('my-custom-button');
 ```
 

--- a/docs/04-development-workflow.md
+++ b/docs/04-development-workflow.md
@@ -32,7 +32,7 @@ pnpm build:components  # All component packages
 pnpm build:storybook   # Storybook static site
 
 # Watch design tokens for changes
-pnpm --filter @dsn/design-tokens watch
+pnpm --filter @dsn-starter-kit/design-tokens watch
 
 # Start Storybook in development mode
 pnpm dev
@@ -93,10 +93,10 @@ pnpm build
 
 ```bash
 # Build a specific package
-pnpm --filter @dsn/design-tokens build
+pnpm --filter @dsn-starter-kit/design-tokens build
 
 # Add dependency to a package
-pnpm --filter @dsn/components-react add react
+pnpm --filter @dsn-starter-kit/components-react add react
 
 # Add dev dependency to root
 pnpm add -Dw eslint
@@ -109,7 +109,7 @@ pnpm -r build
 
 ## Versioning
 
-All publishable packages (`@dsn/design-tokens`, `@dsn/core`, `@dsn/components-html`, `@dsn/components-react`, `@dsn/components-web`) are versioned together. They share a single version number so consumers can always install a coherent set.
+All publishable packages (`@dsn-starter-kit/design-tokens`, `@dsn-starter-kit/core`, `@dsn-starter-kit/components-html`, `@dsn-starter-kit/components-react`, `@dsn-starter-kit/components-web`) are versioned together. They share a single version number so consumers can always install a coherent set.
 
 ### When to bump
 
@@ -133,12 +133,24 @@ git commit -m "chore: bump to $(node -p "require('./package.json').version")"
 git tag "v$(node -p "require('./package.json').version")"
 ```
 
-The scripts use `--no-git-tag-version` so you control exactly what gets committed and tagged. `@dsn/storybook` is private and excluded from the bump; its version is cosmetic.
+The scripts use `--no-git-tag-version` so you control exactly what gets committed and tagged. `@dsn-starter-kit/storybook` is private and excluded from the bump; its version is cosmetic.
 
 ### After bumping
 
 1. Add an entry to `docs/changelog.md` under the new version number
-2. Push the tag: `git push origin --tags`
+2. Push commit and tag — this automatically triggers the npm publish workflow:
+
+```bash
+git push && git push --tags
+```
+
+### Publishing to npm
+
+Packages are published automatically via GitHub Actions when a version tag is pushed. The workflow (`.github/workflows/publish.yml`) builds all packages and runs `pnpm publish -r`.
+
+**Required secret:** `NPM_TOKEN` must be set in GitHub → Settings → Secrets and variables → Actions. Use a Granular Access Token from npmjs.com with "Read and write" on "All packages" and "Bypass 2FA" enabled.
+
+You can also trigger a publish manually without a tag via GitHub → Actions → "Publish to npm" → Run workflow.
 
 ---
 
@@ -243,7 +255,7 @@ This makes each token file readable top-to-bottom: first what a thing looks like
 2. **Run the build**
 
    ```bash
-   pnpm --filter @dsn/design-tokens build
+   pnpm --filter @dsn-starter-kit/design-tokens build
    ```
 
 3. **Verify output** in `dist/css/`
@@ -310,14 +322,19 @@ See [Architecture: Adding a New Project Type](./01-architecture.md#adding-a-new-
 
 ### React Components (Barrel Exports)
 
-The `@dsn/components-react` package provides a barrel export for convenient importing:
+The `@dsn-starter-kit/components-react` package provides a barrel export for convenient importing:
 
 ```tsx
 // ✅ Recommended: Import multiple components from barrel export
-import { Button, TextInput, Heading, FormField } from '@dsn/components-react';
+import {
+  Button,
+  TextInput,
+  Heading,
+  FormField,
+} from '@dsn-starter-kit/components-react';
 
 // Also supported: Import individual components
-import { Button } from '@dsn/components-react/Button';
+import { Button } from '@dsn-starter-kit/components-react/Button';
 ```
 
 **Benefits:**
@@ -333,7 +350,7 @@ CSS components can be imported individually:
 
 ```tsx
 // In React components that use HTML/CSS styles
-import './Button.css'; // Re-exports from @dsn/components-html
+import './Button.css'; // Re-exports from @dsn-starter-kit/components-html
 
 // The CSS file contains:
 // @import '../../../components-html/src/button/button.css';
@@ -341,7 +358,7 @@ import './Button.css'; // Re-exports from @dsn/components-html
 
 **Package Exports:**
 
-The `@dsn/components-html` package exports individual CSS files:
+The `@dsn-starter-kit/components-html` package exports individual CSS files:
 
 ```json
 {
@@ -357,21 +374,21 @@ The `@dsn/components-html` package exports individual CSS files:
 
 ```tsx
 // CSS
-@import '@dsn/design-tokens/css';         // Light theme
-@import '@dsn/design-tokens/css/dark';    // Dark theme
+@import '@dsn-starter-kit/design-tokens/css';         // Light theme
+@import '@dsn-starter-kit/design-tokens/css/dark';    // Dark theme
 
 // JavaScript/TypeScript (typed exports)
-import { DsnColorNeutralBgDocument } from '@dsn/design-tokens';
+import { DsnColorNeutralBgDocument } from '@dsn-starter-kit/design-tokens';
 ```
 
 ### Core Utilities
 
 ```tsx
 // JavaScript utilities
-import { classNames, bem, bemModifiers } from '@dsn/core';
+import { classNames, bem, bemModifiers } from '@dsn-starter-kit/core';
 
 // CSS utilities and reset
-import '@dsn/core/css'; // Includes reset + utilities
+import '@dsn-starter-kit/core/css'; // Includes reset + utilities
 ```
 
 ---
@@ -521,7 +538,7 @@ pnpm test --coverage
 
 ```tsx
 import { render, screen } from '@testing-library/react';
-import { Button } from '@dsn/components-react';
+import { Button } from '@dsn-starter-kit/components-react';
 // or: import { Button } from './Button';
 
 describe('Button', () => {
@@ -605,7 +622,7 @@ The project uses Husky + lint-staged to run checks before commits:
 pnpm type-check
 
 # Type-check specific package
-pnpm --filter @dsn/components-react type-check
+pnpm --filter @dsn-starter-kit/components-react type-check
 ```
 
 ### Prettier

--- a/docs/05-storybook-configuration.md
+++ b/docs/05-storybook-configuration.md
@@ -459,7 +459,7 @@ Each component has **three files**:
 ```tsx
 // Button.stories.tsx
 import type { Meta, StoryObj } from '@storybook/react';
-import { Button } from '@dsn/components-react';
+import { Button } from '@dsn-starter-kit/components-react';
 import DocsPage from './Button.docs.mdx';
 import { TEKST, rtlDecorator } from './story-helpers';
 
@@ -646,7 +646,7 @@ Components
 pnpm dev
 
 # Build static Storybook
-pnpm --filter @dsn/storybook build
+pnpm --filter @dsn-starter-kit/storybook build
 ```
 
 ### Adding Documentation for a New Component

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,22 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 1.0.1 (May 16, 2026)
+
+### npm publishing
+
+#### Added
+
+- **npm publish workflow** (`.github/workflows/publish.yml`): publiceert alle 5 packages automatisch naar npm bij een versie-tag (`v*`) of via een handmatige workflow dispatch
+- **CSS build stap** in `@dsn-starter-kit/components-react`: `scripts/build-css.js` resolvet alle `@import`-ketens en schrijft zelfstandige CSS-bestanden naar `dist/` zodat componentstijlen correct worden meegeleverd bij npm-installatie
+- **`./css` export** aan `@dsn-starter-kit/components-react` toegevoegd: consumers kunnen `@dsn-starter-kit/components-react/css` importeren voor een gebundeld CSS-bestand met alle componentstijlen
+- **`publishConfig: { access: "public" }`** aan alle 5 publishable packages toegevoegd (vereist voor scoped packages op npm)
+- **`CONTRIBUTING.md`** toegevoegd met bijdragecriteria en PR-checklist (PR #262)
+
+#### Changed
+
+- **Scope hernoemd** van `@dsn/` naar `@dsn-starter-kit/` — de `@dsn` scope was al in gebruik op npm; alle package-namen, imports en workflow-filters zijn bijgewerkt
+
 ## Version 1.0.0 (May 15, 2026)
 
 ### Package version alignment


### PR DESCRIPTION
## Summary

- Vervang alle `@dsn/` referenties door `@dsn-starter-kit/` in README en alle docs (scope is hernoemd na npm publish setup)
- Voeg "Install from npm" sectie toe aan README als primaire installatiemethode voor consumers
- Voeg npm publish workflow documentatie toe aan `docs/04-development-workflow.md` (hoe te releasen, vereiste secret)
- Voeg changelog entry toe voor v1.0.1 (npm publishing + scope rename)

## Test plan

- [ ] Controleer README: package-namen, installatie-sectie en codevoorbeelden correct
- [ ] Controleer `docs/04-development-workflow.md`: scope-namen en publish-sectie aanwezig
- [ ] Controleer `docs/changelog.md`: v1.0.1 entry aanwezig boven v1.0.0
- [ ] Geen `@dsn/` meer aanwezig buiten historische changelog-entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)