### PR TITLE
fix(Hero): herstel dark mode contrast voor image/image-blend varianten

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,33 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 1.0.4 (June 10, 2026)
+
+### Hero — dark mode contrast
+
+#### Fixed
+
+- **Hero `image` en `image-blend` varianten in dark mode**: tekst, knoppen en blend-kleur gebruikten de donkere `accent-1-inverse` kleurschaal, waardoor zwarte tekst op de foto-achtergrond verscheen. Een foto-achtergrond vereist altijd lichte kleuren ongeacht de kleurmodus.
+
+  **Oplossing**: de token-build genereert nu per thema een scoped CSS-bestand (`{theme}-light-hero-image.css`) dat alle light-mode kleurwaarden declareert op `.dsn-theme-{theme} .dsn-hero--image`. Daarmee overschrijft het element lokaal de dark-mode `:root`-variabelen, terwijl de rest van de pagina dark mode blijft. In light mode zijn de declaraties identiek aan `:root` (geen effect).
+  - Start dark mode: witte tekst, donkerblauwe blend-overlay (`#1b59a4`), lichte strong-button
+  - Wireframe dark mode: witte tekst, zwarte blend-overlay (eigen Wireframe-kleuren)
+
+- **`build-css.js`** in `@dsn-starter-kit/components-react`: CSS `@import` met packagenamen (bijv. `@dsn-starter-kit/design-tokens/css/scoped/...`) werden niet herkend en behandeld als relatief pad. `resolvePackageImport()` toegevoegd die via de directory-boom `node_modules` opspoort en `package.json` exports raadpleegt voor het juiste bestandspad.
+
+#### Changed (token/build)
+
+- Nieuw token-build output: `createHeroImageForceLightConfigs()` in `packages/design-tokens/src/config/config.js` genereert per thema een scoped CSS-bestand (`dist/css/scoped/{theme}-light-hero-image.css`). Filtert op `dsn-color-*` en `dsn-hero-*` tokens — generieke component-tokens (`dsn-heading-*`, `dsn-button-*`) zijn uitgesloten omdat de hero die zelf beheert.
+- Nieuwe package exports in `@dsn-starter-kit/design-tokens`: `./css/scoped/start-hero-image-light` en `./css/scoped/wireframe-hero-image-light`
+
+### Grid token
+
+#### Changed
+
+- **Grid `margin` token hernoemd naar `padding-inline`** (PR #286): `dsn.grid.margin` → `dsn.grid.padding-inline`; CSS custom property `--dsn-grid-margin` → `--dsn-grid-padding-inline`. Alle template stories bijgewerkt. De `dsn-full-bleed` klasse gebruikt nu `calc(-1 * var(--dsn-grid-padding-inline))`.
+
+---
+
 ## Version 1.0.3 (June 4, 2026)
 
 ### Accessibility — Forced Colors Mode

--- a/packages/components-html/src/hero/hero.css
+++ b/packages/components-html/src/hero/hero.css
@@ -1,3 +1,7 @@
+/* Force light-mode kleurwaarden binnen image hero — voorkomt donkere tekst op foto.
+   Gegenereerd door de token-build; vervangt alle :root dark-mode overrides lokaal. */
+@import '@dsn-starter-kit/design-tokens/css/scoped/hero-image-light';
+
 /**
  * Hero Component
  * Prominente introductiesectie direct onder de PageHeader. Beslaat de volledige
@@ -144,17 +148,17 @@
   background-image: var(--dsn-hero-bg-image);
   background-size: cover;
   background-position: center;
-  color: var(--dsn-hero-image-text-color);
+  color: var(--dsn-hero-color-inverse);
 
-  /* Tekst-componenten — altijd lichte kleur ongeacht kleurmodus */
-  --dsn-pre-heading-color: var(--dsn-hero-image-text-color);
-  --dsn-heading-level-1-color: var(--dsn-hero-image-text-color);
-  --dsn-heading-level-2-color: var(--dsn-hero-image-text-color);
-  --dsn-heading-level-3-color: var(--dsn-hero-image-text-color);
-  --dsn-heading-level-4-color: var(--dsn-hero-image-text-color);
-  --dsn-heading-level-5-color: var(--dsn-hero-image-text-color);
-  --dsn-heading-level-6-color: var(--dsn-hero-image-text-color);
-  --dsn-paragraph-color: var(--dsn-hero-image-text-color);
+  /* Tekst-componenten */
+  --dsn-pre-heading-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-1-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-2-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-3-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-4-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-5-color: var(--dsn-hero-color-inverse);
+  --dsn-heading-level-6-color: var(--dsn-hero-color-inverse);
+  --dsn-paragraph-color: var(--dsn-hero-color-inverse);
 
   /* Buttons — zelfde als inverse */
   --dsn-button-strong-background-color: var(--dsn-color-action-1-bg-default);
@@ -189,10 +193,6 @@
 .dsn-hero--image.dsn-hero--image-blend {
   background-color: var(--dsn-hero-image-blend-color);
   background-blend-mode: multiply;
-}
-
-.dsn-theme-dark .dsn-hero--image.dsn-hero--image-blend {
-  background-color: var(--dsn-hero-image-blend-color-dark);
 }
 
 /* =============================================================================

--- a/packages/components-html/src/hero/hero.css
+++ b/packages/components-html/src/hero/hero.css
@@ -1,6 +1,7 @@
 /* Force light-mode kleurwaarden binnen image hero — voorkomt donkere tekst op foto.
-   Gegenereerd door de token-build; vervangt alle :root dark-mode overrides lokaal. */
-@import '@dsn-starter-kit/design-tokens/css/scoped/hero-image-light';
+   Per thema gescoopt (.dsn-theme-{name} .dsn-hero--image); gegenereerd door token-build. */
+@import '@dsn-starter-kit/design-tokens/css/scoped/start-hero-image-light';
+@import '@dsn-starter-kit/design-tokens/css/scoped/wireframe-hero-image-light';
 
 /**
  * Hero Component

--- a/packages/components-html/src/hero/hero.css
+++ b/packages/components-html/src/hero/hero.css
@@ -144,17 +144,17 @@
   background-image: var(--dsn-hero-bg-image);
   background-size: cover;
   background-position: center;
-  color: var(--dsn-hero-color-inverse);
+  color: var(--dsn-hero-image-text-color);
 
-  /* Tekst-componenten */
-  --dsn-pre-heading-color: var(--dsn-hero-color-inverse);
-  --dsn-heading-level-1-color: var(--dsn-hero-color-inverse);
-  --dsn-heading-level-2-color: var(--dsn-hero-color-inverse);
-  --dsn-heading-level-3-color: var(--dsn-hero-color-inverse);
-  --dsn-heading-level-4-color: var(--dsn-hero-color-inverse);
-  --dsn-heading-level-5-color: var(--dsn-hero-color-inverse);
-  --dsn-heading-level-6-color: var(--dsn-hero-color-inverse);
-  --dsn-paragraph-color: var(--dsn-hero-color-inverse);
+  /* Tekst-componenten — altijd lichte kleur ongeacht kleurmodus */
+  --dsn-pre-heading-color: var(--dsn-hero-image-text-color);
+  --dsn-heading-level-1-color: var(--dsn-hero-image-text-color);
+  --dsn-heading-level-2-color: var(--dsn-hero-image-text-color);
+  --dsn-heading-level-3-color: var(--dsn-hero-image-text-color);
+  --dsn-heading-level-4-color: var(--dsn-hero-image-text-color);
+  --dsn-heading-level-5-color: var(--dsn-hero-image-text-color);
+  --dsn-heading-level-6-color: var(--dsn-hero-image-text-color);
+  --dsn-paragraph-color: var(--dsn-hero-image-text-color);
 
   /* Buttons — zelfde als inverse */
   --dsn-button-strong-background-color: var(--dsn-color-action-1-bg-default);
@@ -189,6 +189,10 @@
 .dsn-hero--image.dsn-hero--image-blend {
   background-color: var(--dsn-hero-image-blend-color);
   background-blend-mode: multiply;
+}
+
+.dsn-theme-dark .dsn-hero--image.dsn-hero--image-blend {
+  background-color: var(--dsn-hero-image-blend-color-dark);
 }
 
 /* =============================================================================

--- a/packages/components-react/scripts/build-css.js
+++ b/packages/components-react/scripts/build-css.js
@@ -16,11 +16,63 @@ const path = require('path');
 const SRC_DIR = path.resolve(__dirname, '../src');
 const DIST_DIR = path.resolve(__dirname, '../dist');
 
+/**
+ * Resolves a package import (e.g. '@scope/pkg/subpath') to an absolute path.
+ * Walks up the directory tree searching for node_modules, then uses package.json
+ * exports to find the actual file.
+ */
+function resolvePackageImport(importPath, startDir) {
+  const parts = importPath.split('/');
+  const packageName = importPath.startsWith('@')
+    ? parts.slice(0, 2).join('/')
+    : parts[0];
+  const subPath = importPath.startsWith('@')
+    ? parts.slice(2).join('/')
+    : parts.slice(1).join('/');
+
+  let dir = startDir;
+  while (dir !== path.dirname(dir)) {
+    const packageDir = path.join(
+      dir,
+      'node_modules',
+      ...packageName.split('/')
+    );
+    if (fs.existsSync(packageDir)) {
+      const pkgJsonPath = path.join(packageDir, 'package.json');
+      if (fs.existsSync(pkgJsonPath)) {
+        const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+        const exportKey = subPath ? `./${subPath}` : '.';
+        const exports = pkg.exports || {};
+        if (exports[exportKey]) {
+          const entry = exports[exportKey];
+          const filePath =
+            typeof entry === 'string' ? entry : entry.default || entry.import;
+          return path.join(packageDir, filePath);
+        }
+      }
+      // Fallback: direct subpath within the package
+      if (subPath) {
+        return path.join(packageDir, subPath);
+      }
+    }
+    dir = path.dirname(dir);
+  }
+  throw new Error(
+    `Package not found: ${packageName} (imported from ${startDir})`
+  );
+}
+
 function resolveImports(cssContent, baseDir) {
   return cssContent.replace(
     /@import\s+['"]([^'"]+)['"]\s*;/g,
     (match, importPath) => {
-      const resolved = path.resolve(baseDir, importPath);
+      // Package import: doesn't start with . or /
+      const isPackageImport =
+        !importPath.startsWith('.') && !importPath.startsWith('/');
+      const resolved = isPackageImport
+        ? resolvePackageImport(importPath, baseDir)
+        : path.resolve(baseDir, importPath);
+
       if (!fs.existsSync(resolved)) {
         throw new Error(
           `CSS import not found: ${resolved} (imported from ${baseDir})`

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -20,7 +20,8 @@
     "./css/dark-scoped": "./dist/css/variables-dark-scoped.css",
     "./scss": "./dist/scss/_variables.scss",
     "./scss/dark": "./dist/scss/_variables-dark.scss",
-    "./css/scoped/hero-image-light": "./dist/css/scoped/start-light-hero-image.css"
+    "./css/scoped/start-hero-image-light": "./dist/css/scoped/start-light-hero-image.css",
+    "./css/scoped/wireframe-hero-image-light": "./dist/css/scoped/wireframe-light-hero-image.css"
   },
   "files": [
     "dist"

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -19,7 +19,8 @@
     "./css/dark": "./dist/css/variables-dark.css",
     "./css/dark-scoped": "./dist/css/variables-dark-scoped.css",
     "./scss": "./dist/scss/_variables.scss",
-    "./scss/dark": "./dist/scss/_variables-dark.scss"
+    "./scss/dark": "./dist/scss/_variables-dark.scss",
+    "./css/scoped/hero-image-light": "./dist/css/scoped/start-light-hero-image.css"
   },
   "files": [
     "dist"

--- a/packages/design-tokens/src/config/build.js
+++ b/packages/design-tokens/src/config/build.js
@@ -8,6 +8,7 @@ import {
   projectTypes,
   fullConfigs,
   scopedConfigs,
+  createHeroImageForceLightConfig,
 } from './config.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -196,10 +197,28 @@ function printSummary() {
   console.log('\n🎉 Build complete!\n');
 }
 
+async function buildHeroImageForceLightConfig() {
+  console.log(
+    '🦸 Building hero image force-light config (light-mode colors scoped to .dsn-hero--image)...\n'
+  );
+  try {
+    const sd = new StyleDictionary(createHeroImageForceLightConfig());
+    await sd.buildAllPlatforms();
+    console.log('   ✅ dist/css/scoped/start-light-hero-image.css\n');
+  } catch (error) {
+    console.error(
+      '   ❌ Error building hero image force-light:',
+      error.message
+    );
+    process.exit(1);
+  }
+}
+
 async function main() {
   await buildFullConfigs();
   await appendReducedMotion();
   await buildScopedConfigs();
+  await buildHeroImageForceLightConfig();
   createBackwardCompatibilityAliases();
   printSummary();
 }

--- a/packages/design-tokens/src/config/build.js
+++ b/packages/design-tokens/src/config/build.js
@@ -8,7 +8,7 @@ import {
   projectTypes,
   fullConfigs,
   scopedConfigs,
-  createHeroImageForceLightConfig,
+  createHeroImageForceLightConfigs,
 } from './config.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -197,28 +197,30 @@ function printSummary() {
   console.log('\n🎉 Build complete!\n');
 }
 
-async function buildHeroImageForceLightConfig() {
+async function buildHeroImageForceLightConfigs() {
   console.log(
-    '🦸 Building hero image force-light config (light-mode colors scoped to .dsn-hero--image)...\n'
+    '🦸 Building hero image force-light configs (light-mode colors scoped to .dsn-hero--image per theme)...\n'
   );
-  try {
-    const sd = new StyleDictionary(createHeroImageForceLightConfig());
-    await sd.buildAllPlatforms();
-    console.log('   ✅ dist/css/scoped/start-light-hero-image.css\n');
-  } catch (error) {
-    console.error(
-      '   ❌ Error building hero image force-light:',
-      error.message
-    );
-    process.exit(1);
+  const configs = createHeroImageForceLightConfigs();
+  for (const config of configs) {
+    const destination = config.platforms.css.files[0].destination;
+    try {
+      const sd = new StyleDictionary(config);
+      await sd.buildAllPlatforms();
+      console.log(`   ✅ dist/css/scoped/${destination}`);
+    } catch (error) {
+      console.error(`   ❌ Error building ${destination}:`, error.message);
+      process.exit(1);
+    }
   }
+  console.log();
 }
 
 async function main() {
   await buildFullConfigs();
   await appendReducedMotion();
   await buildScopedConfigs();
-  await buildHeroImageForceLightConfig();
+  await buildHeroImageForceLightConfigs();
   createBackwardCompatibilityAliases();
   printSummary();
 }

--- a/packages/design-tokens/src/config/config.js
+++ b/packages/design-tokens/src/config/config.js
@@ -227,16 +227,20 @@ function createThemeBaseScopedConfig(theme) {
 }
 
 /**
- * Creates a scoped CSS file met alle start-light kleurwaarden gescoopt op .dsn-hero--image.
+ * Creates a scoped CSS file per thema met light-mode kleurwaarden gescoopt op .dsn-hero--image.
  * Dit zorgt dat de image/image-blend Hero altijd in light-mode kleuren rendert,
  * ongeacht of de pagina in dark mode staat. De :root dark-mode waarden worden
  * lokaal overschreven — in light mode zijn de waarden identiek aan :root (geen effect).
+ *
+ * CSS-erfenis-toelichting: component-tokens zoals --dsn-hero-color-inverse erven van
+ * :root als resolved waarden (#000000 in dark mode). Door ze expliciet op het element
+ * te declareren, resolven var()-referenties opnieuw met de lokale lichte kleurwaarden.
  */
-export function createHeroImageForceLightConfig() {
+function createHeroImageForceLightConfigForTheme(theme) {
   return {
     source: [
-      'src/tokens/themes/start/base.json',
-      'src/tokens/themes/start/colors-light.json',
+      `src/tokens/themes/${theme}/base.json`,
+      `src/tokens/themes/${theme}/colors-light.json`,
       'src/tokens/components/*.json',
       'src/tokens/project-types/default/*.json',
     ],
@@ -246,21 +250,17 @@ export function createHeroImageForceLightConfig() {
         buildPath: 'dist/css/scoped/',
         files: [
           {
-            destination: 'start-light-hero-image.css',
+            destination: `${theme}-light-hero-image.css`,
             format: 'css/variables-scoped',
             // Primitieve kleurschaal (dsn.color.*) + hero-specifieke tokens (dsn.hero.*).
-            // Probleem: component-tokens erven van :root als resolved waarde. In dark
-            // mode is --dsn-hero-color-inverse geërfd als #000000. Door hero-tokens
-            // expliciet te declareren op het element worden var()-referenties opnieuw
-            // resolved met de lokale lichte kleurwaarden.
-            // Uitgesloten: generieke component-tokens zoals --dsn-heading-* en
-            // --dsn-button-* (die beheert hero.css zelf via var(--dsn-hero-color-*)).
+            // Generieke component-tokens zoals --dsn-heading-* en --dsn-button-* zijn
+            // uitgesloten — die beheert hero.css zelf via var(--dsn-hero-color-*).
             filter: (token) =>
               token.$type === 'color' &&
               (token.name.startsWith('dsn-color-') ||
                 token.name.startsWith('dsn-hero-')),
             options: {
-              selector: '.dsn-theme-start .dsn-hero--image',
+              selector: `.dsn-theme-${theme} .dsn-hero--image`,
               outputReferences: false,
             },
           },
@@ -268,6 +268,10 @@ export function createHeroImageForceLightConfig() {
       },
     },
   };
+}
+
+export function createHeroImageForceLightConfigs() {
+  return themes.map((theme) => createHeroImageForceLightConfigForTheme(theme));
 }
 
 // =============================================================================

--- a/packages/design-tokens/src/config/config.js
+++ b/packages/design-tokens/src/config/config.js
@@ -15,7 +15,7 @@ StyleDictionary.registerFormat({
 
     const lines = dictionary.allTokens.map((token) => {
       const comment = token.description ? ` /* ${token.description} */` : '';
-      let value = token.value;
+      let value = token.value ?? token.$value;
 
       // If outputReferences is enabled and the original value had references,
       // convert them to CSS custom property references
@@ -218,6 +218,40 @@ function createThemeBaseScopedConfig(theme) {
             options: {
               selector: `.dsn-theme-${theme}`,
               outputReferences: true,
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+/**
+ * Creates a scoped CSS file met alle start-light kleurwaarden gescoopt op .dsn-hero--image.
+ * Dit zorgt dat de image/image-blend Hero altijd in light-mode kleuren rendert,
+ * ongeacht of de pagina in dark mode staat. De :root dark-mode waarden worden
+ * lokaal overschreven — in light mode zijn de waarden identiek aan :root (geen effect).
+ */
+export function createHeroImageForceLightConfig() {
+  return {
+    source: [
+      'src/tokens/themes/start/base.json',
+      'src/tokens/themes/start/colors-light.json',
+      'src/tokens/components/*.json',
+      'src/tokens/project-types/default/*.json',
+    ],
+    platforms: {
+      css: {
+        transformGroup: 'css',
+        buildPath: 'dist/css/scoped/',
+        files: [
+          {
+            destination: 'start-light-hero-image.css',
+            format: 'css/variables-scoped',
+            filter: (token) => token.$type === 'color',
+            options: {
+              selector: '.dsn-hero--image',
+              outputReferences: false,
             },
           },
         ],

--- a/packages/design-tokens/src/config/config.js
+++ b/packages/design-tokens/src/config/config.js
@@ -248,9 +248,19 @@ export function createHeroImageForceLightConfig() {
           {
             destination: 'start-light-hero-image.css',
             format: 'css/variables-scoped',
-            filter: (token) => token.$type === 'color',
+            // Primitieve kleurschaal (dsn.color.*) + hero-specifieke tokens (dsn.hero.*).
+            // Probleem: component-tokens erven van :root als resolved waarde. In dark
+            // mode is --dsn-hero-color-inverse geërfd als #000000. Door hero-tokens
+            // expliciet te declareren op het element worden var()-referenties opnieuw
+            // resolved met de lokale lichte kleurwaarden.
+            // Uitgesloten: generieke component-tokens zoals --dsn-heading-* en
+            // --dsn-button-* (die beheert hero.css zelf via var(--dsn-hero-color-*)).
+            filter: (token) =>
+              token.$type === 'color' &&
+              (token.name.startsWith('dsn-color-') ||
+                token.name.startsWith('dsn-hero-')),
             options: {
-              selector: '.dsn-hero--image',
+              selector: '.dsn-theme-start .dsn-hero--image',
               outputReferences: false,
             },
           },

--- a/packages/design-tokens/src/tokens/components/hero.json
+++ b/packages/design-tokens/src/tokens/components/hero.json
@@ -51,10 +51,20 @@
         "$description": "Breedte van de transparante border-block op de Hero — zichtbaar in forced-colors / High Contrast mode om de sectieafbakening aan te geven"
       },
       "image": {
+        "text-color": {
+          "$value": "#ffffff",
+          "$type": "color",
+          "$description": "Tekstkleur in de image/image-blend hero — statisch wit voor contrast op foto-achtergrond, ongeacht kleurmodus"
+        },
         "blend-color": {
           "$value": "{dsn.color.accent-1-inverse.bg-default}",
           "$type": "color",
-          "$description": "Blendkleur voor de image-blend variant — zelfde als inverse achtergrond voor visuele samenhang"
+          "$description": "Blendkleur voor de image-blend variant in light mode — donker blauw via multiply"
+        },
+        "blend-color-dark": {
+          "$value": "{dsn.color.accent-1.bg-document}",
+          "$type": "color",
+          "$description": "Blendkleur voor de image-blend variant in dark mode — resolveert naar donker navy (#001126) zodat multiply de foto verdonkert"
         }
       }
     }

--- a/packages/design-tokens/src/tokens/components/hero.json
+++ b/packages/design-tokens/src/tokens/components/hero.json
@@ -51,20 +51,10 @@
         "$description": "Breedte van de transparante border-block op de Hero — zichtbaar in forced-colors / High Contrast mode om de sectieafbakening aan te geven"
       },
       "image": {
-        "text-color": {
-          "$value": "#ffffff",
-          "$type": "color",
-          "$description": "Tekstkleur in de image/image-blend hero — statisch wit voor contrast op foto-achtergrond, ongeacht kleurmodus"
-        },
         "blend-color": {
           "$value": "{dsn.color.accent-1-inverse.bg-default}",
           "$type": "color",
-          "$description": "Blendkleur voor de image-blend variant in light mode — donker blauw via multiply"
-        },
-        "blend-color-dark": {
-          "$value": "{dsn.color.accent-1.bg-document}",
-          "$type": "color",
-          "$description": "Blendkleur voor de image-blend variant in dark mode — resolveert naar donker navy (#001126) zodat multiply de foto verdonkert"
+          "$description": "Blendkleur voor de image-blend variant — donker blauw via multiply"
         }
       }
     }

--- a/packages/storybook/src/Hero.docs.md
+++ b/packages/storybook/src/Hero.docs.md
@@ -39,6 +39,14 @@ Bij `variant="image"` of `"image-blend"` levert u de afbeelding via de `backgrou
 
 Gebruik bij voorkeur `variant="image-blend"` boven `variant="image"`: de kleur-overlay verbetert de kans op voldoende contrast en geeft de Hero een consistentere uitstraling bij wisselende afbeeldingen.
 
+### Dark mode
+
+De `image` en `image-blend` varianten renderen altijd in light-mode kleuren, ook als de pagina in dark mode staat. Een foto-achtergrond vereist lichte tekst en een donkere overlay ongeacht de kleurmodus — de semantische "inverse" kleuren van de donkere kleurschaal zijn hier niet bruikbaar.
+
+Dit gedrag is ingebakken via gegenereerde scoped CSS (per thema): het component overschrijft lokaal de dark-mode `:root`-variabelen. U hoeft hier als gebruiker van het component niets voor te doen.
+
+De `default` en `inverse` varianten volgen wél de actieve kleurmodus.
+
 ### Hoogte
 
 De standaardhoogte is `70svh` met een minimum van `400px`. Overschrijf `--dsn-hero-block-size` via een inline stijl om de hoogte per instantie aan te passen:


### PR DESCRIPTION
## Summary

- De `image` en `image-blend` Hero-varianten toonden donkere tekst op een foto-achtergrond in dark mode, waardoor het contrast onvoldoende was
- Oplossing: force-light CSS wordt gegenereerd per thema (Start + Wireframe) en gescoopt op `.dsn-theme-{theme} .dsn-hero--image` — de component rendert altijd in light-mode kleuren, ongeacht de actieve kleurmodus
- `build-css.js` is uitgebreid met ondersteuning voor package imports (`@dsn-starter-kit/design-tokens/...`) in CSS `@import`-statements

## Technische aanpak

De `dsn-hero--image` modifier krijgt via gegenereerde scoped CSS alle light-mode kleurwaarden (dsn-color-* + dsn-hero-*) expliciet gedeclareerd. Dit is nodig omdat CSS custom properties als resolved values erven — het overschrijven van een referenced token werkt niet retroactief op al geërvede waarden.

## Gewijzigde bestanden

- `packages/components-html/src/hero/hero.css` — voegt twee `@import` statements toe voor de force-light CSS
- `packages/design-tokens/src/config/config.js` — voegt `createHeroImageForceLightConfigs()` toe
- `packages/design-tokens/src/config/build.js` — bouwt de nieuwe scoped CSS per thema
- `packages/design-tokens/package.json` — voegt exports toe voor de twee nieuwe CSS-bestanden
- `packages/components-react/scripts/build-css.js` — ondersteuning voor package imports in CSS `@import`
- `packages/storybook/src/Hero.docs.md` — dark mode gedrag gedocumenteerd
- `docs/changelog.md` — v1.0.4 entry toegevoegd

## Test plan

- [ ] Storybook Hero stories controleren in dark mode: `image` en `image-blend` tonen lichte tekst op foto
- [ ] Wireframe thema in dark mode: Start-kleuren mogen niet lekken naar Wireframe hero
- [ ] `default` en `inverse` varianten volgen wél de actieve kleurmodus (niet geforced)
- [ ] `pnpm build` slaagt zonder fouten
- [ ] `pnpm test` — alle tests groen
- [ ] `pnpm --filter storybook exec tsc --noEmit` — 0 TypeScript-fouten

🤖 Generated with [Claude Code](https://claude.com/claude-code)