### PR TITLE
chore: bump alle packages naar v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system-starter-kit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Production-ready white-label design system starter kit",
   "author": "Jeffrey Lauwers",

--- a/packages/components-html/package.json
+++ b/packages/components-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsn-starter-kit/components-html",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pure HTML/CSS components for the design system",
   "style": "dist/components.css",
   "main": "dist/components.css",

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsn-starter-kit/components-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React components for the design system",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/components-web/package.json
+++ b/packages/components-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsn-starter-kit/components-web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Web Components for the design system",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsn-starter-kit/core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Core styles and utilities for the design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsn-starter-kit/design-tokens",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Design tokens for the design system",
   "main": "dist/js/tokens.js",
   "types": "dist/js/tokens.d.ts",


### PR DESCRIPTION
## Waarom

De publish workflow van gisteren gaf `There are no new packages that should be published` omdat alle packages al op `v1.0.0` stonden op npm. `pnpm publish -r` vergelijkt de versie in `package.json` met npm en slaat over als die al bestaat.

## Wat

Alle publishable packages gebumpt naar `v1.0.1` via `pnpm version:patch`:
- `@dsn-starter-kit/components-html`
- `@dsn-starter-kit/components-react`
- `@dsn-starter-kit/design-tokens`
- `@dsn-starter-kit/core`
- `@dsn-starter-kit/components-web`

## Na merge

Na merge van deze PR: tag aanmaken op main om de publish workflow te triggeren:

```bash
git checkout main && git pull
git tag v1.0.1
git push origin v1.0.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)