### PR TITLE
docs(decisions): voeg drie initiële decision records toe

### DIFF
--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -80,6 +80,19 @@ Updaten bij: nieuwe naamgevingspatronen, nieuwe utility-klassen, wijzigingen in 
 
 Updaten bij: nieuwe addons, nieuwe story-types, gewijzigde Storybook config, nieuwe TokenTable features.
 
+### `docs/decisions/`
+
+Controleer of recente commits een beslissing bevatten die een decision record rechtvaardigt. Maak een nieuw record aan als **minstens één** van deze vragen 'ja' is:
+
+- Is er een naamconventie, token-architectuur of component-API veranderd?
+- Is er een keuze gemaakt waarbij redelijke mensen het oneens hadden kunnen zijn?
+- Is er een vraag beantwoord die al eerder opkwam (of zeker nog zal opkomen)?
+- Is er een expliciete trade-off geaccepteerd die toekomstige contributors zouden kunnen terugdraaien zonder de context te kennen?
+
+Zo ja: maak een nieuw bestand aan in `docs/decisions/` met naamconventie `DR-{JAAR}-{VOLGNUMMER}-{korte-beschrijving}.md` en voeg het toe aan de index in `docs/decisions/README.md`. Gebruik de structuur van een bestaand record als template.
+
+Sla deze stap over als de recente commits alleen bug fixes, stijlwijzigingen of toevoegingen zijn die de bestaande patronen volgen.
+
 ### `docs/changelog.md`
 
 Voeg een nieuwe entry toe voor commits die nog niet gedocumenteerd zijn. Formaat:

