### PR TITLE
fix(PreHeading, HeadingGroup): verander 'Stap X' naar 'Stap X van 4' in story voorbeelden

### DIFF
--- a/packages/storybook/src/HeadingGroup.docs.md
+++ b/packages/storybook/src/HeadingGroup.docs.md
@@ -36,7 +36,7 @@ De `preHeading` prop accepteert zowel strings als ReactNode. Gebruik een ReactNo
 // ReactNode met visueel verborgen dubbele punt (stap-indicator)
 <HeadingGroup
   level={2}
-  preHeading={<>Stap 2<span className="dsn-visually-hidden">:</span></>}
+  preHeading={<>Stap 2 van 4<span className="dsn-visually-hidden">:</span></>}
 >
   Uw gegevens
 </HeadingGroup>
@@ -47,7 +47,7 @@ De `preHeading` prop accepteert zowel strings als ReactNode. Gebruik een ReactNo
 ```html
 <h2 class="dsn-heading dsn-heading--heading-2 dsn-heading-group">
   <span class="dsn-pre-heading"
-    >Stap 2<span class="dsn-visually-hidden">:</span></span
+    >Stap 2 van 4<span class="dsn-visually-hidden">:</span></span
   >
   Uw gegevens
 </h2>
@@ -77,6 +77,6 @@ HeadingGroup voegt geen nieuwe design tokens toe. Het hergebruikt tokens van `ds
 
 - HeadingGroup rendert als `<hx>` element. De accessible name omvat zowel de pre-heading als de heading-tekst.
 - Dezelfde ARIA-regels als het Heading component zijn van toepassing.
-- Screenreaders lezen de volledige heading inclusief pre-heading als één heading: "Stap 2: Uw gegevens (niveau 2)".
+- Screenreaders lezen de volledige heading inclusief pre-heading als één heading: "Stap 2 van 4: Uw gegevens (niveau 2)".
 - `dsn-heading-group` voegt alleen `display: flex; flex-direction: column` toe en heeft geen eigen ARIA-rol.
 - Gebruik `<span className="dsn-visually-hidden">:</span>` bij stap-indicatoren voor een duidelijke scheidingstekst in de accessible name.

--- a/packages/storybook/src/HeadingGroup.docs.mdx
+++ b/packages/storybook/src/HeadingGroup.docs.mdx
@@ -18,7 +18,7 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 <CodeTabs
   of={HeadingGroupStories.Default}
   html={`<h2 class="dsn-heading dsn-heading--heading-2 dsn-heading-group">
-  <span class="dsn-pre-heading">Stap 2</span>
+  <span class="dsn-pre-heading">Stap 2 van 4</span>
   Uw gegevens
 </h2>`}
 />

--- a/packages/storybook/src/HeadingGroup.stories.tsx
+++ b/packages/storybook/src/HeadingGroup.stories.tsx
@@ -41,7 +41,7 @@ const meta: Meta<typeof HeadingGroup> = {
   },
   args: {
     level: 2,
-    preHeading: 'Stap 2',
+    preHeading: 'Stap 2 van 4',
     children: 'Uw gegevens',
   },
 };
