### PR TITLE
feat(ProgressBar, FormStep): voeg progress stories toe en hideValue prop

### DIFF
--- a/packages/components-react/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/components-react/src/ProgressBar/ProgressBar.test.tsx
@@ -143,4 +143,23 @@ describe('ProgressBar', () => {
     const percentage = container.querySelector('.dsn-progress-bar__percentage');
     expect(percentage).toHaveTextContent('100%');
   });
+
+  it('hides percentage when hideValue is true', () => {
+    const { container } = render(
+      <ProgressBar label="Uploaden" value={35} hideValue />
+    );
+    expect(
+      container.querySelector('.dsn-progress-bar__percentage')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('.dsn-progress-bar__header')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows percentage by default when hideValue is not set', () => {
+    const { container } = render(<ProgressBar label="Uploaden" value={35} />);
+    expect(
+      container.querySelector('.dsn-progress-bar__percentage')
+    ).toBeInTheDocument();
+  });
 });

--- a/packages/components-react/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components-react/src/ProgressBar/ProgressBar.tsx
@@ -5,7 +5,7 @@ import './ProgressBar.css';
 export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Visueel verborgen label dat de voortgangsbalk beschrijft voor screenreaders.
-   * Altijd vereist — gekoppeld via <label for> aan het <progress>-element.
+   * Altijd vereist — gekoppeld via `<label for>` aan het `<progress>`-element.
    */
   label: string;
 
@@ -26,10 +26,16 @@ export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
   description?: React.ReactNode;
 
   /**
-   * ID voor het <progress>-element en de bijbehorende <label>.
+   * ID voor het `<progress>`-element en de bijbehorende `<label>`.
    * Automatisch gegenereerd via useId() indien weggelaten.
    */
   id?: string;
+
+  /**
+   * Verbergt het zichtbare percentage-getal. Gebruik dit voor decoratief gebruik
+   * in combinatie met aria-hidden="true" op de component.
+   */
+  hideValue?: boolean;
 }
 
 /**
@@ -57,7 +63,19 @@ export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
  * ```
  */
 export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