--- a/docs/decisions/DR-2026-01-button-label-span-over-aria-label.md
+++ b/docs/decisions/DR-2026-01-button-label-span-over-aria-label.md
@@ -1,0 +1,115 @@
+# DR-2026-01: Gebruik dsn-button\_\_label span in plaats van aria-label
+
+**ID:** DR-2026-01
+**Datum:** Januari 2026
+**Status:** Accepted
+**Auteurs:** Jeffrey Lauwers
+
+---
+
+## Context
+
+Icon-only buttons hebben een toegankelijke naam nodig zodat screenreadergebruikers begrijpen wat de knop doet. De meest gebruikte aanpak is `aria-label="Sluiten"` direct op het `<button>` element. Dit is eenvoudig, breed ondersteund en staat in veel tutorials als de aanbevolen oplossing.
+
+Er is echter een fundamenteel probleem: `aria-label` wordt **niet vertaald** door browser-vertaaltools zoals Google Translate, Microsoft Translator of ingebouwde mobiele vertalers. Een gebruiker die de interface in het Frans leest, ziet knoppen waarvan de zichtbare tekst is vertaald maar de toegankelijke naam Nederlandstalig blijft — een inconsistentie die screenreadergebruikers in vertaalde contexten discrimineert.
+
+De design system componenten worden gebruikt in publieke Nederlandse overheidsinterfaces die verplicht internationaal toegankelijk moeten zijn.
+
+---
+
+## Opties overwogen
+
+### Optie 1: `aria-label` op het button-element
+
+```html
+<button aria-label="Sluiten">
+  <svg aria-hidden="true">...</svg>
+</button>
+```
+
+**Voordeel:** Eenvoudig, geen extra markup, breed gedocumenteerd.
+**Nadeel:** Wordt niet vertaald door browsertranslators. Screenreadergebruikers in vertaalde interfaces horen de originele taal, niet de vertaalde taal. Dit is een bekende WCAG-fout bij gebruik van machinevertaling (Success Criterion 3.1.2 Language of Parts).
+
+### Optie 2: `aria-labelledby` met verborgen span
+
+```html
+<span id="btn-label" hidden>Sluiten</span>
+<button aria-labelledby="btn-label">
+  <svg aria-hidden="true">...</svg>
+</button>
+```
+
+**Voordeel:** Tekst is vertaalbaar.
+**Nadeel:** Vereist unieke IDs per instantie, wat in React `useId()` vereist en in plain HTML handmatig beheer. Markup is verspreid over het DOM. Moeilijk schaalbaar bij herhaalde instanties.
+
+### Optie 3: Visueel verborgen span inside de button (gekozen)
+
+```html
+<button class="dsn-button dsn-button--icon-only">
+  <svg class="dsn-icon" aria-hidden="true">...</svg>
+  <span class="dsn-button__label">Sluiten</span>
+</button>
+```
+
+De `.dsn-button--icon-only` modifier past clip-path/overflow-hidden toe op de `__label` span zodat hij visueel verdwijnt maar in de accessibility tree aanwezig blijft.
+
+**Voordeel:** Tekst zit als zichtbare DOM-node in de button — vertaaltools vinden en vertalen hem. Geen extra IDs nodig. De label is altijd aanwezig bij de knop.
+**Nadeel:** Licht meer markup dan `aria-label`. Vereist dat ontwikkelaars de span niet vergeten en er geen verkorte `aria-label` naast zetten.
+
+---
+
+## Beslissing
+
+**Alle buttons in het design system gebruiken altijd een `dsn-button__label` span. `aria-label` op een button-element is verboden.**
+
+De reden is vertaalbaarheid: een `<span>` is een DOM-tekst-node die browser-vertaaltools oppikken. `aria-label` is een attribuutwaarde die buiten de vertaalketen valt. Voor een systeem dat vertaalbare interfaces ondersteunt, is de span de enige correcte aanpak.
+
+De trade-off die we accepteren: iets meer markup en de vereiste dat elke button-implementatie — inclusief die van contributors — de span bevat. Dit wordt gehandhaafd via CLAUDE.md (regel 1), code review en componenttests.
+
+---
+
+## Impact
+
+| Dimension                     | Meting                                                                                                                               |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Bestanden geraakt             | Alle button-achtige componenten: `button.css`, `Button.tsx`, `ButtonLink.tsx`, `LinkButton.tsx`, `menu-button.css`, `MenuButton.tsx` |
+| Componenten geraakt           | 4 directe (Button, ButtonLink, LinkButton, MenuButton), indirect alle composites die een button bevatten                             |
+| Breaking changes              | Nee — de span was al aanwezig bij introductie van het systeem                                                                        |
+| Alternatief dat verwijderd is | `aria-label` op button-elementen — mag niet voorkomen in nieuwe of bijgewerkte componenten                                           |
+
+---
+
+## Gevolgen
+
+**Wat makkelijker wordt:**
+
+- Interfaces zijn correct vertaalbaar zonder extra werk van productteams.
+- Er is één consistente aanpak voor accessible naming van buttons in het hele systeem.
+- De label-tekst is altijd zichtbaar in de DOM voor debugging en testtools.
+
+**Wat moeilijker wordt:**
+
+- Contributors die gewend zijn aan `aria-label` zullen de regel moeten leren. Dit is documenteerbaar maar vraagt expliciete communicatie bij onboarding.
+- Icon-only buttons met rijcontext (bijv. "Verwijder voor product: Laptop Pro") vereisen een geneste `dsn-visually-hidden` span inside de `__label`, wat iets meer markup is dan een enkel `aria-label`.
+
+**Nieuwe verplichting voor contributors:**
+Elk icon-only button-patroon in een PR dat `aria-label` gebruikt in plaats van `dsn-button__label` wordt geblokkeerd bij code review. De CLAUDE.md-sessieregel ("NOOIT aria-label") handhaaft dit automatisch bij AI-geassisteerde implementaties.
+
+---
+
+## Supersedes / superseded by
+
+Niet van toepassing — dit is een initieel besluit.
+
+---
+
+## Gerelateerde records
+
+- DR-2026-02 (twee-lagenpatroon) — de span-aanpak werkt in beide lagen identiek
+- Zie ook: CLAUDE.md §1 "Button accessible naming: NOOIT aria-label"
+
+---
+
+## Review trigger
+
+Herzie dit besluit als de CSS-specificatie `aria-label`-vertaling introduceert (momenteel niet gepland) of als WCAG een nieuwe SC introduceert die dit patroon wijzigt.

