### PR TITLE
chore: hernoem grid-margin token naar padding-inline en documenteer paginaconventies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,94 @@ Tokens zijn gelaagd: `base.json` (gedeelde primitieven) → component-token JSON
 
 `pnpm --filter storybook exec tsc --noEmit` geeft **0 fouten en 0 warnings**. Nieuwe code mag geen nieuwe fouten of warnings introduceren.
 
+### 6. Navigatie: homepage krijgt altijd een 'Home' item als eerste, met `current`
+
+Wanneer een URL een homepage is (domein zonder pad, of pad eindigt op `/`), **voeg dan 'Home' toe als eerste navigatie-item** en markeer dit als `current`. Niet een willekeurig ander item als current markeren.
+
+```tsx
+// ✅ Homepage: Home als eerste item, current
+<MenuLink href="/" level={1} current>Home</MenuLink>
+<MenuLink href="/over" level={1}>Over</MenuLink>
+
+// ❌ Homepage maar 'Contact' current — misleidend
+<MenuLink href="/over" level={1}>Over</MenuLink>
+<MenuLink href="/contact" level={1} current>Contact</MenuLink>
+```
+
+Dit geldt ook als de originele website zelf geen 'Home' in de navigatie heeft — de gedeelde URL is de homepage, dus voeg het toe.
+
+### 7. Cards: CardGroup vs Grid — kies bewust en gebruik mobile-first colSpan
+
+**Wanneer CardGroup:**
+
+- Gelijkwaardige cards waarbij het aantal variabel kan zijn
+- Auto-responsive gewenst: cards wrappen automatisch zodra ze niet meer passen op `--dsn-card-group-item-min-width` (280px)
+- Geen noodzaak voor expliciete kolomcontrole
+
+**Wanneer Grid + GridItem:**
+
+- Expliciete kolomverdeling vereist (bijv. 8+4 layout naast andere content)
+- Cards moeten uitlijnen met niet-card-inhoud in hetzelfde grid
+
+**Kritieke regel bij Grid + cards: altijd mobile-first, begin met `colSpan={12}`**
+
+```tsx
+// ✅ Mobile-first: 1-kolom → 2-kolom sm → 3-kolom md
+<GridItem colSpan={12} colSpanSm={6} colSpanMd={4}>
+
+// ✅ Mobile-first: 1-kolom → 2-kolom md
+<GridItem colSpan={12} colSpanMd={6}>
+
+// ❌ Desktop-first: cards worden te smal op mobile
+<GridItem colSpan={4}>
+<GridItem colSpan={4} colSpanSm={6} colSpanMd={4}>
+```
+
+`colSpan={12}` als basis garandeert dat cards op kleine viewports dezelfde volledige breedte pakken als gestackte CardGroup-cards. Daarnaast: Cards in GridItems altijd `style={{ height: '100%' }}` geven zodat ze de volledige GridItem-hoogte vullen (CardGroup regelt dit automatisch via flex).
+
+### 8. Inverse context: alle tekst-componenten meenemen
+
+Wanneer een container-component (Hero, PageHeader, PageFooter) kleur-overrides definieert voor een inverse/donkere achtergrond, moeten **alle** tekst-componenten met een eigen `--dsn-*-color` custom property worden meegenomen — inclusief `PreHeading`. De override-lijst in de CSS moet compleet zijn:
+
+```css
+/* ✅ Compleet: alle tekst-componenten overschreven */
+--dsn-pre-heading-color: var(--dsn-hero-color-inverse);
+--dsn-heading-level-1-color: var(--dsn-hero-color-inverse);
+--dsn-paragraph-color: var(--dsn-hero-color-inverse);
+
+/* ❌ Onvolledig: PreHeading mist → donkere tekst op donkere achtergrond */
+--dsn-heading-level-1-color: var(--dsn-hero-color-inverse);
+--dsn-paragraph-color: var(--dsn-hero-color-inverse);
+```
+
+Controleer bij elke nieuwe inverse container of `--dsn-pre-heading-color` is opgenomen.
+
+### 9. Paginastructuur: gebruik dsn-page-body\_\_inner, geen inline max-inline-size
+
+Content op een pagina zit altijd binnen `PageBody`, die automatisch `dsn-page-body__inner` rendert met de juiste `max-inline-size` en `padding-inline`. **Voeg geen extra wrapper divs toe met hardcoded `max-inline-size: 960px`.**
+
+```tsx
+// ✅ Content is al geconstrained door dsn-page-body__inner
+<PageBody>
+  <main>
+    <section style={{ paddingBlock: 'var(--dsn-space-block-6xl)' }}>
+      <Heading>...</Heading>
+    </section>
+  </main>
+</PageBody>
+
+// ❌ Onnodige re-constraint — dsn-page-body__inner doet dit al
+<PageBody>
+  <main>
+    <div style={{ maxInlineSize: '960px', marginInline: 'auto', paddingInline: '...' }}>
+      <Heading>...</Heading>
+    </div>
+  </main>
+</PageBody>
+```
+
+Content **binnen** een `BreakoutSection` of `Hero` (die uitbreken uit de inner wrapper) moet wél opnieuw geconstrained worden — gebruik dan `className="dsn-page-body__inner"`.
+
 ---
 
 ## Nieuw component bouwen: checklist