-  ({ className, label, value, max = 100, description, id, ...props }, ref) => {
+  (
+    {
+      className,
+      label,
+      value,
+      max = 100,
+      description,
+      hideValue,
+      id,
+      ...props
+    },
+    ref
+  ) => {
     const generatedId = useId();
     const progressId = id ?? generatedId;
     const percentage = Math.round((value / max) * 100);
@@ -71,14 +89,16 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
         <label className="dsn-visually-hidden" htmlFor={progressId}>
           {label}
         </label>
-        <div className="dsn-progress-bar__header">
-          <p
-            className="dsn-paragraph dsn-progress-bar__percentage"
-            aria-hidden="true"
-          >
-            {percentage}%
-          </p>
-        </div>
+        {!hideValue && (
+          <div className="dsn-progress-bar__header">
+            <p
+              className="dsn-paragraph dsn-progress-bar__percentage"
+              aria-hidden="true"
+            >
+              {percentage}%
+            </p>
+          </div>
+        )}
         <progress
           id={progressId}
           className="dsn-progress-bar__bar"

--- a/packages/storybook/src/templates/FormStepPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepPage.stories.tsx
@@ -10,6 +10,7 @@ import {
   Grid,
   GridItem,
   Heading,
+  HeadingGroup,
   Icon,
   Link,
   LinkButton,
@@ -23,6 +24,7 @@ import {
   PageHeader,
   PageLayout,
   Paragraph,
+  ProgressBar,
   RadioGroup,
   RadioOption,
   SkipLink,
@@ -210,6 +212,233 @@ function FormStepExamplePage() {
   );
 }
 
+function FormStepExampleWithProgressPage() {
+  const [activeModal, setActiveModal] = React.useState<ActiveModal>(null);
+  return (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          layout="compact"
+          hideMenuButton
+          hideSearchButton
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainStyle}>
+            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+              <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
+                <Stack space="3xl">
+                  <Heading level={1}>Titel formulier</Heading>
+
+                  <Link href="#" iconStart={<Icon name="arrow-left" />}>
+                    Vorige stap
+                  </Link>
+
+                  <Stack space="sm">
+                    <HeadingGroup
+                      level={2}
+                      preHeading={
+                        <>
+                          Stap 2 van 4
+                          <span className="dsn-visually-hidden">:</span>
+                        </>
+                      }
+                    >
+                      Titel van stap
+                    </HeadingGroup>
+
+                    <Paragraph>
+                      Vul alles in. Als iets niet verplicht is, staat dat erbij.
+                    </Paragraph>
+                  </Stack>
+
+                  <form noValidate>
+                    <Stack space="3xl">
+                      <FormField label="Naam" htmlFor="naam">
+                        <TextInput id="naam" autoComplete="name" />
+                      </FormField>
+
+                      <FormFieldset legend="Favoriete fruit">
+                        <RadioGroup>
+                          <RadioOption
+                            name="fruit"
+                            label="Appel"
+                            value="appel"
+                          />
+                          <RadioOption
+                            name="fruit"
+                            label="Banaan"
+                            value="banaan"
+                          />
+                          <RadioOption name="fruit" label="Kiwi" value="kiwi" />
+                        </RadioGroup>
+                      </FormFieldset>
+
+                      <FormField
+                        label="Telefoonnummer"
+                        htmlFor="telefoon"
+                        labelSuffix="(niet verplicht)"
+                      >
+                        <TelephoneInput id="telefoon" width="md" />
+                      </FormField>
+
+                      <ActionGroup
+                        direction="vertical"
+                        style={{
+                          marginBlockStart: 'var(--dsn-space-block-3xl)',
+                        }}
+                      >
+                        <Button variant="strong" type="submit">
+                          Volgende stap
+                        </Button>
+                        <LinkButton onClick={() => setActiveModal('save')}>
+                          Opslaan en later verder
+                        </LinkButton>
+                        <LinkButton onClick={() => setActiveModal('stop')}>
+                          Stoppen met het formulier
+                        </LinkButton>
+                      </ActionGroup>
+                    </Stack>
+                  </form>
+                </Stack>
+              </GridItem>
+            </Grid>
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+      <FormModals
+        activeModal={activeModal}
+        onClose={() => setActiveModal(null)}
+      />
+    </Body>
+  );
+}
+
+function FormStepExampleWithProgressBarPage() {
+  const [activeModal, setActiveModal] = React.useState<ActiveModal>(null);
+  return (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          layout="compact"
+          hideMenuButton
+          hideSearchButton
+        />
+        <PageBody>
+          <main id="main-content" tabIndex={-1} style={mainStyle}>
+            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+              <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
+                <Stack space="3xl">
+                  <Heading level={1}>Titel formulier</Heading>
+
+                  <Link href="#" iconStart={<Icon name="arrow-left" />}>
+                    Vorige stap
+                  </Link>
+
+                  <Stack space="lg">
+                    <HeadingGroup
+                      level={2}
+                      preHeading={
+                        <>
+                          Stap 2 van 4
+                          <span className="dsn-visually-hidden">:</span>
+                        </>
+                      }
+                      style={{ marginBlockEnd: 0 }}
+                    >
+                      Titel van stap
+                    </HeadingGroup>
+
+                    <ProgressBar
+                      label="Stap voortgang"
+                      value={2}
+                      max={4}
+                      hideValue
+                      aria-hidden="true"
+                    />
+
+                    <Paragraph>
+                      Vul alles in. Als iets niet verplicht is, staat dat erbij.
+                    </Paragraph>
+                  </Stack>
+
+                  <form noValidate>
+                    <Stack space="3xl">
+                      <FormField label="Naam" htmlFor="naam">
+                        <TextInput id="naam" autoComplete="name" />
+                      </FormField>
+
+                      <FormFieldset legend="Favoriete fruit">
+                        <RadioGroup>
+                          <RadioOption
+                            name="fruit"
+                            label="Appel"
+                            value="appel"
+                          />
+                          <RadioOption
+                            name="fruit"
+                            label="Banaan"
+                            value="banaan"
+                          />
+                          <RadioOption name="fruit" label="Kiwi" value="kiwi" />
+                        </RadioGroup>
+                      </FormFieldset>
+
+                      <FormField
+                        label="Telefoonnummer"
+                        htmlFor="telefoon"
+                        labelSuffix="(niet verplicht)"
+                      >
+                        <TelephoneInput id="telefoon" width="md" />
+                      </FormField>
+
+                      <ActionGroup
+                        direction="vertical"
+                        style={{
+                          marginBlockStart: 'var(--dsn-space-block-3xl)',
+                        }}
+                      >
+                        <Button variant="strong" type="submit">
+                          Volgende stap
+                        </Button>
+                        <LinkButton onClick={() => setActiveModal('save')}>
+                          Opslaan en later verder
+                        </LinkButton>
+                        <LinkButton onClick={() => setActiveModal('stop')}>
+                          Stoppen met het formulier
+                        </LinkButton>
+                      </ActionGroup>
+                    </Stack>
+                  </form>
+                </Stack>
+              </GridItem>
+            </Grid>
+          </main>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+      <FormModals
+        activeModal={activeModal}
+        onClose={() => setActiveModal(null)}
+      />
+    </Body>
+  );
+}
+
 // =============================================================================
 // META
 // =============================================================================
@@ -232,4 +461,14 @@ type Story = StoryObj;
 export const Example: Story = {
   name: 'Form step: Example',
   render: () => <FormStepExamplePage />,
+};
+
+export const WithProgress: Story = {
+  name: 'Form step: Example: With progress',
+  render: () => <FormStepExampleWithProgressPage />,
+};
+
+export const WithProgressBar: Story = {
+  name: 'Form step: Example: With progress bar',
+  render: () => <FormStepExampleWithProgressBarPage />,
 };


### PR DESCRIPTION
## Summary

- Twee nieuwe template stories aan **Form step: Example** toegevoegd:
  - **With progress**: gebruikt `HeadingGroup` met stappenteller ('Stap 2 van 4') in plaats van een kale `<h2>`
  - **With progress bar**: zelfde HeadingGroup + decoratieve `ProgressBar` (aria-hidden, geen percentage, geen description) tussen de heading en de intro-paragraaf
- `hideValue` prop toegevoegd aan `ProgressBar` om het zichtbare percentagegetal en de bijbehorende header-div te verbergen
- JSDoc-tags `<progress>` en `<label>` vervangen door backtick-notatie zodat Storybook ze niet rendert als echte HTML-elementen in de props-tabel

## Test plan

- [ ] Storybook: controleer de twee nieuwe stories onder Templates > Form flow > Form step: Example
- [ ] Storybook: controleer dat de ProgressBar docs-pagina geen echte progress-elementen meer toont in de prop-beschrijvingen
- [ ] `ProgressBar` met `hideValue` toont geen percentagegetal
- [ ] `ProgressBar` in de With progress bar story heeft `aria-hidden="true"` en is niet zichtbaar voor screenreaders
- [ ] CI groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)