--- a/docs/decisions/DR-2026-02-twee-lagenpatroon-html-css-plus-react.md
+++ b/docs/decisions/DR-2026-02-twee-lagenpatroon-html-css-plus-react.md
@@ -1,0 +1,130 @@
+# DR-2026-02: Twee-lagenpatroon — HTML/CSS als bron van waarheid, React als wrapper
+
+**ID:** DR-2026-02
+**Datum:** December 2025
+**Status:** Accepted
+**Auteurs:** Jeffrey Lauwers
+
+---
+
+## Context
+
+Het design system moest van het begin af aan meerdere consumptiemodellen ondersteunen: teams die vanilla HTML/CSS gebruiken, teams die React gebruiken, en toekomstige Web Components. De vraag was: waar zit de stijllogica, en wat is de relatie tussen de lagen?
+
+Er zijn drie fundamenteel verschillende architectuurkeuzes denkbaar:
+
+1. CSS-only: één CSS-bestand per component, geen opiniative JavaScript-laag.
+2. React-first: componenten zijn primair React, CSS is een bijproduct (CSS Modules, styled-components, Tailwind).
+3. Twee-lagen: HTML/CSS is de bron van waarheid, React is een dunne wrapper die de juiste klassen genereert.
+
+De keuze hier heeft langetermijngevolgen voor adoptie, theming, Web Components, en de vraag of het systeem overdraagbaar is naar andere frameworks.
+
+---
+
+## Opties overwogen
+
+### Optie 1: CSS-only (geen React-laag)
+
+Componenten leven als CSS-klassen. Frameworks gebruiken de klassen direct.
+
+**Voordeel:** Framework-agnostisch van nature. Geen lock-in. Eenvoudig te begrijpen.
+**Nadeel:** Geen TypeScript-props, geen autocompletion, geen compile-time fouten. Elke React-ontwikkelaar moet de BEM-klassen kennen en correct samenstellen. Moeilijk om complexe conditionals (loading + disabled + fullWidth tegelijk) consistent te houden.
+
+### Optie 2: React-first met CSS Modules of styled-components
+
+CSS leeft dicht bij de React-component, gegenereerd of geïmporteerd als module.
+
+**Voordeel:** Standaard React DX, goede tooling, autocompletion.
+**Nadeel:** CSS is niet meer los importeerbaar voor HTML-teams. Web Components zouden de CSS moeten dupliceren of van React afhangen. Theming via design tokens werkt minder goed: CSS custom properties zijn de standaard voor theming, maar CSS-in-JS kan die niet altijd correct doorgeven. Het systeem wordt React-afhankelijk.
+
+### Optie 3: Twee-lagen — HTML/CSS als bron van waarheid (gekozen)
+
+```
+packages/components-html/src/button/button.css   ← bron van waarheid
+packages/components-react/src/Button/Button.tsx  ← wrapper, importeert .css, genereert klassen
+packages/components-web/src/button/               ← wrapper, importeert dezelfde .css
+```
+
+React doet niets meer dan de juiste BEM-klassen samenstellen op basis van props:
+
+```tsx
+const classes = classNames(
+  'dsn-button',
+  `dsn-button--${variant}`,
+  `dsn-button--size-${size}`,
+  loading && 'dsn-button--loading'
+);
+```
+
+**Voordeel:**
+
+- HTML/CSS-teams en React-teams gebruiken hetzelfde visuele systeem — er is geen "React-versie" en "HTML-versie" die kunnen divergeren.
+- Web Components kunnen dezelfde CSS importeren zonder extra abstractielaag.
+- Theming via CSS custom properties werkt in alle lagen identiek.
+- De CSS is de specificatie: als je wilt weten wat een component kan, lees je de CSS.
+
+**Nadeel:**
+
+- Contributors moeten twee bestanden bijhouden per component (CSS + TSX).
+- Sommige form-componenten (Checkbox, Radio, Select) hebben geen HTML/CSS-tegenpartij in `components-html` omdat hun JS-gedrag (show/hide, custom styling) niet zinvol is zonder React. Dit creëert een lichte asymmetrie in het systeem.
+
+---
+
+## Beslissing
+
+**Het design system gebruikt het twee-lagenpatroon. HTML/CSS is de bron van waarheid; React genereert de juiste klassen zonder eigen stijllogica toe te voegen.**
+
+De primaire reden is portabiliteit: de CSS-laag werkt in elk framework en in Web Components zonder aanpassing. De React-laag is een DX-verbetering bovenop een systeem dat zonder React volledig functioneel is. Dit maakt het systeem ook bruikbaar als "design system starter kit" voor teams die React misschien later wisselen voor iets anders.
+
+De trade-off die we accepteren: twee bestanden per component in plaats van één. Dit is expliciete overhead, maar de betaalbaarheid is hoog: de CSS-bestanden zijn klein, de React-wrappers zijn dunne klassen-assemblers, en de structuur is volledig voorspelbaar.
+
+---
+
+## Impact
+
+| Dimension                          | Meting                                                                               |
+| ---------------------------------- | ------------------------------------------------------------------------------------ |
+| Componenten met beide lagen        | 50 (alle componenten in `components-html`)                                           |
+| Componenten React-only             | 19 (form-opties en gespecialiseerde inputs waarbij JS-gedrag de HTML-laag domineert) |
+| Componenten met Web Component laag | 7 (button, heading, icon, link, ordered-list, paragraph, unordered-list)             |
+| Manifest-registratie               | `packages/components-html/manifest.json` — platforms-veld per component              |
+| Breaking changes                   | Nee — architectuurkeuze bij aanvang van het project                                  |
+
+---
+
+## Gevolgen
+
+**Wat makkelijker wordt:**
+
+- Een component debuggen: de CSS-klasse is de bron van waarheid, niet de component-output.
+- Theming: CSS custom properties werken in alle lagen identiek — één token-definitie, drie platforms.
+- Web Components toevoegen: de CSS is al klaar, de Web Component schrijft alleen een klassen-assembler.
+- Adoptie door niet-React teams: ze gebruiken `components-html` direct.
+
+**Wat moeilijker wordt:**
+
+- Nieuwe contributors moeten begrijpen dat ze bij een bug in de visuele uitvoer de CSS moeten aanpassen, niet de TSX.
+- De asymmetrie bij form-componenten (geen HTML/CSS counterpart voor Checkbox etc.) is verwarrend als je het patroon niet kent. Dit staat gedocumenteerd in `manifest.json` via het `platforms`-veld.
+
+**Nieuwe verplichting voor contributors:**
+Bij elk nieuw component moeten beide lagen worden uitgewerkt. Een PR met alleen een React-component of alleen een CSS-bestand is incompleet. Dit staat als vaste checklist in `new-component-issue.md`.
+
+---
+
+## Supersedes / superseded by
+
+Niet van toepassing — dit is een initieel besluit.
+
+---
+
+## Gerelateerde records
+
+- DR-2026-01 (button label) — de twee-lagenstructuur is de reden waarom de label-span in HTML bestaat, niet als React-prop
+- DR-2026-03 (breakpoints) — dezelfde reden dat breakpoints als CSS-waarden leven, niet als React-props
+- Zie ook: CLAUDE.md §"Twee-lagen implementatiepatroon: ALTIJD"
+
+---
+
+## Review trigger
+
+Herzie dit besluit als een groot deel van de productteams overschakelt naar een framework waarvan de integratie met plain CSS significant slechter is, of als Web Components voldoende marktpositie hebben om de React-laag als primaire laag te vervangen.