--- a/packages/components-html/src/grid/grid.css
+++ b/packages/components-html/src/grid/grid.css
@@ -41,7 +41,7 @@
   grid-template-columns: repeat(12, 1fr);
   column-gap: var(--dsn-grid-gutter);
   row-gap: var(--dsn-grid-row-gap);
-  padding-inline: var(--dsn-grid-margin);
+  padding-inline: var(--dsn-grid-padding-inline);
 }
 
 /* Max-width variant — gecentreerd met margin-inline: auto */
@@ -64,7 +64,7 @@
 
 .dsn-full-bleed {
   grid-column: 1 / -1;
-  margin-inline: calc(-1 * var(--dsn-grid-margin));
+  margin-inline: calc(-1 * var(--dsn-grid-padding-inline));
 }
 
 /* ============================================================

--- a/packages/components-html/src/hero/hero.css
+++ b/packages/components-html/src/hero/hero.css
@@ -99,6 +99,7 @@
   color: var(--dsn-hero-color-inverse);
 
   /* Tekst-componenten */
+  --dsn-pre-heading-color: var(--dsn-hero-color-inverse);
   --dsn-heading-level-1-color: var(--dsn-hero-color-inverse);
   --dsn-heading-level-2-color: var(--dsn-hero-color-inverse);
   --dsn-heading-level-3-color: var(--dsn-hero-color-inverse);
@@ -146,6 +147,7 @@
   color: var(--dsn-hero-color-inverse);
 
   /* Tekst-componenten */
+  --dsn-pre-heading-color: var(--dsn-hero-color-inverse);
   --dsn-heading-level-1-color: var(--dsn-hero-color-inverse);
   --dsn-heading-level-2-color: var(--dsn-hero-color-inverse);
   --dsn-heading-level-3-color: var(--dsn-hero-color-inverse);

--- a/packages/components-html/src/page-footer/page-footer.css
+++ b/packages/components-html/src/page-footer/page-footer.css
@@ -25,7 +25,6 @@
    ============================================================================= */
 
 .dsn-page-footer {
-  --dsn-grid-margin: 0;
   background-color: var(--dsn-page-footer-background-color);
   border-block-start: var(--dsn-page-footer-border-block-start-width) solid
     var(--dsn-page-footer-border-block-start-color);

--- a/packages/design-tokens/src/tokens/components/grid.json
+++ b/packages/design-tokens/src/tokens/components/grid.json
@@ -11,10 +11,10 @@
         "$type": "dimension",
         "$description": "Vertical gap between grid rows (overridden to column.md in information-dense)"
       },
