### PR TITLE
feat(color-palette-generator): verbeter kleurberekening, contrast en export-volgorde

### DIFF
--- a/packages/color-palette-generator/README.md
+++ b/packages/color-palette-generator/README.md
@@ -15,7 +15,12 @@ Interactieve OKLCH kleurenpalet generator voor het Design System Starter Kit. Ge
 - **Custom kleurgroepen** — toevoegen, hernoemen, verwijderen
 - **Exporteren** in drie formaten: DTCG JSON, Tokens Studio JSON, Generieke JSON
 
-## Gebruik
+## Live
+
+De tool is beschikbaar op:
+**https://jeffreylauwers.github.io/design-system-starter-kit/color-palette-generator/**
+
+## Lokaal ontwikkelen
 
 ```bash
 pnpm --filter @dsn-starter-kit/color-palette-generator dev

--- a/packages/color-palette-generator/src/components/ColorGroupRow.css
+++ b/packages/color-palette-generator/src/components/ColorGroupRow.css
@@ -31,9 +31,6 @@
   padding: 2px 4px;
   border-radius: 3px;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 100%;
   text-align: left;
 }
 

--- a/packages/color-palette-generator/src/components/ColorSwatch.css
+++ b/packages/color-palette-generator/src/components/ColorSwatch.css
@@ -50,6 +50,12 @@
   color: white;
 }
 
+.color-swatch__badge--fallback {
+  background: rgba(180, 100, 0, 0.9);
+  color: white;
+  font-size: 11px;
+}
+
 .color-swatch__copied {
   position: absolute;
   inset: 0;

--- a/packages/color-palette-generator/src/components/ColorSwatch.tsx
+++ b/packages/color-palette-generator/src/components/ColorSwatch.tsx
@@ -42,21 +42,34 @@ export function ColorSwatch({ data, label, format }: Props) {
 
   const showContrast = data.contrastVsBgDefault !== undefined;
   const pass = data.contrastPass;
+  const isFallback = data.isFallback;
+
+  const contrastLabel = showContrast
+    ? ` — contrast: ${data.contrastVsBgDefault?.toFixed(2)}:1${isFallback ? ' (zelfde als color-default; subtle-variant haalt 4.5:1 niet zelfstandig)' : ''}`
+    : '';
 
   return (
     <button
       className="color-swatch"
       style={{ backgroundColor: data.hex }}
       onClick={handleClick}
-      title={`${label}: ${displayValue}${showContrast ? ` — contrast: ${data.contrastVsBgDefault?.toFixed(2)}:1` : ''}`}
+      title={`${label}: ${displayValue}${contrastLabel}`}
       aria-label={`${label} — ${displayValue}${copied ? ', gekopieerd' : ''}`}
     >
-      {showContrast && (
+      {showContrast && !isFallback && (
         <span
           className={`color-swatch__badge ${pass ? 'color-swatch__badge--pass' : 'color-swatch__badge--fail'}`}
           aria-hidden="true"
         >
           {pass ? '✓' : '✗'}
+        </span>
+      )}
+      {isFallback && (
+        <span
+          className="color-swatch__badge color-swatch__badge--fallback"
+          aria-hidden="true"
+        >
+          ≈
         </span>
       )}
       {copied && (

--- a/packages/color-palette-generator/src/components/PaletteGrid.css
+++ b/packages/color-palette-generator/src/components/PaletteGrid.css
@@ -16,8 +16,8 @@
   border-right: 1px solid var(--border-subtle);
   text-align: center;
   position: sticky;
-  top: 0;
-  z-index: 3;
+  top: 22px;
+  z-index: 2;
 }
 
 .palette-grid__header--sticky {
@@ -40,8 +40,16 @@
   text-transform: uppercase;
   letter-spacing: 0.03em;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+}
+
+.palette-grid__track-spacer {
+  background: color-mix(in srgb, var(--bg-surface) 88%, var(--accent) 12%);
+  border-bottom: 1px solid var(--border-subtle);
+  border-right: 1px solid var(--border-default);
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 5;
 }
 
 .palette-grid__track-label {
@@ -57,8 +65,8 @@
   display: flex;
   align-items: center;
   position: sticky;
-  top: 44px;
-  z-index: 2;
+  top: 0;
+  z-index: 3;
 }
 
 .palette-grid__track-label--inverse {

--- a/packages/color-palette-generator/src/components/PaletteGrid.tsx
+++ b/packages/color-palette-generator/src/components/PaletteGrid.tsx
@@ -66,35 +66,11 @@ export function PaletteGrid({
       <div
         className="palette-grid"
         style={{
-          gridTemplateColumns: `220px repeat(${visibleSteps.length}, minmax(56px, 1fr))`,
+          gridTemplateColumns: `220px repeat(${visibleSteps.length}, 160px)`,
         }}
       >
-        {/* Header row */}
-        <div className="palette-grid__header palette-grid__header--sticky">
-          <span className="palette-grid__header-label">Kleurgroep</span>
-        </div>
-
-        {TOKEN_STEPS.map((step) => (
-          <div key={step} className="palette-grid__header">
-            <span className="palette-grid__header-label">
-              {COLUMN_LABELS[step]}
-            </span>
-          </div>
-        ))}
-
-        {showInverse &&
-          INVERSE_TOKEN_STEPS.map((step) => (
-            <div
-              key={step}
-              className="palette-grid__header palette-grid__header--inverse"
-            >
-              <span className="palette-grid__header-label">
-                {COLUMN_LABELS[step]}
-              </span>
-            </div>
-          ))}
-
-        {/* Divider labels */}
+        {/* Row 1: Track labels (bovenste sticky rij) */}
+        <div className="palette-grid__track-spacer" />
         <div
           className="palette-grid__track-label"
           style={{ gridColumn: '2 / 8' }}
@@ -135,6 +111,31 @@ export function PaletteGrid({
             </div>
           </>
         )}
+
+        {/* Row 2: Kolomheaders */}
+        <div className="palette-grid__header palette-grid__header--sticky">
+          <span className="palette-grid__header-label">Kleurgroep</span>
+        </div>
+
+        {TOKEN_STEPS.map((step) => (
+          <div key={step} className="palette-grid__header">
+            <span className="palette-grid__header-label">
+              {COLUMN_LABELS[step]}
+            </span>
+          </div>
+        ))}
+
+        {showInverse &&
+          INVERSE_TOKEN_STEPS.map((step) => (
+            <div
+              key={step}
+              className="palette-grid__header palette-grid__header--inverse"
+            >
+              <span className="palette-grid__header-label">
+                {COLUMN_LABELS[step]}
+              </span>
+            </div>
+          ))}
 
         {/* Color group rows */}
         {groups.map((group) => (

--- a/packages/color-palette-generator/src/engine/export.ts
+++ b/packages/color-palette-generator/src/engine/export.ts
@@ -58,6 +58,8 @@ function buildDtcgOutput(
   const output: DtcgOutput = { dsn: { color: {} } };
   for (const group of groups) {
     output.dsn.color[group.name] = buildDtcgGroup(group, format);
+  }
+  for (const group of groups) {
     output.dsn.color[`${group.name}-inverse`] = buildDtcgInverseGroup(
       group,
       format
@@ -90,7 +92,9 @@ export function exportGeneric(groups: ColorGroup[]): string {
     for (const step of TOKEN_STEPS) {
       output[group.name][step] = group.tokens[step].hex;
     }
+  }
 
+  for (const group of groups) {
     output[`${group.name}-inverse`] = {};
     for (const step of INVERSE_TOKEN_STEPS) {
       const key = step.replace('inverse-', '');

--- a/packages/color-palette-generator/src/engine/palette.ts
+++ b/packages/color-palette-generator/src/engine/palette.ts
@@ -17,7 +17,8 @@ import type {
 function swatch(
   oklch: OklchColor,
   bgForContrast?: OklchColor,
-  required?: number
+  required?: number,
+  isFallback?: boolean
 ): SwatchData {
   const clamped = clampToSRGB(oklch);
   const hex = oklchToHex(clamped);
@@ -35,6 +36,7 @@ function swatch(
     contrastVsBgDefault,
     contrastRequired: required,
     contrastPass,
+    isFallback,
   };
 }
 
@@ -71,8 +73,9 @@ function generateLightPalette(
   const bgActive = makeOklch(0.895, C(baseC * 0.22), H);
 
   // Track 2: Borders (mid-range L, higher C)
+  // Anchor at L=0.52 for cross-group visual alignment; adjust only if needed.
   const borderSubtle = makeOklch(0.77, C(baseC * 0.45), H);
-  let borderDefault = makeOklch(base.l, C(baseC), H);
+  let borderDefault = makeOklch(0.52, C(baseC), H);
   borderDefault = adjustLForContrast(borderDefault, bgDefault, 3, 'darken');
   let borderHover = makeOklch(borderDefault.l - 0.04, C(borderDefault.c), H);
   borderHover = adjustLForContrast(borderHover, bgHover, 3, 'darken');
@@ -80,7 +83,8 @@ function generateLightPalette(
   borderActive = adjustLForContrast(borderActive, bgActive, 3, 'darken');
 
   // Track 3: Text/icons (high contrast)
-  let colorDefault = makeOklch(base.l, C(baseC), H);
+  // Anchor at L=0.40 for cross-group visual alignment; adjust only if needed.
+  let colorDefault = makeOklch(0.4, C(baseC), H);
   colorDefault = adjustLForContrast(colorDefault, bgDefault, 4.5, 'darken');
   let colorHover = makeOklch(colorDefault.l - 0.04, C(colorDefault.c), H);
   colorHover = adjustLForContrast(colorHover, bgHover, 4.5, 'darken');
@@ -93,8 +97,10 @@ function generateLightPalette(
     C(colorDefault.c * 0.9),
     H
   );
+  let colorSubtleFallback = false;
   if (contrastRatio(colorSubtle, bgSubtle) < 4.5) {
     colorSubtle = colorDefault;
+    colorSubtleFallback = true;
   }
 
   // color-document: very dark tint
@@ -191,11 +197,11 @@ function generateLightPalette(
       'bg-default': swatch(bgDefault),
       'bg-hover': swatch(bgHover),
       'bg-active': swatch(bgActive),
-      'border-subtle': swatch(borderSubtle),
+      'border-subtle': swatch(borderSubtle, bgDefault, 3),
       'border-default': swatch(borderDefault, bgDefault, 3),
       'border-hover': swatch(borderHover, bgHover, 3),
       'border-active': swatch(borderActive, bgActive, 3),
-      'color-subtle': swatch(colorSubtle, bgSubtle, 4.5),
+      'color-subtle': swatch(colorSubtle, bgSubtle, 4.5, colorSubtleFallback),
       'color-default': swatch(colorDefault, bgDefault, 4.5),
       'color-hover': swatch(colorHover, bgHover, 4.5),
       'color-active': swatch(colorActive, bgActive, 4.5),
@@ -237,8 +243,9 @@ function generateDarkPalette(
   const bgActive = makeOklch(0.26, C(baseC * 0.22), H);
 
   // Borders: mid-range, visible on dark bg
+  // Anchor at L=0.52 for cross-group visual alignment; adjust only if needed.
   const borderSubtle = makeOklch(0.38, C(baseC * 0.45), H);
-  let borderDefault = makeOklch(base.l, C(baseC), H);
+  let borderDefault = makeOklch(0.52, C(baseC), H);
   borderDefault = adjustLForContrast(borderDefault, bgDefault, 3, 'lighten');
   let borderHover = makeOklch(borderDefault.l + 0.04, C(borderDefault.c), H);
   borderHover = adjustLForContrast(borderHover, bgHover, 3, 'lighten');
@@ -246,8 +253,8 @@ function generateDarkPalette(
   borderActive = adjustLForContrast(borderActive, bgActive, 3, 'lighten');
 
   // Text: light on dark bg
-  let colorDefault = makeOklch(base.l, C(baseC), H);
-  if (colorDefault.l < 0.6) colorDefault = makeOklch(0.75, C(baseC * 0.8), H);
+  // Anchor at L=0.72 for cross-group visual alignment; adjust only if needed.
+  let colorDefault = makeOklch(0.72, C(baseC * 0.8), H);
   colorDefault = adjustLForContrast(colorDefault, bgDefault, 4.5, 'lighten');
 
   let colorHover = makeOklch(colorDefault.l + 0.04, C(colorDefault.c * 0.9), H);
@@ -260,7 +267,11 @@ function generateDarkPalette(
     C(colorDefault.c * 0.85),
     H
   );
-  if (contrastRatio(colorSubtle, bgSubtle) < 4.5) colorSubtle = colorDefault;
+  let colorSubtleFallback = false;
+  if (contrastRatio(colorSubtle, bgSubtle) < 4.5) {
+    colorSubtle = colorDefault;
+    colorSubtleFallback = true;
+  }
 
   let colorDocument = makeOklch(0.93, C(baseC * 0.15), H);
   colorDocument = adjustLForContrast(colorDocument, bgSubtle, 4.5, 'lighten');
@@ -345,11 +356,11 @@ function generateDarkPalette(
       'bg-default': swatch(bgDefault),
       'bg-hover': swatch(bgHover),
       'bg-active': swatch(bgActive),
-      'border-subtle': swatch(borderSubtle),
+      'border-subtle': swatch(borderSubtle, bgDefault, 3),
       'border-default': swatch(borderDefault, bgDefault, 3),
       'border-hover': swatch(borderHover, bgHover, 3),
       'border-active': swatch(borderActive, bgActive, 3),
-      'color-subtle': swatch(colorSubtle, bgSubtle, 4.5),
+      'color-subtle': swatch(colorSubtle, bgSubtle, 4.5, colorSubtleFallback),
       'color-default': swatch(colorDefault, bgDefault, 4.5),
       'color-hover': swatch(colorHover, bgHover, 4.5),
       'color-active': swatch(colorActive, bgActive, 4.5),

--- a/packages/color-palette-generator/src/types.ts
+++ b/packages/color-palette-generator/src/types.ts
@@ -107,6 +107,7 @@ export interface SwatchData {
   contrastVsBgDefault?: number;
   contrastRequired?: number;
   contrastPass?: boolean;
+  isFallback?: boolean;
 }
 
 export type TokenMap = Record<TokenStep, SwatchData>;


### PR DESCRIPTION
## Summary

- **Perceptuele rijuitlijning (OKLCH)**: `color-default` en `border-default` tracks starten nu vanuit een gekalibreerde anker-L (licht: 0.40/0.52, donker: 0.72/0.52) in plaats van `base.l` van de invoerkleur. Hierdoor landen alle kleurgroepen in dezelfde rij op nagenoeg gelijke helderheid, wat OKLCH's perceptuele uniformiteit benut.
- **Contrastcheck `border-subtle`**: `border-subtle` krijgt nu een zichtbare 3:1-check op `bg-default`, zodat de bewuste afwijking inzichtelijk is.
- **Fallback-indicator `color-subtle`**: Wanneer de subtle-variant 4.5:1 niet zelfstandig haalt en terugvalt op `color-default`, toont de swatch een oranje **≈**-badge met uitleg in de tooltip.
- **Export-volgorde**: Alle reguliere kleurgroepen verschijnen nu vóór alle inverse groepen in zowel DTCG- als Generic-export (was voorheen afwisselend per groep).

## Test plan

- [ ] Light mode: controleer dat `color-default`-rij visueel gelijkmatig is over alle kleurgroepen
- [ ] Dark mode: zelfde controle
- [ ] `border-subtle` toont een ✗-badge (verwacht: haalt 3:1 doorgaans niet)
- [ ] Bij een laagchroma/neutrale kleur: controleer dat ≈-badge verschijnt op `color-subtle` als fallback actief is
- [ ] DTCG-export: alle reguliere groepen eerst, daarna alle `-inverse` groepen
- [ ] Generic-export: zelfde volgorde

🤖 Generated with [Claude Code](https://claude.com/claude-code)