@@ -66,7 +66,7 @@ export const WithStep: Story = {
       level={2}
       preHeading={
         <>
-          Stap 2<span className="dsn-visually-hidden">:</span>
+          Stap 2 van 4<span className="dsn-visually-hidden">:</span>
         </>
       }
     >
@@ -110,16 +110,16 @@ export const AllLevels: Story = {
   name: 'All Levels',
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-      <HeadingGroup level={1} preHeading="Stap 1">
+      <HeadingGroup level={1} preHeading="Stap 1 van 4">
         Heading 1
       </HeadingGroup>
-      <HeadingGroup level={2} preHeading="Stap 2">
+      <HeadingGroup level={2} preHeading="Stap 2 van 4">
         Heading 2
       </HeadingGroup>
-      <HeadingGroup level={3} preHeading="Stap 3">
+      <HeadingGroup level={3} preHeading="Stap 3 van 4">
         Heading 3
       </HeadingGroup>
-      <HeadingGroup level={4} preHeading="Stap 4">
+      <HeadingGroup level={4} preHeading="Stap 4 van 4">
         Heading 4
       </HeadingGroup>
     </div>

--- a/packages/storybook/src/PreHeading.docs.md
+++ b/packages/storybook/src/PreHeading.docs.md
@@ -10,7 +10,7 @@ PreHeading is een `<span>` met `display: block` die als eerste kind binnen een `
 
 Gebruik PreHeading voor:
 
-- Stap-indicatoren in meerstappenformulieren: "Stap 2" boven "Uw gegevens"
+- Stap-indicatoren in meerstappenformulieren: "Stap 2 van 4" boven "Uw gegevens"
 - Sectie-categorisering: "Diensten" boven "We helpen u groeien"
 - Processtap-context: "Stap 1 van 4" boven de staptitel
 
@@ -36,23 +36,23 @@ PreHeading staat altijd als eerste kind van een `<hx>` element. Gebruik het nooi
 <!-- ✅ Correct: PreHeading als eerste kind van een heading -->
 <h2 class="dsn-heading dsn-heading--heading-2">
   <span class="dsn-pre-heading"
-    >Stap 2<span class="dsn-visually-hidden">:</span></span
+    >Stap 2 van 4<span class="dsn-visually-hidden">:</span></span
   >
   Uw gegevens
 </h2>
 
 <!-- ❌ Nooit: PreHeading als zelfstandig element -->
-<span class="dsn-pre-heading">Stap 2</span>
+<span class="dsn-pre-heading">Stap 2 van 4</span>
 <h2 class="dsn-heading dsn-heading--heading-2">Uw gegevens</h2>
 ```
 
 ### Interpunctie voor screenreaders
 
-Bij stap-indicatoren: sluit de pre-heading af met een visueel verborgen dubbele punt. Dit zorgt voor een duidelijke scheiding in de accessible name ("Stap 2: Uw gegevens" in plaats van "Stap 2 Uw gegevens").
+Bij stap-indicatoren: sluit de pre-heading af met een visueel verborgen dubbele punt. Dit zorgt voor een duidelijke scheiding in de accessible name ("Stap 2 van 4: Uw gegevens" in plaats van "Stap 2 van 4 Uw gegevens").
 
 ```html
 <span class="dsn-pre-heading">
-  Stap 2<span class="dsn-visually-hidden">:</span>
+  Stap 2 van 4<span class="dsn-visually-hidden">:</span>
 </span>
 ```
 
@@ -77,6 +77,6 @@ Wanneer je de pre-heading en heading altijd samen gebruikt, overweeg dan de [Hea
 
 - De `<span class="dsn-pre-heading">` heeft geen eigen ARIA-rol. De inhoud wordt onderdeel van de accessible name van de bovenliggende heading.
 - Screenreaders (NVDA, JAWS, VoiceOver) lezen de volledige heading inclusief pre-heading als één heading.
-- Bij heading-navigatie horen gebruikers de complete heading: "Stap 2: Uw gegevens (niveau 2)".
+- Bij heading-navigatie horen gebruikers de complete heading: "Stap 2 van 4: Uw gegevens (niveau 2)".
 - `display: block` heeft geen effect op de semantische heading; het is puur visueel.
 - Gebruik `<span class="dsn-visually-hidden">:</span>` bij stap-indicatoren voor een duidelijke scheidingstekst in de accessible name.

--- a/packages/storybook/src/PreHeading.docs.mdx
+++ b/packages/storybook/src/PreHeading.docs.mdx
@@ -18,7 +18,7 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
 <CodeTabs
   of={PreHeadingStories.Default}
   html={`<h2 class="dsn-heading dsn-heading--heading-2">
-  <span class="dsn-pre-heading">Stap 2<span class="dsn-visually-hidden">:</span></span>
+  <span class="dsn-pre-heading">Stap 2 van 4<span class="dsn-visually-hidden">:</span></span>
   Uw gegevens
 </h2>`}
 />

--- a/packages/storybook/src/PreHeading.stories.tsx
+++ b/packages/storybook/src/PreHeading.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof PreHeading> = {
     },
   },
   args: {
-    children: 'Stap 2',
+    children: 'Stap 2 van 4',
   },
 };
 
@@ -66,7 +66,7 @@ export const WithVisuallyHiddenColon: Story = {
   render: () => (
     <Heading level={2}>
       <PreHeading>
-        Stap 2<span className="dsn-visually-hidden">:</span>
+        Stap 2 van 4<span className="dsn-visually-hidden">:</span>
       </PreHeading>
       Uw gegevens
     </Heading>
@@ -83,25 +83,25 @@ export const AllHeadingLevels: Story = {
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
       <Heading level={1}>
         <PreHeading>
-          Stap 1<span className="dsn-visually-hidden">:</span>
+          Stap 1 van 4<span className="dsn-visually-hidden">:</span>
         </PreHeading>
         Heading 1
       </Heading>
       <Heading level={2}>
         <PreHeading>
-          Stap 2<span className="dsn-visually-hidden">:</span>
+          Stap 2 van 4<span className="dsn-visually-hidden">:</span>
         </PreHeading>
         Heading 2
       </Heading>
       <Heading level={3}>
         <PreHeading>
-          Stap 3<span className="dsn-visually-hidden">:</span>
+          Stap 3 van 4<span className="dsn-visually-hidden">:</span>
         </PreHeading>
         Heading 3
       </Heading>
       <Heading level={4}>
         <PreHeading>
-          Stap 4<span className="dsn-visually-hidden">:</span>
+          Stap 4 van 4<span className="dsn-visually-hidden">:</span>
         </PreHeading>
         Heading 4
       </Heading>


### PR DESCRIPTION
## Summary

- Alle "Stap X" teksten in de PreHeading en HeadingGroup Storybook stories vervangen door "Stap X van 4" voor een realistischer voorbeeld.
- Bijgewerkt in beide meta `args` (default controls) en alle individuele render-functies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)