--- a/docs/decisions/DR-2026-03-breakpoints-als-reference-only-tokens.md
+++ b/docs/decisions/DR-2026-03-breakpoints-als-reference-only-tokens.md
@@ -1,0 +1,139 @@
+# DR-2026-03: Breakpoints als reference-only tokens — hardcoded waarden in CSS @media rules
+
+**ID:** DR-2026-03
+**Datum:** Februari 2026
+**Status:** Accepted
+**Auteurs:** Jeffrey Lauwers
+
+---
+
+## Context
+
+Het design system gebruikt design tokens voor alle visuele waarden: kleuren, spacing, typografie, rondingen. De logische volgende stap is breakpoints ook als tokens te definiëren zodat ze op één plek gewijzigd kunnen worden — `dsn.breakpoint.lg` in plaats van `64em` verspreid over CSS-bestanden.
+
+CSS heeft echter een fundamentele beperking: **CSS custom properties (`var()`) werken niet in `@media` query-condities.** De browser evalueert `@media (min-width: var(--dsn-breakpoint-lg))` niet — de query wordt genegeerd als ongeldig.
+
+Dit is geen implementatiefout maar een specificatiebeslissing in CSS: custom properties worden geresolved na cascade-berekening, maar media queries worden geëvalueerd vóór de cascade.
+
+Op het moment van dit besluit waren er 12 CSS-bestanden met `@media`-queries en 4 unieke breakpoint-waarden in gebruik (sm: 36em, md: 44em, lg: 64em, xl: 74em).
+
+---
+
+## Opties overwogen
+
+### Optie 1: Breakpoints helemaal niet tokeniseren
+
+Breakpoints leven als gedocumenteerde conventies in de CSS-naamgevingsdocumentatie, maar bestaan niet als tokens.
+
+**Voordeel:** Eerlijk — er is geen token als de waarde toch niet gebruikt kan worden.
+**Nadeel:** De breakpoint-waarden zijn dan niet machineleesbaar voor tooling, documentatie-generatoren of de manifest. Nieuwe contributors moeten de waarden opzoeken in de CSS-bestanden.
+
+### Optie 2: PostCSS-plugin voor token-substitutie in @media (overwogen, afgewezen)
+
+Een PostCSS-transformatiestap kan `@media (min-width: token(dsn.breakpoint.lg))` tijdens de build omzetten naar `@media (min-width: 64em)`.
+
+**Voordeel:** Broncode gebruikt token-referenties; gecompileerde CSS heeft hardcoded waarden.
+**Nadeel:**
+
+- Introduceert een build-afhankelijkheid voor wat een eenvoudige CSS-feature zou moeten zijn.
+- De `token()`-syntaxis is niet-standaard — tooling, linters en IDE-ondersteuning begrijpen hem niet.
+- Als de PostCSS-stap uitvalt of verandert, breekt de gehele responsieve layout.
+- Het systeem benadrukt al dat de twee-lagenarchitectuur (DR-2026-02) plain CSS ondersteunt zonder extra build-stappen voor HTML-consumers.
+
+### Optie 3: CSS `env()` met media query range syntax (experimenteel)
+
+De CSS Media Queries Level 5 spec introduceert environment variables voor breakpoints. Op dit moment niet breed ondersteund.
+
+**Voordeel:** Standaard-gebaseerd, geen tooling nodig.
+**Nadeel:** Browser-ondersteuning is begin 2026 onvoldoende voor productiegebruik.
+
+### Optie 4: Reference-only tokens — DTCG JSON, hardcoded CSS (gekozen)
+
+Breakpoints bestaan als tokens in `base.json` met een expliciete `$description` die aangeeft dat ze reference-only zijn:
+
+```json
+"breakpoint": {
+  "lg": {
+    "$value": "64em",
+    "$type": "dimension",
+    "$description": "Large breakpoint - ~1024px. Reference only; use hardcoded values in CSS @media rules."
+  }
+}
+```
+
+CSS gebruikt de hardcoded waarden direct:
+
+```css
+@media (min-width: 64em) {
+  /* lg breakpoint styles */
+}
+```
+
+**Voordeel:**
+
+- De breakpoint-waarden zijn machineleesbaar via de tokens (voor tooling, manifest, documentatiegeneratoren).
+- Geen build-afhankelijkheid of niet-standaard syntaxis.
+- CSS-bestanden zijn valide, lintbaar en begrijpelijk zonder kennis van het tokensysteem.
+- De `$description` is expliciet — er is geen verborgen reden waarom tokens hier niet werken.
+
+**Nadeel:**
+
+- Wijzigen van een breakpoint vereist aanpassingen op twee plaatsen: het token én alle CSS-bestanden. Dit is de bewuste trade-off.
+- Er is geen automatische manier om de consistentie te controleren (een token-waarde van 64em die afwijkt van een hardcoded 64em in CSS is een stille inconsistentie).
+
+---
+
+## Beslissing
+
+**Breakpoints worden gedefinieerd als reference-only tokens in `base.json`. CSS-bestanden gebruiken hardcoded `em`-waarden in `@media`-queries. De `$description` van elk breakpoint-token documenteert expliciet dat `var()` niet werkt in media queries.**
+
+De reden is dat de alternatieve aanpakken (PostCSS, experimentele CSS-features) meer complexiteit introduceren dan ze oplossen voor een systeem dat plain CSS ondersteunt. Reference-only tokens bieden machineleesbare documentatie van de breakpoint-waarden zonder build-tooling te vereisen.
+
+De trade-off die we accepteren: de token-waarden en de CSS-waarden kunnen handmatig uit de pas lopen bij een breakpoint-wijziging. Dit risico is beheersbaar omdat (a) breakpoints zelden wijzigen, (b) er slechts 4 unieke waarden zijn verspreid over 12 bestanden, en (c) een eenvoudige `grep` de afwijkingen vindt.
+
+---
+
+## Impact
+
+| Dimension                            | Meting                       |
+| ------------------------------------ | ---------------------------- |
+| CSS-bestanden met @media queries     | 12                           |
+| Unieke breakpoint-waarden in gebruik | 4 (36em, 44em, 64em, 74em)   |
+| Token-bestanden geraakt              | 1 (`themes/start/base.json`) |
+| Build-stappen toegevoegd             | 0                            |
+| Breaking changes                     | Nee                          |
+
+---
+
+## Gevolgen
+
+**Wat makkelijker wordt:**
+
+- CSS-bestanden zijn valide standaard-CSS zonder kennis van het tokensysteem.
+- De breakpoint-waarden zijn gedocumenteerd en vindbaar via `base.json`.
+- HTML-consumers van `@dsn-starter-kit/components-html` hebben geen build-pipeline nodig.
+
+**Wat moeilijker wordt:**
+
+- Een breakpoint-wijziging vereist aanpassing in `base.json` én in alle betrokken CSS-bestanden. Er is geen automatische synchronisatie.
+- De inconsistentie tussen "we tokeniseren alles" en "behalve in @media" is verwarrend voor contributors die het "waarom" niet kennen. Dit is de primaire reden voor dit decision record.
+
+**Nieuwe verplichting voor contributors:**
+Bij een breakpoint-aanpassing altijd beide plaatsen bijwerken: (1) de `$value` in `base.json`, en (2) alle hardcoded waarden in CSS-bestanden. De juiste waarden zijn documentatie, niet bron van waarheid voor de build.
+
+---
+
+## Supersedes / superseded by
+
+Herzie dit besluit wanneer:
+
+- CSS environment variables voor media queries brede browser-ondersteuning bereiken (dan: migreer naar native standaard)
+- De CSS Houdini custom media spec stabiel is in alle major browsers
+
+---
+
+## Gerelateerde records
+
+- DR-2026-02 (twee-lagenpatroon) — plain CSS zonder build-dependencies is een expliciete architectuurdoelstelling
+- Zie ook: CLAUDE.md §2 "Tokens: nooit hardcoded waarden in CSS" — breakpoints zijn de gedocumenteerde uitzondering op deze regel
+- Zie ook: `docs/02-design-tokens-reference.md` voor de volledige tokenlijst inclusief breakpoints

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,21 @@
+# Decision Records
+
+Architectuurkeuzes voor het Design System Starter Kit.
+
+Een decision record documenteert **waarom** iets is zoals het is — niet alleen wat er is beslist, maar welke alternatieven zijn overwogen en welke trade-offs bewust zijn gemaakt. Lees deze records als je je afvraagt: "waarom doen we het zo?"
+
+## Index
+
+| ID                                                                | Besluit                                                              | Status   |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------- | -------- |
+| [DR-2026-01](DR-2026-01-button-label-span-over-aria-label.md)     | `dsn-button__label` span in plaats van `aria-label` op buttons       | Accepted |
+| [DR-2026-02](DR-2026-02-twee-lagenpatroon-html-css-plus-react.md) | HTML/CSS als bron van waarheid, React als wrapper                    | Accepted |
+| [DR-2026-03](DR-2026-03-breakpoints-als-reference-only-tokens.md) | Breakpoints als reference-only tokens, hardcoded in CSS @media rules | Accepted |
+
+## Een nieuw record toevoegen
+
+Gebruik de `/decision-record` skill in Claude Code, of kopieer de structuur van een bestaand record.
+
+Bestandsnaamconventie: `DR-{JAAR}-{VOLGNUMMER}-{korte-beschrijving}.md`
+
+Wanneer een record aanmaken? Als je je afvraagt: "Als ik dit over 12 maanden teruglees, snap ik dan nog waarom we dit zo hebben gedaan?" — zo niet, schrijf het op.


### PR DESCRIPTION
## Summary

Introduceert `docs/decisions/` met drie decision records voor de meest load-bearing architectuurkeuzes — de beslissingen die nieuwe contributors het meest zullen bevragen.

- **DR-2026-01** — `dsn-button__label` span in plaats van `aria-label`: `aria-label` wordt niet vertaald door browser-vertaaltools; een DOM-tekst-node wel
- **DR-2026-02** — Twee-lagenpatroon HTML/CSS + React: HTML/CSS is de bron van waarheid, React is een dunne klassen-assembler voor portabiliteit en framework-onafhankelijkheid
- **DR-2026-03** — Breakpoints als reference-only tokens: CSS custom properties werken niet in `@media`-condities; PostCSS zou een build-afhankelijkheid introduceren die niet past bij een plain CSS-systeem

Elke record bevat: context, overwogen alternatieven, beslissing met trade-offs, impact, gevolgen en een review trigger.

## Test plan

- [x] Drie records aangemaakt in `docs/decisions/`
- [x] README met index toegevoegd
- [x] Lint schoon

🤖 Generated with [Claude Code](https://claude.com/claude-code)