### PR TITLE
feat(color-palette-generator): toon kleurwaarde in swatch bij hover

### DIFF
--- a/packages/color-palette-generator/src/components/ColorSwatch.css
+++ b/packages/color-palette-generator/src/components/ColorSwatch.css
@@ -56,6 +56,27 @@
   font-size: 11px;
 }
 
+.color-swatch__tooltip {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  white-space: nowrap;
+  border-radius: 3px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.color-swatch:hover .color-swatch__tooltip {
+  opacity: 1;
+}
+
 .color-swatch__copied {
   position: absolute;
   inset: 0;

--- a/packages/color-palette-generator/src/components/ColorSwatch.tsx
+++ b/packages/color-palette-generator/src/components/ColorSwatch.tsx
@@ -53,9 +53,11 @@ export function ColorSwatch({ data, label, format }: Props) {
       className="color-swatch"
       style={{ backgroundColor: data.hex }}
       onClick={handleClick}
-      title={`${label}: ${displayValue}${contrastLabel}`}
-      aria-label={`${label} — ${displayValue}${copied ? ', gekopieerd' : ''}`}
+      aria-label={`${label} — ${displayValue}${contrastLabel}${copied ? ', gekopieerd' : ''}`}
     >
+      <span className="color-swatch__tooltip" aria-hidden="true">
+        {displayValue}
+      </span>
       {showContrast && !isFallback && (
         <span
           className={`color-swatch__badge ${pass ? 'color-swatch__badge--pass' : 'color-swatch__badge--fail'}`}


### PR DESCRIPTION
## Summary

- Toont de hex- of OKLCH-waarde (afhankelijk van gekozen weergave) als overlay in het midden van de swatch bij hover
- Overlay is visueel consistent met de bestaande 'Gekopieerd'-feedback (zelfde donkere achtergrond, witte monospace tekst)
- `title`-attribuut vervangen door uitgebreide `aria-label` met kleurwaarde én contrastinfo

## Test plan

- [ ] Hover over een swatch — kleurwaarde verschijnt gecentreerd in de swatch
- [ ] Wissel van HEX naar OKLCH — tooltip toont de juiste waarde
- [ ] Klik op een swatch — 'Gekopieerd' overlay verschijnt en tooltip verdwijnt automatisch
- [ ] Controleer in zowel Light als Dark modus

🤖 Generated with [Claude Code](https://claude.com/claude-code)