### PR TITLE
fix(color-palette-generator): herstel grid-layout en verwijder label-truncation

### DIFF
--- a/packages/color-palette-generator/README.md
+++ b/packages/color-palette-generator/README.md
@@ -15,7 +15,12 @@ Interactieve OKLCH kleurenpalet generator voor het Design System Starter Kit. Ge
 - **Custom kleurgroepen** — toevoegen, hernoemen, verwijderen
 - **Exporteren** in drie formaten: DTCG JSON, Tokens Studio JSON, Generieke JSON
 
-## Gebruik
+## Live
+
+De tool is beschikbaar op:
+**https://jeffreylauwers.github.io/design-system-starter-kit/color-palette-generator/**
+
+## Lokaal ontwikkelen
 
 ```bash
 pnpm --filter @dsn-starter-kit/color-palette-generator dev

--- a/packages/color-palette-generator/src/components/ColorGroupRow.css
+++ b/packages/color-palette-generator/src/components/ColorGroupRow.css
@@ -31,9 +31,6 @@
   padding: 2px 4px;
   border-radius: 3px;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 100%;
   text-align: left;
 }
 

--- a/packages/color-palette-generator/src/components/PaletteGrid.css
+++ b/packages/color-palette-generator/src/components/PaletteGrid.css
@@ -16,8 +16,8 @@
   border-right: 1px solid var(--border-subtle);
   text-align: center;
   position: sticky;
-  top: 0;
-  z-index: 3;
+  top: 22px;
+  z-index: 2;
 }
 
 .palette-grid__header--sticky {
@@ -40,8 +40,16 @@
   text-transform: uppercase;
   letter-spacing: 0.03em;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+}
+
+.palette-grid__track-spacer {
+  background: color-mix(in srgb, var(--bg-surface) 88%, var(--accent) 12%);
+  border-bottom: 1px solid var(--border-subtle);
+  border-right: 1px solid var(--border-default);
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 5;
 }
 
 .palette-grid__track-label {
@@ -57,8 +65,8 @@
   display: flex;
   align-items: center;
   position: sticky;
-  top: 44px;
-  z-index: 2;
+  top: 0;
+  z-index: 3;
 }
 
 .palette-grid__track-label--inverse {

--- a/packages/color-palette-generator/src/components/PaletteGrid.tsx
+++ b/packages/color-palette-generator/src/components/PaletteGrid.tsx
@@ -66,35 +66,11 @@ export function PaletteGrid({
       <div
         className="palette-grid"
         style={{
-          gridTemplateColumns: `220px repeat(${visibleSteps.length}, minmax(56px, 1fr))`,
+          gridTemplateColumns: `220px repeat(${visibleSteps.length}, 160px)`,
         }}
       >
-        {/* Header row */}
-        <div className="palette-grid__header palette-grid__header--sticky">
-          <span className="palette-grid__header-label">Kleurgroep</span>
-        </div>
-
-        {TOKEN_STEPS.map((step) => (
-          <div key={step} className="palette-grid__header">
-            <span className="palette-grid__header-label">
-              {COLUMN_LABELS[step]}
-            </span>
-          </div>
-        ))}
-
-        {showInverse &&
-          INVERSE_TOKEN_STEPS.map((step) => (
-            <div
-              key={step}
-              className="palette-grid__header palette-grid__header--inverse"
-            >
-              <span className="palette-grid__header-label">
-                {COLUMN_LABELS[step]}
-              </span>
-            </div>
-          ))}
-
-        {/* Divider labels */}
+        {/* Row 1: Track labels (bovenste sticky rij) */}
+        <div className="palette-grid__track-spacer" />
         <div
           className="palette-grid__track-label"
           style={{ gridColumn: '2 / 8' }}
@@ -135,6 +111,31 @@ export function PaletteGrid({
             </div>
           </>
         )}
+
+        {/* Row 2: Kolomheaders */}
+        <div className="palette-grid__header palette-grid__header--sticky">
+          <span className="palette-grid__header-label">Kleurgroep</span>
+        </div>
+
+        {TOKEN_STEPS.map((step) => (
+          <div key={step} className="palette-grid__header">
+            <span className="palette-grid__header-label">
+              {COLUMN_LABELS[step]}
+            </span>
+          </div>
+        ))}
+
+        {showInverse &&
+          INVERSE_TOKEN_STEPS.map((step) => (
+            <div
+              key={step}
+              className="palette-grid__header palette-grid__header--inverse"
+            >
+              <span className="palette-grid__header-label">
+                {COLUMN_LABELS[step]}
+              </span>
+            </div>
+          ))}
 
         {/* Color group rows */}
         {groups.map((group) => (


### PR DESCRIPTION
## Summary

- Track labels (Backgrounds / Borders / Colors) staan nu boven de kolomheaders als bovenste sticky rij, zodat ze niet meer over de eerste kleurgroep-rij vallen
- Spacer-cel toegevoegd in kolom 1 van de track label rij, waardoor de grid auto-placement de kleurgroep-rijen correct in een eigen rij plaatst
- Sticky `top`-waarden aangepast: track labels op `0`, kolomheaders op `22px`
- Grid-template gewijzigd naar `220px repeat(n, 160px)` (vaste breedte per kolom) zodat labels als `bg-document` en `border-default` volledig leesbaar zijn
- `overflow: hidden` en `text-overflow: ellipsis` verwijderd van kolomheaders en rijnamen
- Live URL toegevoegd aan README

## Test plan

- [ ] Backgrounds / Borders / Colors balk staat boven de kolomheaders
- [ ] Geen overlap tussen track labels en de eerste kleurgroep-rij (neutral)
- [ ] Kolomlabels (bg-document, border-default, etc.) volledig leesbaar
- [ ] Rijnamen (accent-1, action-2, negative, warning) volledig leesbaar
- [ ] Horizontaal scrollen werkt correct
- [ ] Sticky gedrag werkt bij verticaal scrollen (track labels + kolomheaders blijven zichtbaar)
- [ ] Inverse-modus toont ook correcte track labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)