### PR TITLE
feat(PreHeading, HeadingGroup): voeg PreHeading en HeadingGroup componenten toe

### DIFF
--- a/packages/color-palette-generator/src/App.tsx
+++ b/packages/color-palette-generator/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { PaletteGrid } from './components/PaletteGrid';
 import { Toolbar } from './components/Toolbar';
+import { DocumentationSection } from './components/DocumentationSection';
 import { parseToOklch } from './engine/oklch';
 import { buildColorGroup } from './engine/palette';
 import { exportDtcg, exportGeneric, downloadJson } from './engine/export';
@@ -158,6 +159,8 @@ export function App() {
             <span>Klik op een swatch om de kleurwaarde te kopiëren</span>
           </div>
         </div>
+
+        <DocumentationSection />
       </main>
     </div>
   );

--- a/packages/color-palette-generator/src/components/DocumentationSection.css
+++ b/packages/color-palette-generator/src/components/DocumentationSection.css
@@ -1,0 +1,255 @@
+.doc-section {
+  margin-top: 40px;
+  padding-top: 32px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+/* ── Blokken ── */
+
+.doc-block {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  padding: 24px 28px;
+}
+
+.doc-block--feedback {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+/* ── Typografie ── */
+
+.doc-block__title {
+  margin: 0 0 14px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+
+.doc-block p {
+  margin: 0 0 12px;
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  max-width: 72ch;
+}
+
+.doc-block p:last-child {
+  margin-bottom: 0;
+}
+
+/* ── Lijsten ── */
+
+.doc-list {
+  margin: 0 0 12px;
+  padding-left: 20px;
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  max-width: 72ch;
+}
+
+.doc-list--ordered {
+  padding-left: 22px;
+}
+
+.doc-list--nested {
+  margin: 6px 0 0;
+}
+
+.doc-list li {
+  margin-bottom: 8px;
+}
+
+.doc-list li:last-child {
+  margin-bottom: 0;
+}
+
+/* ── Code ── */
+
+.doc-code {
+  font-family: 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
+  font-size: 12px;
+  background: var(--bg-surface-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 1px 5px;
+  color: var(--text-primary);
+}
+
+/* ── Links ── */
+
+.doc-link {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.doc-link:hover {
+  color: var(--accent-hover);
+}
+
+/* ── Track-kaarten ── */
+
+.doc-tracks {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+  margin: 12px 0 16px;
+}
+
+.doc-track {
+  background: var(--bg-surface-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+
+.doc-track__label {
+  display: inline-block;
+  margin-bottom: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.doc-track__desc {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+
+/* ── Technische details (details/summary) ── */
+
+.doc-details {
+  margin-top: 20px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.doc-details__summary {
+  padding: 12px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  user-select: none;
+  background: var(--bg-surface-raised);
+  transition: background 0.12s;
+}
+
+.doc-details__summary::-webkit-details-marker {
+  display: none;
+}
+
+.doc-details__summary::before {
+  content: '›';
+  font-size: 16px;
+  line-height: 1;
+  transition: transform 0.18s;
+  display: inline-block;
+  color: var(--text-muted);
+}
+
+.doc-details[open] .doc-details__summary::before {
+  transform: rotate(90deg);
+}
+
+.doc-details__summary:hover {
+  background: var(--bg-hover);
+}
+
+.doc-details__body {
+  padding: 20px 20px 16px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.doc-details__body p {
+  margin: 0 0 12px;
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  max-width: 72ch;
+}
+
+.doc-details__body p:last-child {
+  margin-bottom: 0;
+}
+
+.doc-details__body .doc-list {
+  margin: 0 0 12px;
+}
+
+/* ── Token-tabel ── */
+
+.doc-table {
+  width: 100%;
+  max-width: 640px;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin: 4px 0 16px;
+}
+
+.doc-table th,
+.doc-table td {
+  text-align: left;
+  padding: 7px 12px;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+}
+
+.doc-table th {
+  background: var(--bg-surface-raised);
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.doc-table tr:nth-child(even) td {
+  background: var(--bg-surface-raised);
+}
+
+/* ── Feedback-knop ── */
+
+.doc-feedback-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  background: var(--accent);
+  color: white;
+  border-radius: 7px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    background 0.12s,
+    transform 0.1s;
+}
+
+.doc-feedback-btn:hover {
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+}
+
+.doc-feedback-btn:active {
+  transform: translateY(0);
+}

--- a/packages/color-palette-generator/src/components/DocumentationSection.tsx
+++ b/packages/color-palette-generator/src/components/DocumentationSection.tsx
@@ -1,0 +1,295 @@
+import './DocumentationSection.css';
+
+export function DocumentationSection() {
+  return (
+    <section className="doc-section" aria-label="Documentatie">
+      {/* 1 — Waarvoor */}
+      <div className="doc-block">
+        <h2 className="doc-block__title">Waarvoor dient deze tool?</h2>
+        <p>
+          De DSN Color Palette Generator maakt een volledig semantisch
+          kleurenpalet op basis van één basiskleur per kleurgroep. Het resultaat
+          is direct bruikbaar als design-token JSON voor{' '}
+          <a
+            className="doc-link"
+            href="https://styledictionary.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Style Dictionary
+          </a>{' '}
+          en volgt het{' '}
+          <a
+            className="doc-link"
+            href="https://design-tokens.github.io/community-group/format/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            DTCG-formaat
+          </a>
+          .
+        </p>
+        <p>De tool is bedoeld voor:</p>
+        <ul className="doc-list">
+          <li>
+            <strong>Design system teams</strong> die een nieuw kleurthema willen
+            opzetten of een bestaand thema willen uitbreiden.
+          </li>
+          <li>
+            <strong>Designers</strong> die snel willen verkennen hoe een
+            merkkleur uitpakt als volledig semantisch palet.
+          </li>
+          <li>
+            <strong>Developers</strong> die tokens rechtstreeks willen
+            exporteren naar hun token-pipeline zonder handmatig contrast te
+            berekenen.
+          </li>
+        </ul>
+        <p>
+          Het contrast van elke tint wordt automatisch gecontroleerd conform{' '}
+          <strong>WCAG 2.x</strong>: tekst- en icoontokens halen minimaal 4,5:1
+          op hun achtergrond, bordertokens minimaal 3:1.
+        </p>
+      </div>
+
+      {/* 2 — Hoe gebruiken */}
+      <div className="doc-block">
+        <h2 className="doc-block__title">Hoe gebruik je de tool?</h2>
+        <ol className="doc-list doc-list--ordered">
+          <li>
+            <strong>Kies een basiskleur</strong> per kleurgroep via het kleurvak
+            links in elke rij. De basiskleur bepaalt de tint (hue) van het
+            volledige palet. Je kunt meerdere groepen tegelijk beheren voor
+            bijvoorbeeld <em>accent</em>, <em>neutral</em> en <em>negative</em>.
+          </li>
+          <li>
+            <strong>Hernoem een groep</strong> door op de groepsnaam te klikken.
+            De naam wordt gebruikt als tokennaam bij export (bijv.{' '}
+            <code className="doc-code">accent-1</code> wordt{' '}
+            <code className="doc-code">dsn.color.accent-1.*</code>).
+          </li>
+          <li>
+            <strong>Pas de intensiteit aan</strong> via de schuifregelaar (0,3×
+            tot 2×). Lagere intensiteit geeft gedempte, neutrale tinten; hogere
+            intensiteit geeft levendigere kleuren. De standaard is 1×.
+          </li>
+          <li>
+            <strong>Wissel tussen light en dark modus</strong> om te zien hoe
+            het palet eruitziet op donkere achtergronden. Exporteer elke modus
+            apart als <code className="doc-code">colors-light.json</code> en{' '}
+            <code className="doc-code">colors-dark.json</code>.
+          </li>
+          <li>
+            <strong>Toon de inverse tokens</strong> via de
+            &ldquo;Inverse&rdquo;-knop. Inverse tokens zijn bedoeld voor
+            UI-elementen die op een gekleurde achtergrond staan, zoals een
+            banner in de merkkleur.
+          </li>
+          <li>
+            <strong>Kopieer een kleurwaarde</strong> door op een swatch te
+            klikken. De waarde wordt gekopieerd in het formaat dat je hebt
+            gekozen (HEX of OKLCH).
+          </li>
+          <li>
+            <strong>Exporteer de tokens</strong> via de knoppen rechts in de
+            toolbar:
+            <ul className="doc-list doc-list--nested">
+              <li>
+                <strong>DTCG</strong> — JSON in het W3C Design Token Community
+                Group-formaat, klaar voor Style Dictionary v4.
+              </li>
+              <li>
+                <strong>Generic</strong> — een platte JSON met alle hex-waarden
+                voor gebruik in tools die DTCG niet ondersteunen.
+              </li>
+            </ul>
+          </li>
+        </ol>
+      </div>
+
+      {/* 3 — Hoe werkt het */}
+      <div className="doc-block">
+        <h2 className="doc-block__title">Hoe werkt het op de achtergrond?</h2>
+        <p>
+          Het palet is opgebouwd uit drie functionele <em>tracks</em>. Elke
+          track heeft een ander doel, en daarom ook een andere kleursterkte:
+        </p>
+        <div className="doc-tracks">
+          <div className="doc-track">
+            <span className="doc-track__label">Backgrounds</span>
+            <p className="doc-track__desc">
+              Heel lichte, subtiel gekleurde tinten. Hoge kleursterkte hier zou
+              de pagina onrustig maken; de tint is er puur om kleuridentiteit te
+              geven.
+            </p>
+          </div>
+          <div className="doc-track">
+            <span className="doc-track__label">Borders</span>
+            <p className="doc-track__desc">
+              Middelmatige kleursterkte. Borders zijn structureel en hoeven niet
+              te schreeuwen, maar moeten wel zichtbaar zijn tegen hun
+              achtergrond.
+            </p>
+          </div>
+          <div className="doc-track">
+            <span className="doc-track__label">Colors</span>
+            <p className="doc-track__desc">
+              Tekst- en icoontokens krijgen de hoogste kleursterkte. De
+              helderheid wordt vervolgens automatisch bijgesteld totdat het
+              contrast voldoende is.
+            </p>
+          </div>
+        </div>
+        <p>
+          Elk token toont een <strong>✓</strong> of <strong>✗</strong> met de
+          gemeten contrastverhouding. Bij een ✗ is het contrast automatisch
+          gecorrigeerd door de helderheid (L) stapsgewijs aan te passen totdat
+          de WCAG-drempel gehaald wordt.
+        </p>
+
+        <details className="doc-details">
+          <summary className="doc-details__summary">
+            Technische details voor developers
+          </summary>
+          <div className="doc-details__body">
+            <p>
+              Alle kleuren worden intern berekend in <strong>OKLCH</strong>{' '}
+              (Lightness, Chroma, Hue). OKLCH heeft ten opzichte van HSL als
+              voordeel dat gelijke L-waarden ook perceptueel even licht ogen,
+              ongeacht de tint. Dat maakt het mogelijk om paletten van
+              verschillende kleuren visueel te aligneren op dezelfde raster.
+            </p>
+            <p>De drie assen:</p>
+            <ul className="doc-list">
+              <li>
+                <code className="doc-code">L</code> (0–1) — perceptuele
+                helderheid; 0 = zwart, 1 = wit.
+              </li>
+              <li>
+                <code className="doc-code">C</code> (0–∞, praktisch ≤ 0,4) —
+                chroma, de &ldquo;kleursterkte&rdquo;. Hoe hoger, hoe
+                levendiger.
+              </li>
+              <li>
+                <code className="doc-code">H</code> (0–360°) — tint. Wordt
+                altijd overgenomen van de basiskleur en nooit aangepast.
+              </li>
+            </ul>
+            <p>
+              Per track worden de volgende chroma-vermenigvuldigers gebruikt:
+            </p>
+            <table className="doc-table">
+              <thead>
+                <tr>
+                  <th>Track</th>
+                  <th>Token</th>
+                  <th>Chroma-factor (light)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Backgrounds</td>
+                  <td>
+                    <code className="doc-code">bg-document / bg-elevated</code>
+                  </td>
+                  <td>baseC × 0,06</td>
+                </tr>
+                <tr>
+                  <td>Backgrounds</td>
+                  <td>
+                    <code className="doc-code">bg-subtle … bg-active</code>
+                  </td>
+                  <td>baseC × 0,10 – 0,22</td>
+                </tr>
+                <tr>
+                  <td>Borders</td>
+                  <td>
+                    <code className="doc-code">border-subtle</code>
+                  </td>
+                  <td>baseC × 0,45</td>
+                </tr>
+                <tr>
+                  <td>Borders</td>
+                  <td>
+                    <code className="doc-code">
+                      border-default … border-active
+                    </code>
+                  </td>
+                  <td>baseC × 1,0</td>
+                </tr>
+                <tr>
+                  <td>Colors</td>
+                  <td>
+                    <code className="doc-code">
+                      color-default … color-active
+                    </code>
+                  </td>
+                  <td>baseC × 1,0</td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              De intensiteitsregelaar werkt als globale vermenigvuldiger bovenop
+              deze factoren:{' '}
+              <code className="doc-code">
+                effectiefC = baseC × trackFactor × intensity
+              </code>
+              .
+            </p>
+            <p>
+              Voor contrast-correctie gebruikt de engine{' '}
+              <code className="doc-code">adjustLForContrast()</code>: de
+              L-waarde wordt in stappen van 0,005 aangepast (verduisterd of
+              verlicht) totdat
+              <code className="doc-code">wcagContrast()</code> via de
+              culori-library de vereiste verhouding haalt, of totdat L de grens
+              (0 of 1) bereikt.
+            </p>
+            <p>
+              Ten slotte wordt elke kleur door{' '}
+              <code className="doc-code">clampToSRGB()</code> geleid:{' '}
+              <code className="doc-code">clampChroma()</code> van culori
+              reduceert C totdat de kleur binnen het sRGB-gamut valt. Kleuren
+              buiten dat gamut zijn niet weergefbaar in standaard browsers en
+              monitors.
+            </p>
+          </div>
+        </details>
+      </div>
+
+      {/* 4 — Feedback */}
+      <div className="doc-block doc-block--feedback">
+        <h2 className="doc-block__title">Feedback geven</h2>
+        <p>
+          Werkt iets niet zoals verwacht, of heb je een idee voor verbetering?
+          Maak een issue aan op GitHub. Goede feedback bevat: welke basiskleur
+          je gebruikte, welk gedrag je verwachtte en wat je zag, en eventueel
+          een screenshot.
+        </p>
+        <a
+          className="doc-feedback-btn"
+          href="https://github.com/jeffreylauwers/design-system-starter-kit/issues/new?labels=color-palette-generator&title=%5BColor+Palette+Generator%5D+"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Issue aanmaken op GitHub
+          <svg
+            aria-hidden="true"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+            <polyline points="15 3 21 3 21 9" />
+            <line x1="10" y1="14" x2="21" y2="3" />
+          </svg>
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/packages/color-palette-generator/src/engine/palette.ts
+++ b/packages/color-palette-generator/src/engine/palette.ts
@@ -65,12 +65,12 @@ function generateLightPalette(
   _baseHex: string
 ): { tokens: TokenMap; inverseTokens: InverseTokenMap } {
   // Track 1: Backgrounds (very light, barely tinted)
-  const bgDocument = makeOklch(0.975, C(baseC * 0.06), H);
-  const bgElevated = makeOklch(0.975, C(baseC * 0.06), H);
+  const bgDocument = makeOklch(0.99, C(baseC * 0.06), H);
+  const bgElevated = makeOklch(0.99, C(baseC * 0.06), H);
   const bgSubtle = makeOklch(0.955, C(baseC * 0.1), H);
-  const bgDefault = makeOklch(0.935, C(baseC * 0.14), H);
-  const bgHover = makeOklch(0.915, C(baseC * 0.18), H);
-  const bgActive = makeOklch(0.895, C(baseC * 0.22), H);
+  const bgDefault = makeOklch(0.915, C(baseC * 0.14), H);
+  const bgHover = makeOklch(0.895, C(baseC * 0.18), H);
+  const bgActive = makeOklch(0.875, C(baseC * 0.22), H);
 
   // Track 2: Borders (mid-range L, higher C)
   // Anchor at L=0.52 for cross-group visual alignment; adjust only if needed.
@@ -238,9 +238,9 @@ function generateDarkPalette(
   const bgDocument = makeOklch(0.12, C(baseC * 0.12), H);
   const bgElevated = makeOklch(0.155, C(baseC * 0.14), H); // lighter for elevation
   const bgSubtle = makeOklch(0.175, C(baseC * 0.16), H);
-  const bgDefault = makeOklch(0.2, C(baseC * 0.18), H);
-  const bgHover = makeOklch(0.23, C(baseC * 0.2), H);
-  const bgActive = makeOklch(0.26, C(baseC * 0.22), H);
+  const bgDefault = makeOklch(0.23, C(baseC * 0.18), H);
+  const bgHover = makeOklch(0.26, C(baseC * 0.2), H);
+  const bgActive = makeOklch(0.29, C(baseC * 0.22), H);
 
   // Borders: mid-range, visible on dark bg
   // Anchor at L=0.52 for cross-group visual alignment; adjust only if needed.

--- a/packages/components-html/manifest.json
+++ b/packages/components-html/manifest.json
@@ -188,6 +188,32 @@
       ]
     },
     {
+      "name": "HeadingGroup",
+      "cssBlock": "dsn-heading-group",
+      "category": "content",
+      "purpose": "Heading with an integrated pre-heading; renders as a flex-column hx element combining PreHeading and Heading in one API.",
+      "platforms": ["html-css", "react"],
+      "primaryProps": [
+        { "name": "level", "values": [1, 2, 3, 4, 5, 6], "default": 2 },
+        {
+          "name": "appearance",
+          "values": [1, 2, 3, 4, 5, 6],
+          "default": "matches level"
+        },
+        { "name": "preHeading", "type": "ReactNode", "required": false }
+      ]
+    },
+    {
+      "name": "PreHeading",
+      "cssBlock": "dsn-pre-heading",
+      "category": "content",
+      "purpose": "Block-level span placed as first child inside a heading element; becomes part of the heading's accessible name.",
+      "platforms": ["html-css", "react"],
+      "primaryProps": [
+        { "name": "children", "type": "ReactNode", "required": true }
+      ]
+    },
+    {
       "name": "Paragraph",
       "cssBlock": "dsn-paragraph",
       "category": "content",

--- a/packages/components-html/package.json
+++ b/packages/components-html/package.json
@@ -29,6 +29,8 @@
     "./form-field-status": "./src/form-field-status/form-field-status.css",
     "./grid": "./src/grid/grid.css",
     "./heading": "./src/heading/heading.css",
+    "./heading-group": "./src/heading-group/heading-group.css",
+    "./pre-heading": "./src/pre-heading/pre-heading.css",
     "./hero": "./src/hero/hero.css",
     "./icon": "./src/icon/icon.css",
     "./image": "./src/image/image.css",

--- a/packages/components-html/src/heading-group/heading-group.css
+++ b/packages/components-html/src/heading-group/heading-group.css
@@ -1,0 +1,4 @@
+.dsn-heading-group {
+  display: flex;
+  flex-direction: column;
+}

--- a/packages/components-html/src/pre-heading/pre-heading.css
+++ b/packages/components-html/src/pre-heading/pre-heading.css
@@ -1,0 +1,9 @@
+.dsn-pre-heading {
+  display: block;
+  color: var(--dsn-pre-heading-color);
+  font-family: var(--dsn-pre-heading-font-family);
+  font-size: var(--dsn-pre-heading-font-size);
+  font-weight: var(--dsn-pre-heading-font-weight);
+  line-height: var(--dsn-pre-heading-line-height);
+  margin-block-end: var(--dsn-pre-heading-margin-block-end);
+}

--- a/packages/components-react/src/HeadingGroup/HeadingGroup.css
+++ b/packages/components-react/src/HeadingGroup/HeadingGroup.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/heading-group/heading-group.css';

--- a/packages/components-react/src/HeadingGroup/HeadingGroup.test.tsx
+++ b/packages/components-react/src/HeadingGroup/HeadingGroup.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { HeadingGroup } from './HeadingGroup';
+
+describe('HeadingGroup', () => {
+  it('renders children', () => {
+    render(<HeadingGroup>Uw gegevens</HeadingGroup>);
+    expect(screen.getByText('Uw gegevens')).toBeInTheDocument();
+  });
+
+  it('defaults to h2 element', () => {
+    render(<HeadingGroup>Title</HeadingGroup>);
+    expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
+  });
+
+  it('renders correct heading level', () => {
+    render(<HeadingGroup level={1}>H1</HeadingGroup>);
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('has dsn-heading and dsn-heading-group classes', () => {
+    render(<HeadingGroup>Label</HeadingGroup>);
+    const el = screen.getByRole('heading');
+    expect(el).toHaveClass('dsn-heading');
+    expect(el).toHaveClass('dsn-heading-group');
+  });
+
+  it('defaults appearance to match level', () => {
+    render(<HeadingGroup level={3}>Match</HeadingGroup>);
+    expect(screen.getByRole('heading')).toHaveClass('dsn-heading--heading-3');
+  });
+
+  it('allows appearance independent of level', () => {
+    render(
+      <HeadingGroup level={2} appearance="heading-4">
+        Mixed
+      </HeadingGroup>
+    );
+    const el = screen.getByRole('heading', { level: 2 });
+    expect(el).toHaveClass('dsn-heading--heading-4');
+  });
+
+  it('renders preHeading wrapped in dsn-pre-heading span', () => {
+    const { container } = render(
+      <HeadingGroup preHeading="Stap 2">Uw gegevens</HeadingGroup>
+    );
+    const preHeadingSpan = container.querySelector('.dsn-pre-heading');
+    expect(preHeadingSpan).toBeInTheDocument();
+    expect(preHeadingSpan).toHaveTextContent('Stap 2');
+  });
+
+  it('does not render dsn-pre-heading span when preHeading is not provided', () => {
+    const { container } = render(<HeadingGroup>Heading</HeadingGroup>);
+    expect(container.querySelector('.dsn-pre-heading')).not.toBeInTheDocument();
+  });
+
+  it('renders ReactNode preHeading', () => {
+    const { container } = render(
+      <HeadingGroup
+        preHeading={
+          <>
+            Stap 2<span className="dsn-visually-hidden">:</span>
+          </>
+        }
+      >
+        Uw gegevens
+      </HeadingGroup>
+    );
+    const preHeadingSpan = container.querySelector('.dsn-pre-heading');
+    expect(preHeadingSpan).toBeInTheDocument();
+    expect(preHeadingSpan).toHaveTextContent('Stap 2');
+  });
+
+  it('applies custom className', () => {
+    render(<HeadingGroup className="custom">Label</HeadingGroup>);
+    const el = screen.getByRole('heading');
+    expect(el).toHaveClass('dsn-heading');
+    expect(el).toHaveClass('custom');
+  });
+
+  it('forwards ref', () => {
+    const ref = { current: null as HTMLHeadingElement | null };
+    render(<HeadingGroup ref={ref}>Label</HeadingGroup>);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('spreads additional HTML attributes', () => {
+    render(<HeadingGroup data-testid="hgroup">Label</HeadingGroup>);
+    expect(screen.getByTestId('hgroup')).toBeInTheDocument();
+  });
+});

--- a/packages/components-react/src/HeadingGroup/HeadingGroup.tsx
+++ b/packages/components-react/src/HeadingGroup/HeadingGroup.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { classNames } from '@dsn-starter-kit/core';
+import type { HeadingLevel, HeadingAppearance } from '../Heading/Heading';
+import './HeadingGroup.css';
+
+export interface HeadingGroupProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  /**
+   * Semantic heading level — determines the HTML element (h1–h6)
+   * @default 2
+   */
+  level?: HeadingLevel;
+
+  /**
+   * Visual appearance — controls font size, line height, and spacing.
+   * Defaults to matching the level (e.g. level 2 → heading-2).
+   */
+  appearance?: HeadingAppearance;
+
+  /**
+   * Content of the pre-heading. Wrapped in a dsn-pre-heading span automatically.
+   */
+  preHeading?: React.ReactNode;
+
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export const HeadingGroup = React.forwardRef<
+  HTMLHeadingElement,
+  HeadingGroupProps
+>(
+  (
+    { level = 2, appearance, preHeading, className, children, ...props },
+    ref
+  ) => {
+    const resolvedAppearance =
+      appearance ?? (`heading-${level}` as HeadingAppearance);
+    const Tag = `h${level}` as const;
+
+    const classes = classNames(
+      'dsn-heading',
+      `dsn-heading--${resolvedAppearance}`,
+      'dsn-heading-group',
+      className
+    );
+
+    return (
+      <Tag ref={ref} className={classes} {...props}>
+        {preHeading != null && (
+          <span className="dsn-pre-heading">{preHeading}</span>
+        )}
+        {children}
+      </Tag>
+    );
+  }
+);
+
+HeadingGroup.displayName = 'HeadingGroup';

--- a/packages/components-react/src/HeadingGroup/index.ts
+++ b/packages/components-react/src/HeadingGroup/index.ts
@@ -1,0 +1,2 @@
+export { HeadingGroup } from './HeadingGroup';
+export type { HeadingGroupProps } from './HeadingGroup';

--- a/packages/components-react/src/PreHeading/PreHeading.css
+++ b/packages/components-react/src/PreHeading/PreHeading.css
@@ -1,0 +1,1 @@
+@import '../../../components-html/src/pre-heading/pre-heading.css';

--- a/packages/components-react/src/PreHeading/PreHeading.test.tsx
+++ b/packages/components-react/src/PreHeading/PreHeading.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PreHeading } from './PreHeading';
+
+describe('PreHeading', () => {
+  it('renders children', () => {
+    render(<PreHeading>Stap 2</PreHeading>);
+    expect(screen.getByText('Stap 2')).toBeInTheDocument();
+  });
+
+  it('renders as a span element', () => {
+    render(<PreHeading>Label</PreHeading>);
+    expect(screen.getByText('Label').tagName).toBe('SPAN');
+  });
+
+  it('has dsn-pre-heading class', () => {
+    render(<PreHeading>Label</PreHeading>);
+    expect(screen.getByText('Label')).toHaveClass('dsn-pre-heading');
+  });
+
+  it('applies custom className', () => {
+    render(<PreHeading className="custom">Label</PreHeading>);
+    const el = screen.getByText('Label');
+    expect(el).toHaveClass('dsn-pre-heading');
+    expect(el).toHaveClass('custom');
+  });
+
+  it('forwards ref', () => {
+    const ref = { current: null as HTMLSpanElement | null };
+    render(<PreHeading ref={ref}>Label</PreHeading>);
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+
+  it('spreads additional HTML attributes', () => {
+    render(<PreHeading data-testid="pre-heading">Label</PreHeading>);
+    expect(screen.getByTestId('pre-heading')).toBeInTheDocument();
+  });
+
+  it('renders nested elements as children', () => {
+    render(
+      <PreHeading>
+        Stap 2<span className="dsn-visually-hidden">:</span>
+      </PreHeading>
+    );
+    expect(screen.getByText('Stap 2')).toBeInTheDocument();
+  });
+});

--- a/packages/components-react/src/PreHeading/PreHeading.tsx
+++ b/packages/components-react/src/PreHeading/PreHeading.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { classNames } from '@dsn-starter-kit/core';
+import './PreHeading.css';
+
+export interface PreHeadingProps extends React.HTMLAttributes<HTMLSpanElement> {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export const PreHeading = React.forwardRef<HTMLSpanElement, PreHeadingProps>(
+  ({ children, className, ...props }, ref) => {
+    return (
+      <span
+        ref={ref}
+        className={classNames('dsn-pre-heading', className)}
+        {...props}
+      >
+        {children}
+      </span>
+    );
+  }
+);
+
+PreHeading.displayName = 'PreHeading';

--- a/packages/components-react/src/PreHeading/index.ts
+++ b/packages/components-react/src/PreHeading/index.ts
@@ -1,0 +1,2 @@
+export { PreHeading } from './PreHeading';
+export type { PreHeadingProps } from './PreHeading';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -16,6 +16,8 @@ export * from './Stack';
 
 // Layout & Typography
 export * from './Heading';
+export * from './HeadingGroup';
+export * from './PreHeading';
 export * from './Paragraph';
 export * from './Link';
 export * from './UnorderedList';

--- a/packages/design-tokens/src/tokens/components/pre-heading.json
+++ b/packages/design-tokens/src/tokens/components/pre-heading.json
@@ -1,0 +1,36 @@
+{
+  "dsn": {
+    "pre-heading": {
+      "color": {
+        "$type": "color",
+        "$value": "{dsn.color.neutral.color-document}",
+        "$description": "Pre-heading text color"
+      },
+      "font-family": {
+        "$type": "fontFamily",
+        "$value": "{dsn.text.font-family.default}",
+        "$description": "Pre-heading font family"
+      },
+      "font-size": {
+        "$type": "fontSize",
+        "$value": "{dsn.text.font-size.md}",
+        "$description": "Pre-heading font size (same as body text)"
+      },
+      "font-weight": {
+        "$type": "fontWeight",
+        "$value": "{dsn.text.font-weight.bold}",
+        "$description": "Pre-heading font weight (bold to distinguish from heading text)"
+      },
+      "line-height": {
+        "$type": "lineHeight",
+        "$value": "{dsn.text.line-height.md}",
+        "$description": "Pre-heading line height"
+      },
+      "margin-block-end": {
+        "$type": "spacing",
+        "$value": "{dsn.space.row.xs}",
+        "$description": "Space between pre-heading and heading text"
+      }
+    }
+  }
+}

--- a/packages/storybook/src/HeadingGroup.docs.md
+++ b/packages/storybook/src/HeadingGroup.docs.md
@@ -1,0 +1,82 @@
+# HeadingGroup
+
+Een heading die een pre-heading en heading-tekst combineert in één semantisch element.
+
+<!-- VOORBEELD -->
+
+## Doel
+
+HeadingGroup combineert de functionaliteit van [Heading](/docs/components-heading--docs) en [PreHeading](/docs/components-preheading--docs) in één API. De `preHeading` prop zorgt automatisch voor de juiste markup: de inhoud wordt gewrapped in een `<span class="dsn-pre-heading">`. Het component voegt `dsn-heading-group` toe aan het heading-element, zodat pre-heading en heading-tekst als flex-kolom gestapeld worden weergegeven.
+
+HeadingGroup heeft geen eigen semantische HTML-rol. Het rendert als een `<hx>` element, net als Heading. De accessible name omvat zowel de pre-heading als de heading-tekst.
+
+## Use when
+
+- Je altijd een pre-heading en heading samen wilt gebruiken en de koppeling in de markup wilt bewaken.
+- Je in een meerstappenformulier stap-label en paginatitel als één heading wilt presenteren.
+- Je niet handmatig `<PreHeading>` binnen `<Heading>` wilt nesten.
+
+## Don't use when
+
+- Je de pre-heading als semantisch losse tekst wilt presenteren (niet bij de accessible name hoort). Gebruik dan afzonderlijke [Heading](/docs/components-heading--docs) en [Paragraph](/docs/components-paragraph--docs) componenten.
+- Je de pre-heading en heading onafhankelijk van elkaar wilt positioneren in de layout. Gebruik dan [PreHeading](/docs/components-preheading--docs) direct binnen [Heading](/docs/components-heading--docs).
+
+## Best practices
+
+### preHeading prop
+
+De `preHeading` prop accepteert zowel strings als ReactNode. Gebruik een ReactNode wanneer je een visueel verborgen dubbele punt wilt toevoegen voor screenreaders.
+
+```tsx
+// String (categorielabel)
+<HeadingGroup level={2} preHeading="Diensten">
+  We helpen u groeien
+</HeadingGroup>
+
+// ReactNode met visueel verborgen dubbele punt (stap-indicator)
+<HeadingGroup
+  level={2}
+  preHeading={<>Stap 2<span className="dsn-visually-hidden">:</span></>}
+>
+  Uw gegevens
+</HeadingGroup>
+```
+
+### HTML/CSS equivalent
+
+```html
+<h2 class="dsn-heading dsn-heading--heading-2 dsn-heading-group">
+  <span class="dsn-pre-heading"
+    >Stap 2<span class="dsn-visually-hidden">:</span></span
+  >
+  Uw gegevens
+</h2>
+```
+
+### Semantic level vs. visuele appearance
+
+Net als Heading ondersteunt HeadingGroup de `appearance` prop voor ontkoppeling van semantiek en visuele stijl.
+
+```tsx
+// Semantisch h1, visueel heading-2 (kleinere pagina in een flow)
+<HeadingGroup level={1} appearance="heading-2" preHeading="Stap 1 van 4">
+  Persoonlijke gegevens
+</HeadingGroup>
+```
+
+## Design tokens
+
+HeadingGroup voegt geen nieuwe design tokens toe. Het hergebruikt tokens van `dsn-heading` en `dsn-pre-heading`.
+
+| Token                 | Beschrijving                                                                  |
+| --------------------- | ----------------------------------------------------------------------------- |
+| `--dsn-heading-*`     | Alle heading tokens (zie [Heading](/docs/components-heading--docs))           |
+| `--dsn-pre-heading-*` | Alle pre-heading tokens (zie [PreHeading](/docs/components-preheading--docs)) |
+
+## Accessibility
+
+- HeadingGroup rendert als `<hx>` element. De accessible name omvat zowel de pre-heading als de heading-tekst.
+- Dezelfde ARIA-regels als het Heading component zijn van toepassing.
+- Screenreaders lezen de volledige heading inclusief pre-heading als één heading: "Stap 2: Uw gegevens (niveau 2)".
+- `dsn-heading-group` voegt alleen `display: flex; flex-direction: column` toe en heeft geen eigen ARIA-rol.
+- Gebruik `<span className="dsn-visually-hidden">:</span>` bij stap-indicatoren voor een duidelijke scheidingstekst in de accessible name.

--- a/packages/storybook/src/HeadingGroup.docs.mdx
+++ b/packages/storybook/src/HeadingGroup.docs.mdx
@@ -1,0 +1,28 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/addon-docs/blocks';
+import * as HeadingGroupStories from './HeadingGroup.stories';
+import docs from './HeadingGroup.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={HeadingGroupStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={HeadingGroupStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={HeadingGroupStories.Default}
+  html={`<h2 class="dsn-heading dsn-heading--heading-2 dsn-heading-group">
+  <span class="dsn-pre-heading">Stap 2</span>
+  Uw gegevens
+</h2>`}
+/>
+
+<Controls of={HeadingGroupStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/HeadingGroup.stories.tsx
+++ b/packages/storybook/src/HeadingGroup.stories.tsx
@@ -1,0 +1,159 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { HeadingGroup } from '@dsn-starter-kit/components-react';
+import DocsPage from './HeadingGroup.docs.mdx';
+import { VEEL_TEKST, VEEL_TEKST_AR, rtlDecorator } from './story-helpers';
+
+const meta: Meta<typeof HeadingGroup> = {
+  title: 'Components/HeadingGroup',
+  component: HeadingGroup,
+  parameters: {
+    docs: {
+      page: DocsPage,
+    },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const level = args.level ?? 2;
+        const appearance = args.appearance ?? `heading-${level}`;
+        const preHeading = args.preHeading
+          ? `\n  <span class="dsn-pre-heading">${args.preHeading}</span>`
+          : '';
+        return `<h${level} class="dsn-heading dsn-heading--${appearance} dsn-heading-group">${preHeading}\n  ${args.children ?? 'Uw gegevens'}\n</h${level}>`;
+      },
+    },
+  },
+  argTypes: {
+    level: {
+      control: 'select',
+      options: [1, 2, 3, 4, 5, 6],
+    },
+    appearance: {
+      control: 'select',
+      options: [
+        'heading-1',
+        'heading-2',
+        'heading-3',
+        'heading-4',
+        'heading-5',
+        'heading-6',
+      ],
+    },
+  },
+  args: {
+    level: 2,
+    preHeading: 'Stap 2',
+    children: 'Uw gegevens',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof HeadingGroup>;
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {};
+
+// =============================================================================
+// VARIANTEN
+// =============================================================================
+
+export const WithStep: Story = {
+  name: 'With Step',
+  render: () => (
+    <HeadingGroup
+      level={2}
+      preHeading={
+        <>
+          Stap 2<span className="dsn-visually-hidden">:</span>
+        </>
+      }
+    >
+      Uw gegevens
+    </HeadingGroup>
+  ),
+};
+
+export const WithCategory: Story = {
+  name: 'With Category',
+  render: () => (
+    <HeadingGroup level={2} preHeading="Diensten">
+      We helpen u groeien
+    </HeadingGroup>
+  ),
+};
+
+export const Level1: Story = {
+  name: 'Level 1',
+  render: () => (
+    <HeadingGroup level={1} preHeading="Meerstappenformulier">
+      Uw aanvraag
+    </HeadingGroup>
+  ),
+};
+
+export const DifferentAppearance: Story = {
+  name: 'Different Appearance',
+  render: () => (
+    <HeadingGroup level={1} appearance="heading-2" preHeading="Stap 1 van 4">
+      Persoonlijke gegevens
+    </HeadingGroup>
+  ),
+};
+
+// =============================================================================
+// OVERZICHTSSTORIES
+// =============================================================================
+
+export const AllLevels: Story = {
+  name: 'All Levels',
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+      <HeadingGroup level={1} preHeading="Stap 1">
+        Heading 1
+      </HeadingGroup>
+      <HeadingGroup level={2} preHeading="Stap 2">
+        Heading 2
+      </HeadingGroup>
+      <HeadingGroup level={3} preHeading="Stap 3">
+        Heading 3
+      </HeadingGroup>
+      <HeadingGroup level={4} preHeading="Stap 4">
+        Heading 4
+      </HeadingGroup>
+    </div>
+  ),
+};
+
+// =============================================================================
+// TEKST VARIANTEN
+// =============================================================================
+
+export const LongText: Story = {
+  name: 'Long Text',
+  render: () => (
+    <HeadingGroup level={2} preHeading={VEEL_TEKST}>
+      {VEEL_TEKST}
+    </HeadingGroup>
+  ),
+};
+
+// =============================================================================
+// RTL
+// =============================================================================
+
+export const RTL: Story = {
+  name: 'RTL',
+  decorators: [rtlDecorator],
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+      <HeadingGroup level={1} preHeading={VEEL_TEKST_AR}>
+        {VEEL_TEKST_AR}
+      </HeadingGroup>
+      <HeadingGroup level={2} preHeading={VEEL_TEKST_AR}>
+        {VEEL_TEKST_AR}
+      </HeadingGroup>
+    </div>
+  ),
+};

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -83,6 +83,8 @@ function App() {
 - **LinkButton**: Semantisch een `<button>`, visueel gestyled als een Link: voor JS-acties met lage attentiewaarde
 - **Icon**: SVG iconen systeem met 48 iconen
 - **Heading**: H1 t/m H6 met ontkoppelde semantische level en visuele appearance
+- **PreHeading**: Contextueel label als eerste kind van een heading, semantisch onderdeel van de accessible name
+- **HeadingGroup**: Heading met geintegreerde pre-heading via `preHeading` prop, combineert PreHeading en Heading in één API
 - **Paragraph**: Body text met lead, default en small-print varianten
 - **Link**: Hyperlinks met icon ondersteuning en externe link handling
 - **Lists**: OrderedList en UnorderedList
@@ -189,4 +191,4 @@ MIT License: zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.37.0 | **Laatste update:** 6 mei 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.39.0 | **Laatste update:** 28 mei 2026 | **Auteur:** Jeffrey Lauwers

--- a/packages/storybook/src/PreHeading.docs.md
+++ b/packages/storybook/src/PreHeading.docs.md
@@ -1,0 +1,82 @@
+# PreHeading
+
+Een contextueel label dat visueel boven een heading staat en er semantisch deel van uitmaakt.
+
+<!-- VOORBEELD -->
+
+## Doel
+
+PreHeading is een `<span>` met `display: block` die als eerste kind binnen een `<hx class="dsn-heading">` staat. De span heeft geen eigen ARIA-rol: de inhoud wordt onderdeel van de accessible name van de bovenliggende heading. Screenreaders lezen pre-heading en heading als één heading.
+
+Gebruik PreHeading voor:
+
+- Stap-indicatoren in meerstappenformulieren: "Stap 2" boven "Uw gegevens"
+- Sectie-categorisering: "Diensten" boven "We helpen u groeien"
+- Processtap-context: "Stap 1 van 4" boven de staptitel
+
+## Use when
+
+- Je een stap-indicator of categorielabel visueel boven een heading wilt tonen dat ook semantisch bij die heading hoort.
+- De pre-heading en de heading samen één betekenisvolle heading vormen voor screenreaders.
+- Je gebruik maakt van meerstappenformulieren waarbij de staptitel én het stapnummer samen de accessible name van de heading moeten zijn.
+
+## Don't use when
+
+- De pre-heading een semantisch zelfstandige sectie aanduidt. Gebruik dan een structureel lagere heading (`<h3>` onder een `<h2>`), nooit een hogere of gelijkwaardige heading visueel boven de andere.
+- De tekst puur decoratief is en niet bijdraagt aan de accessible name van de heading.
+- Je een subtitle wilt die niet bij de accessible name hoort; gebruik dan een afzonderlijke [Paragraph](/docs/components-paragraph--docs).
+
+## Best practices
+
+### Gebruik altijd binnen een Heading
+
+PreHeading staat altijd als eerste kind van een `<hx>` element. Gebruik het nooit als zelfstandig element buiten een heading.
+
+```html
+<!-- ✅ Correct: PreHeading als eerste kind van een heading -->
+<h2 class="dsn-heading dsn-heading--heading-2">
+  <span class="dsn-pre-heading"
+    >Stap 2<span class="dsn-visually-hidden">:</span></span
+  >
+  Uw gegevens
+</h2>
+
+<!-- ❌ Nooit: PreHeading als zelfstandig element -->
+<span class="dsn-pre-heading">Stap 2</span>
+<h2 class="dsn-heading dsn-heading--heading-2">Uw gegevens</h2>
+```
+
+### Interpunctie voor screenreaders
+
+Bij stap-indicatoren: sluit de pre-heading af met een visueel verborgen dubbele punt. Dit zorgt voor een duidelijke scheiding in de accessible name ("Stap 2: Uw gegevens" in plaats van "Stap 2 Uw gegevens").
+
+```html
+<span class="dsn-pre-heading">
+  Stap 2<span class="dsn-visually-hidden">:</span>
+</span>
+```
+
+Bij categorielabels zonder directe koppeling is geen dubbele punt nodig.
+
+### HeadingGroup als alternatief
+
+Wanneer je de pre-heading en heading altijd samen gebruikt, overweeg dan de [HeadingGroup](/docs/components-headinggroup--docs) component. Die combineert beide in één API via de `preHeading` prop.
+
+## Design tokens
+
+| Token                                | Beschrijving                               |
+| ------------------------------------ | ------------------------------------------ |
+| `--dsn-pre-heading-color`            | Tekstkleur                                 |
+| `--dsn-pre-heading-font-family`      | Lettertypefamilie                          |
+| `--dsn-pre-heading-font-size`        | Lettergrootte (md, gelijk aan body)        |
+| `--dsn-pre-heading-font-weight`      | Font weight (bold)                         |
+| `--dsn-pre-heading-line-height`      | Regelafstand                               |
+| `--dsn-pre-heading-margin-block-end` | Ruimte tussen pre-heading en heading-tekst |
+
+## Accessibility
+
+- De `<span class="dsn-pre-heading">` heeft geen eigen ARIA-rol. De inhoud wordt onderdeel van de accessible name van de bovenliggende heading.
+- Screenreaders (NVDA, JAWS, VoiceOver) lezen de volledige heading inclusief pre-heading als één heading.
+- Bij heading-navigatie horen gebruikers de complete heading: "Stap 2: Uw gegevens (niveau 2)".
+- `display: block` heeft geen effect op de semantische heading; het is puur visueel.
+- Gebruik `<span class="dsn-visually-hidden">:</span>` bij stap-indicatoren voor een duidelijke scheidingstekst in de accessible name.

--- a/packages/storybook/src/PreHeading.docs.mdx
+++ b/packages/storybook/src/PreHeading.docs.mdx
@@ -1,0 +1,28 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/addon-docs/blocks';
+import * as PreHeadingStories from './PreHeading.stories';
+import docs from './PreHeading.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={PreHeadingStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={PreHeadingStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={PreHeadingStories.Default}
+  html={`<h2 class="dsn-heading dsn-heading--heading-2">
+  <span class="dsn-pre-heading">Stap 2<span class="dsn-visually-hidden">:</span></span>
+  Uw gegevens
+</h2>`}
+/>
+
+<Controls of={PreHeadingStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/PreHeading.stories.tsx
+++ b/packages/storybook/src/PreHeading.stories.tsx
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Heading, PreHeading } from '@dsn-starter-kit/components-react';
+import DocsPage from './PreHeading.docs.mdx';
+import {
+  VEEL_TEKST,
+  WEINIG_TEKST,
+  VEEL_TEKST_AR,
+  rtlDecorator,
+} from './story-helpers';
+
+const meta: Meta<typeof PreHeading> = {
+  title: 'Components/PreHeading',
+  component: PreHeading,
+  parameters: {
+    docs: {
+      page: DocsPage,
+    },
+  },
+  args: {
+    children: 'Stap 2',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PreHeading>;
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {
+  render: (args) => (
+    <Heading level={2}>
+      <PreHeading {...args} />
+      Uw gegevens
+    </Heading>
+  ),
+};
+
+// =============================================================================
+// VARIANTEN
+// =============================================================================
+
+export const InsideHeading1: Story = {
+  name: 'Inside Heading 1',
+  render: () => (
+    <Heading level={1}>
+      <PreHeading>Meerstappenformulier</PreHeading>
+      Uw aanvraag
+    </Heading>
+  ),
+};
+
+export const WithCategory: Story = {
+  name: 'With Category',
+  render: () => (
+    <Heading level={2}>
+      <PreHeading>Diensten</PreHeading>
+      We helpen u groeien
+    </Heading>
+  ),
+};
+
+export const WithVisuallyHiddenColon: Story = {
+  name: 'With Visually Hidden Colon',
+  render: () => (
+    <Heading level={2}>
+      <PreHeading>
+        Stap 2<span className="dsn-visually-hidden">:</span>
+      </PreHeading>
+      Uw gegevens
+    </Heading>
+  ),
+};
+
+// =============================================================================
+// OVERZICHTSSTORIES
+// =============================================================================
+
+export const AllHeadingLevels: Story = {
+  name: 'All Heading Levels',
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+      <Heading level={1}>
+        <PreHeading>
+          Stap 1<span className="dsn-visually-hidden">:</span>
+        </PreHeading>
+        Heading 1
+      </Heading>
+      <Heading level={2}>
+        <PreHeading>
+          Stap 2<span className="dsn-visually-hidden">:</span>
+        </PreHeading>
+        Heading 2
+      </Heading>
+      <Heading level={3}>
+        <PreHeading>
+          Stap 3<span className="dsn-visually-hidden">:</span>
+        </PreHeading>
+        Heading 3
+      </Heading>
+      <Heading level={4}>
+        <PreHeading>
+          Stap 4<span className="dsn-visually-hidden">:</span>
+        </PreHeading>
+        Heading 4
+      </Heading>
+    </div>
+  ),
+};
+
+// =============================================================================
+// TEKST VARIANTEN
+// =============================================================================
+
+export const ShortText: Story = {
+  name: 'Short Text',
+  render: () => (
+    <Heading level={2}>
+      <PreHeading>{WEINIG_TEKST}</PreHeading>
+      Heading tekst
+    </Heading>
+  ),
+};
+
+export const LongText: Story = {
+  name: 'Long Text',
+  render: () => (
+    <Heading level={2}>
+      <PreHeading>{VEEL_TEKST}</PreHeading>
+      Heading tekst
+    </Heading>
+  ),
+};
+
+// =============================================================================
+// RTL
+// =============================================================================
+
+export const RTL: Story = {
+  name: 'RTL',
+  decorators: [rtlDecorator],
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+      <Heading level={1}>
+        <PreHeading>{VEEL_TEKST_AR}</PreHeading>
+        {VEEL_TEKST_AR}
+      </Heading>
+      <Heading level={2}>
+        <PreHeading>{VEEL_TEKST_AR}</PreHeading>
+        {VEEL_TEKST_AR}
+      </Heading>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

- **PreHeading** (closes #278): block-level `<span>` als eerste kind van een heading; de inhoud wordt semantisch onderdeel van de accessible name van de bovenliggende heading. Inclusief component tokens (`color`, `font-size md`, `font-weight bold`, `margin-block-end xs`), CSS, React component en Storybook.
- **HeadingGroup** (closes #279): heading met geintegreerde `preHeading` prop; rendert als `flex-column hx` element zodat pre-heading en heading-tekst netjes gestapeld worden. Hergebruikt `dsn-heading` en `dsn-pre-heading` tokens — geen eigen nieuwe tokens.

## Wijzigingen

- `packages/design-tokens/src/tokens/components/pre-heading.json` — 6 component tokens
- `packages/components-html/src/pre-heading/pre-heading.css` — `.dsn-pre-heading` CSS
- `packages/components-html/src/heading-group/heading-group.css` — `.dsn-heading-group` flex-column modifier
- `packages/components-react/src/PreHeading/` — React component, tests, CSS, index
- `packages/components-react/src/HeadingGroup/` — React component, tests, CSS, index
- `packages/storybook/src/` — 6 Storybook bestanden (`.stories.tsx`, `.docs.mdx`, `.docs.md` per component)
- Exports toegevoegd aan `components-react/src/index.ts` en `components-html/package.json`
- Manifest en Introduction.mdx bijgewerkt

## Test plan

- [x] `pnpm test` — 77 test suites, 1568 tests groen
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [x] `pnpm lint` — 0 errors
- [x] Storybook Default, AllLevels en AllHeadingLevels stories visueel geverifieerd

🤖 Generated with [Claude Code](https://claude.com/claude-code)