-      "margin": {
-        "$value": "{dsn.space.column.3xl}",
+      "padding-inline": {
+        "$value": "0px",
         "$type": "dimension",
-        "$description": "Outer padding on both sides of the grid container"
+        "$description": "Outer padding-inline of the grid container. Default 0: grids sit inside dsn-page-body__inner which already provides horizontal padding."
       },
       "max-width": {
         "$value": "74rem",

--- a/packages/storybook/src/Grid.docs.md
+++ b/packages/storybook/src/Grid.docs.md
@@ -92,14 +92,14 @@ Responsive varianten werken hetzelfde als bij `colSpan`: suffix `Sm`, `Md` of `L
 
 ## Full-bleed
 
-Een `GridItem` met `fullBleed` (of `<div class="dsn-full-bleed">`) breekt visueel uit tot de buitenrand van de grid container. Het item beslaat de volle breedte inclusief de `--dsn-grid-margin`. Dit is handig voor achtergrondvlakken die "edge-to-edge" lopen.
+Een `GridItem` met `fullBleed` (of `<div class="dsn-full-bleed">`) breekt visueel uit tot de buitenrand van de grid container. Het item beslaat de volle breedte inclusief de `--dsn-grid-padding-inline`. Dit is handig voor achtergrondvlakken die "edge-to-edge" lopen.
 
 ```html
 <div class="dsn-grid dsn-grid--contained">
   <div class="dsn-col-8">Normale content</div>
   <div class="dsn-full-bleed">
     <div
-      style="background: var(--dsn-color-neutral-bg-subtle); padding: 1.5rem var(--dsn-grid-margin);"
+      style="background: var(--dsn-color-neutral-bg-subtle); padding: 1.5rem var(--dsn-grid-padding-inline);"
     >
       Edge-to-edge sectie
     </div>
@@ -114,13 +114,13 @@ Grid en GridItem zijn puur visuele layout utilities. Ze voegen geen ARIA-attribu
 
 ## Design tokens
 
-| Token                  | Standaard waarde                     | Omschrijving                                                        |
-| ---------------------- | ------------------------------------ | ------------------------------------------------------------------- |
-| `--dsn-grid-gutter`    | `var(--dsn-space-column-xl)` (16px)  | Horizontale ruimte tussen kolommen; 8px in information-dense        |
-| `--dsn-grid-row-gap`   | `var(--dsn-space-column-xl)` (16px)  | Verticale ruimte tussen rijen; 8px in information-dense             |
-| `--dsn-grid-margin`    | `var(--dsn-space-column-3xl)` (24px) | Outer padding aan weerszijden van de grid container                 |
-| `--dsn-grid-max-width` | `74rem` (~1184px)                    | Maximale breedte bij `contained` variant                            |
-| `--dsn-breakpoint-sm`  | `36em`                               | Referentiewaarde small breakpoint (niet te gebruiken in CSS @media) |
-| `--dsn-breakpoint-md`  | `44em`                               | Referentiewaarde medium breakpoint                                  |
-| `--dsn-breakpoint-lg`  | `64em`                               | Referentiewaarde large breakpoint                                   |
-| `--dsn-breakpoint-xl`  | `74em`                               | Referentiewaarde extra large breakpoint                             |
+| Token                       | Standaard waarde                    | Omschrijving                                                                                                                                                                             |
+| --------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--dsn-grid-gutter`         | `var(--dsn-space-column-xl)` (16px) | Horizontale ruimte tussen kolommen; 8px in information-dense                                                                                                                             |
+| `--dsn-grid-row-gap`        | `var(--dsn-space-column-xl)` (16px) | Verticale ruimte tussen rijen; 8px in information-dense                                                                                                                                  |
+| `--dsn-grid-padding-inline` | `0px`                               | Outer padding-inline van de grid container. Standaard 0: grids staan doorgaans binnen `dsn-page-body__inner` die al voor horizontale padding zorgt. Zet expliciet voor standalone grids. |
+| `--dsn-grid-max-width`      | `74rem` (~1184px)                   | Maximale breedte bij `contained` variant                                                                                                                                                 |
+| `--dsn-breakpoint-sm`       | `36em`                              | Referentiewaarde small breakpoint (niet te gebruiken in CSS @media)                                                                                                                      |
+| `--dsn-breakpoint-md`       | `44em`                              | Referentiewaarde medium breakpoint                                                                                                                                                       |
+| `--dsn-breakpoint-lg`       | `64em`                              | Referentiewaarde large breakpoint                                                                                                                                                        |
+| `--dsn-breakpoint-xl`       | `74em`                              | Referentiewaarde extra large breakpoint                                                                                                                                                  |

--- a/packages/storybook/src/Grid.stories.tsx
+++ b/packages/storybook/src/Grid.stories.tsx
@@ -82,7 +82,17 @@ export const Responsive: Story = {
 export const FullBleed: Story = {
   name: 'Full-bleed',
   render: () => (
-    <Grid contained>
+    // --dsn-grid-padding-inline expliciet gezet voor de demo zodat de full-bleed
+    // uitbraak zichtbaar is. In productie staat de default op 0 omdat de padding
+    // al door dsn-page-body__inner wordt geleverd.
+    <Grid
+      contained
+      style={
+        {
+          '--dsn-grid-padding-inline': 'var(--dsn-space-column-3xl)',
+        } as React.CSSProperties
+      }
+    >
       <GridItem colSpan={8}>
         <Container>Normale content (col-8)</Container>
       </GridItem>
@@ -90,7 +100,7 @@ export const FullBleed: Story = {
         <div
           style={{
             background: 'var(--dsn-color-neutral-bg-subtle)',
-            padding: '1.5rem var(--dsn-grid-margin)',
+            padding: '1.5rem var(--dsn-grid-padding-inline)',
             borderBlock: '1px solid var(--dsn-color-neutral-border-subtle)',
           }}
         >

--- a/packages/storybook/src/templates/BasePage.stories.tsx
+++ b/packages/storybook/src/templates/BasePage.stories.tsx
@@ -193,7 +193,7 @@ const breakoutSectionStyle: React.CSSProperties = {
 function GridContent() {
   return (
     <Stack space="2xl">
-      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+      <Grid>
         <GridItem colSpan={12}>
           <Container>
             <Paragraph>Rij 1 — volle breedte (12 kolommen)</Paragraph>
@@ -201,7 +201,7 @@ function GridContent() {
         </GridItem>
       </Grid>
 
-      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+      <Grid>
         <GridItem colSpan={12} colSpanMd={6}>
           <Container>
             <Paragraph>Rij 2 — kolom 1 van 2</Paragraph>
@@ -214,7 +214,7 @@ function GridContent() {
         </GridItem>
       </Grid>
 
-      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+      <Grid>
         <GridItem colSpan={12} colSpanMd={4}>
           <Container>
             <Paragraph>Rij 3 — kolom 1 van 3</Paragraph>

--- a/packages/storybook/src/templates/FormConfirmationPage.stories.tsx
+++ b/packages/storybook/src/templates/FormConfirmationPage.stories.tsx
@@ -66,7 +66,7 @@ export const Example: Story = {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Note

--- a/packages/storybook/src/templates/FormIntroductionPage.stories.tsx
+++ b/packages/storybook/src/templates/FormIntroductionPage.stories.tsx
@@ -64,7 +64,7 @@ export const Example: Story = {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>

--- a/packages/storybook/src/templates/FormReviewPage.stories.tsx
+++ b/packages/storybook/src/templates/FormReviewPage.stories.tsx
@@ -70,7 +70,7 @@ export const Example: Story = {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>

--- a/packages/storybook/src/templates/FormStepAllTypesPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepAllTypesPage.stories.tsx
@@ -144,7 +144,7 @@ function AllTypesPage() {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>

--- a/packages/storybook/src/templates/FormStepEditFromReviewPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepEditFromReviewPage.stories.tsx
@@ -69,7 +69,7 @@ export const Example: Story = {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>

--- a/packages/storybook/src/templates/FormStepExtendedPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepExtendedPage.stories.tsx
@@ -133,7 +133,7 @@ function ExtendedDetailsPage() {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>
@@ -321,7 +321,7 @@ function SingleErrorPage() {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>
@@ -540,7 +540,7 @@ function MultipleErrorsPage() {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>

--- a/packages/storybook/src/templates/FormStepPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepPage.stories.tsx
@@ -125,7 +125,7 @@ function FormStepExamplePage() {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>
@@ -226,7 +226,7 @@ function FormStepExampleWithProgressPage() {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>
@@ -335,7 +335,7 @@ function FormStepExampleWithProgressBarPage() {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>
@@ -487,7 +487,7 @@ export const WithSaveForLaterModal: Story = {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>
@@ -603,7 +603,7 @@ export const WithStopFormModal: Story = {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>

--- a/packages/storybook/src/templates/FormStepSimplePage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepSimplePage.stories.tsx
@@ -123,7 +123,7 @@ function SimpleDetailsPage() {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>
@@ -208,7 +208,7 @@ function SimpleDetailsWithUploadPage() {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>

--- a/packages/storybook/src/templates/FormStepUploadPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepUploadPage.stories.tsx
@@ -123,7 +123,7 @@ function UploadPage() {
         />
         <PageBody>
           <main id="main-content" tabIndex={-1} style={mainStyle}>
-            <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+            <Grid>
               <GridItem colSpan={12} colStartLg={3} colEndLg={11}>
                 <Stack space="3xl">
                   <Heading level={1}>Titel formulier</Heading>

--- a/packages/storybook/src/templates/HomePage.stories.tsx
+++ b/packages/storybook/src/templates/HomePage.stories.tsx
@@ -219,7 +219,7 @@ function GridContent() {
   return (
     <Stack space="2xl" style={gridContentStyle}>
       {/* Rij 1: volle breedte */}
-      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+      <Grid>
         <GridItem colSpan={12}>
           <Container>
             <Paragraph>Rij 1 — volle breedte (12 kolommen)</Paragraph>
@@ -228,7 +228,7 @@ function GridContent() {
       </Grid>
 
       {/* Rij 2: 2 kolommen vanaf md */}
-      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+      <Grid>
         <GridItem colSpan={12} colSpanMd={6}>
           <Container>
             <Paragraph>Rij 2 — kolom 1 van 2</Paragraph>
@@ -242,7 +242,7 @@ function GridContent() {
       </Grid>
 
       {/* Rij 3: 3 kolommen vanaf md */}
-      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+      <Grid>
         <GridItem colSpan={12} colSpanMd={4}>
           <Container>
             <Paragraph>Rij 3 — kolom 1 van 3</Paragraph>

--- a/packages/storybook/src/templates/WithSidebarPage.stories.tsx
+++ b/packages/storybook/src/templates/WithSidebarPage.stories.tsx
@@ -298,7 +298,7 @@ function GridContent() {
   return (
     <Stack space="2xl">
       {/* Rij 1: volle breedte */}
-      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+      <Grid>
         <GridItem colSpan={12}>
           <Container>
             <Paragraph>Rij 1 — volle breedte (12 kolommen)</Paragraph>
@@ -307,7 +307,7 @@ function GridContent() {
       </Grid>
 
       {/* Rij 2: 2 kolommen vanaf md */}
-      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+      <Grid>
         <GridItem colSpan={12} colSpanMd={6}>
           <Container>
             <Paragraph>Rij 2 — kolom 1 van 2</Paragraph>
@@ -321,7 +321,7 @@ function GridContent() {
       </Grid>
 
       {/* Rij 3: 3 kolommen vanaf md */}
-      <Grid style={{ '--dsn-grid-margin': '0' } as React.CSSProperties}>
+      <Grid>
         <GridItem colSpan={12} colSpanMd={4}>
           <Container>
             <Paragraph>Rij 3 — kolom 1 van 3</Paragraph>


### PR DESCRIPTION
## Summary

- **Token rename**: `dsn.grid.margin` → `dsn.grid.padding-inline`, standaard `0px`. Grids staan doorgaans binnen `dsn-page-body__inner` die al voor horizontale padding zorgt; de override was daardoor bij vrijwel alle implementaties overbodig.
- **Overbodige overrides verwijderd**: `--dsn-grid-margin: 0` inline-style uit alle 15 template-stories en `page-footer.css` verwijderd.
- **Hero inverse fix**: `--dsn-pre-heading-color` toegevoegd aan `.dsn-hero--inverse` en `.dsn-hero--image` modifier, zodat `PreHeading` altijd voldoende contrast heeft op een inverse achtergrond.
- **CLAUDE.md uitgebreid** met 4 nieuwe afspraken (regels 6–9):
  - Homepage navigatie: altijd `Home` als eerste item met `current`
  - Cards: CardGroup vs Grid — bewust kiezen, altijd mobile-first `colSpan={12}`
  - Inverse context: alle tekst-componenten meenemen (inclusief `PreHeading`)
  - Paginastructuur: `dsn-page-body__inner` gebruiken, geen inline `max-inline-size`

## Test plan

- [x] `pnpm test` — 1570 tests, 77 suites, alles groen
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)