### PR TITLE
docs: voeg formulierpatronen richtlijnen toe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,11 @@ Het bevat de projectregels, architectuurpatronen en navigatiekaart naar de volle
 | Hoe werken CSS-klassen en token-namen?             | `docs/06-css-naming-conventions.md`  |
 | Hoe werkt Storybook?                               | `docs/05-storybook-configuration.md` |
 | Wat is er recent veranderd?                        | `docs/changelog.md`                  |
+| Hoe werken formulierflows en -patronen?            | `docs/07-form-flow-patterns.md`      |
 
 **Voor een nieuw component:** lees altijd `docs/06-css-naming-conventions.md` en `docs/03-components.md` eerst.
+
+**Bij een formulierflow-opdracht (URL, prompt of schets):** lees altijd `docs/07-form-flow-patterns.md` eerst.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A production-ready, white-label design system starter kit built with design tokens, web components, React components, and comprehensive documentation.
 
+**New here?** Start with the [Getting Started guide](./docs/00-getting-started.md) — it walks you from install to first component in under five minutes. The rest of this file is a reference for contributors and maintainers.
+
 ## Packages
 
 This monorepo contains the following packages:

--- a/docs/00-getting-started.md
+++ b/docs/00-getting-started.md
@@ -1,0 +1,175 @@
+# Getting started
+
+This guide takes you from zero to a working component in under five minutes. It covers installation, CSS setup, a first component, theming, and where to go next.
+
+---
+
+## 1. Install
+
+Install the component library and core styles from npm:
+
+```bash
+npm install @dsn-starter-kit/components-react @dsn-starter-kit/core
+# or
+pnpm add @dsn-starter-kit/components-react @dsn-starter-kit/core
+```
+
+`@dsn-starter-kit/core` provides the design tokens (as CSS custom properties) and a CSS reset. `@dsn-starter-kit/components-react` provides the React components and their styles.
+
+---
+
+## 2. Import the CSS
+
+Import both CSS files once in your application entry point — before any component imports.
+
+**Vite / plain React:**
+
+```tsx
+// main.tsx
+import '@dsn-starter-kit/core/css';
+import '@dsn-starter-kit/components-react/css';
+```
+
+**Next.js (App Router):**
+
+```tsx
+// app/layout.tsx
+import '@dsn-starter-kit/core/css';
+import '@dsn-starter-kit/components-react/css';
+```
+
+**Next.js (Pages Router):**
+
+```tsx
+// pages/_app.tsx
+import '@dsn-starter-kit/core/css';
+import '@dsn-starter-kit/components-react/css';
+```
+
+The order matters: core first (tokens), then components (which reference those tokens).
+
+---
+
+## 3. Use your first component
+
+```tsx
+import {
+  Stack,
+  Heading,
+  Paragraph,
+  Button,
+} from '@dsn-starter-kit/components-react';
+
+export function MyPage() {
+  return (
+    <Stack space="lg">
+      <Heading level={1}>Hello, design system</Heading>
+      <Paragraph>You are up and running.</Paragraph>
+      <Button variant="strong" onClick={() => alert('clicked')}>
+        Get started
+      </Button>
+    </Stack>
+  );
+}
+```
+
+That is all you need. No additional configuration, no theme provider, no CSS module setup.
+
+---
+
+## 4. Theming
+
+The system ships with two themes: **Start** (blue accent) and **Wireframe** (monochrome). Light and dark modes are both included.
+
+Apply a theme by adding a class to your root element:
+
+```html
+<!-- Start theme, light mode (default) -->
+<body class="dsn-theme-start">
+  ...
+</body>
+
+<!-- Start theme, dark mode -->
+<body class="dsn-theme-start dsn-theme-start--dark">
+  ...
+</body>
+
+<!-- Wireframe theme, light mode -->
+<body class="dsn-theme-wireframe">
+  ...
+</body>
+```
+
+The theme class can be set on any container, not just `<body>` — useful for side-by-side theme previews.
+
+To toggle dark mode at runtime:
+
+```tsx
+document.body.classList.toggle('dsn-theme-start--dark');
+```
+
+---
+
+## 5. HTML/CSS (no framework)
+
+All components are available as plain CSS classes if you are not using React:
+
+```bash
+npm install @dsn-starter-kit/components-html @dsn-starter-kit/core
+```
+
+```html
+<link
+  rel="stylesheet"
+  href="node_modules/@dsn-starter-kit/core/dist/core.css"
+/>
+<link
+  rel="stylesheet"
+  href="node_modules/@dsn-starter-kit/components-html/dist/components.css"
+/>
+
+<div class="dsn-stack dsn-stack--space-lg">
+  <h1 class="dsn-heading dsn-heading--level-1">Hello, design system</h1>
+  <p class="dsn-paragraph">You are up and running.</p>
+  <button type="button" class="dsn-button dsn-button--strong">
+    <span class="dsn-button__label">Get started</span>
+  </button>
+</div>
+```
+
+A machine-readable index of all components and their CSS classes is available at:
+
+```bash
+import manifest from '@dsn-starter-kit/components-html/manifest';
+```
+
+---
+
+## 6. Web Components
+
+A subset of components is available as framework-agnostic Web Components:
+
+```bash
+npm install @dsn-starter-kit/components-web @dsn-starter-kit/core
+```
+
+```html
+<script
+  type="module"
+  src="node_modules/@dsn-starter-kit/components-web/dist/index.js"
+></script>
+
+<dsn-button variant="strong">Get started</dsn-button>
+<dsn-heading level="1">Hello, design system</dsn-heading>
+```
+
+Available Web Components: `Button`, `Heading`, `Icon`, `Link`, `OrderedList`, `Paragraph`, `UnorderedList`.
+
+---
+
+## Where to go next
+
+- **[Live Storybook](https://jeffreylauwers.github.io/design-system-starter-kit/)** — browse all 71 components with interactive examples and usage guidelines
+- **[Design Tokens Reference](./02-design-tokens-reference.md)** — all token values, scales, and how to use them in your own CSS
+- **[Components Reference](./03-components.md)** — component API specifications
+- **[Contributing](../CONTRIBUTING.md)** — how to add or change components

--- a/docs/07-form-flow-patterns.md
+++ b/docs/07-form-flow-patterns.md
@@ -1,0 +1,379 @@
+# Formulierpatronen
+
+Richtlijnen voor het ontwerpen en uitwerken van formulierflows.
+
+---
+
+## Enkelvoudig vs meerstappenformulier
+
+Gebruik een **enkelvoudig formulier** (één pagina) als:
+
+- Het formulier weinig velden heeft
+- Het geen gevoelige informatie betreft of een gevoelig onderwerp
+- Groepering in stappen geen meerwaarde heeft
+
+Bij een enkelvoudig formulier:
+
+- Geen introductiepagina
+- Geen reviewpagina: na submit direct naar de bevestigingspagina
+- Voorbeelden: zoekfilter, simpele aanmelding, voorkeurinstellingen
+
+Gebruik een **meerstappenformulier** zodra het formulier substantieel is, gevoelige informatie bevat, of de gebruiker er baat bij heeft om stap voor stap begeleid te worden.
+
+---
+
+## Flow structuur meerstappenformulier
+
+```
+Introductiepagina (optioneel, zie richtlijn)
+  ↓
+Formulierstap 1
+  ↓
+Formulierstap 2
+  ↓  (...)
+Reviewpagina
+  ↓
+Bevestigingspagina
+```
+
+---
+
+## Introductiepagina
+
+Gebruik een introductiepagina:
+
+- Bij formulieren met meer dan 3 stappen, zodat de gebruiker weet wat er komen gaat
+- Als de gebruiker iets moet voorbereiden om het formulier in te kunnen vullen (denk aan documenten, referentienummers, inloggegevens)
+
+Bij twijfel: voeg de introductiepagina toe. Het is vrijwel altijd een verbetering.
+
+**Wat staat er op de introductiepagina:**
+
+- Een korte introductie van het formulier
+- Wat de gebruiker nodig heeft om het formulier in te vullen
+- De stappen die doorlopen worden, bij naam. Bijvoorbeeld: "Dit formulier bestaat uit de volgende stappen: X, Y, Z en het controleren van de ingevulde informatie."
+- Dat niet-verplichte velden worden aangegeven
+- Of het formulier tussendoor opgeslagen kan worden
+- Wat er na het versturen gebeurt (bevestigingsmail, downloadoptie)
+
+**Knop op introductiepagina:** "Doorgaan" (`ButtonLink` variant="strong")
+
+Zie ook het template **Introduction page** in Storybook.
+
+---
+
+## Formulierstappen
+
+### Indeling van stappen
+
+Groepeer gerelateerde vragen samen op één stap. Als een logische groepering moeilijk te maken is en het formulier daardoor niet te lang wordt, mag één vraag per stap ook.
+
+Gebruik voor elke stap:
+
+- `Heading` level 1 voor de **titel van het formulier** (consistent op elke stap)
+- `<h2>` voor de **titel van de stap**
+- `Paragraph` als instructietekst: "Vul alles in. Als iets niet verplicht is, staat dat erbij."
+- `<form noValidate>` met `Stack space="3xl"` voor de velden
+- Navigatielink "Vorige stap" (`Link` met `arrow-left` icoon) boven de titel van de stap
+
+### Niet-verplichte velden
+
+Ga er vanuit dat een formulier alleen de broodnodige velden bevat. De meeste velden zijn daardoor verplicht. Niet-verplichte velden zijn de uitzondering: markeer ze door de tekst "(niet verplicht)" op te nemen als `labelSuffix` op `FormField` of `FormFieldset`.
+
+```tsx
+<FormField
+  label="Tussenvoegsel"
+  htmlFor="tussenvoegsel"
+  labelSuffix="(niet verplicht)"
+>
+  <TextInput id="tussenvoegsel" width="xs" />
+</FormField>
+```
+
+### ActionGroup per stap
+
+```tsx
+<ActionGroup
+  direction="vertical"
+  style={{ marginBlockStart: 'var(--dsn-space-block-3xl)' }}
+>
+  <Button variant="strong" type="submit">
+    Volgende stap
+  </Button>
+  <LinkButton onClick={() => setActiveModal('save')}>
+    Opslaan en later verder
+  </LinkButton>
+  <LinkButton onClick={() => setActiveModal('stop')}>
+    Stoppen met het formulier
+  </LinkButton>
+</ActionGroup>
+```
+
+"Opslaan en later verder" en "Stoppen met het formulier" openen elk een `ModalDialog` ter bevestiging.
+
+Zie ook de templates **Form step: Simple details** en **Form step: Extended details** in Storybook.
+
+### Voortgang tonen
+
+Standaard: toon geen voortgangsindicator. Voeg er een toe alleen als gebruikersonderzoek aantoont dat gebruikers hier behoefte aan hebben.
+
+---
+
+## Formuliercontroles kiezen
+
+### RadioGroup vs Select
+
+- Gebruik **`RadioGroup`** bij 12 opties of minder
+- Gebruik **`RadioGroup`** als de stap puur bestaat uit een keuzelijst, ongeacht het aantal opties: toon alle opties direct en gebruik nooit een `Select`
+- Gebruik **`Select`** alleen als er meer dan 12 opties zijn én de keuze onderdeel is van een bredere stap met meer velden
+
+### Checkbox
+
+- Checkboxen komen vrijwel altijd in een **`CheckboxGroup`**
+- Een alleenstaande `Checkbox` is bedoeld voor het akkoord gaan met iets (bijv. voorwaarden)
+- Zet **nooit een link in het label** van een checkbox of radiobutton. Zet de link vóór de checkbox:
+
+```tsx
+{/* ✅ Link vóór de checkbox */}
+<Link href="/voorwaarden">Bekijk de voorwaarden</Link>
+<CheckboxOption id="akkoord" name="akkoord" label="Ik ga akkoord met de voorwaarden" />
+
+{/* ❌ Link ín het label */}
+<CheckboxOption label={<>Ik ga akkoord met de <Link href="/voorwaarden">voorwaarden</Link></>} />
+```
+
+### Datum uitvragen
+
+Kies op basis van de situatie:
+
+| Situatie                                                                 | Gebruik                                                                      |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| Datum die men uit het hoofd weet (geboortedatum, vervaldatum creditcard) | `DateInputGroup`                                                             |
+| Keuze uit een beperkt aantal aanstaande datums                           | `RadioGroup` met labels zoals "morgen", "overmorgen", "maandag 22 juni 2026" |
+| Datum die verderweg in de toekomst kan liggen, of vrije datumkeuze       | `DateInput`                                                                  |
+
+Gebruik `DateInputGroup` altijd voor data die men kent of kan opzoeken. Gebruik `DateInput` wanneer de gebruiker een datum moet kiezen en de precieze datum niet van tevoren kent.
+
+### Veldbreedte
+
+De breedte van een invulveld communiceert de verwachte invoerlengte. Beschikbare breedtes: `xs`, `sm`, `md`, `lg`, `xl`, `full` (default).
+
+| Invulveld                   | Breedte          |
+| --------------------------- | ---------------- |
+| Huisnummer, postcode, getal | `xs`             |
+| Tussenvoegsel, toevoeging   | `xs`             |
+| Telefoonnummer              | `md`             |
+| Straat, woonplaats          | `xl`             |
+| E-mailadres                 | `xl`             |
+| Naam, achternaam            | `full` (default) |
+| Tekstvlak (`TextArea`)      | `full` (default) |
+
+---
+
+## Validatie
+
+### Wanneer valideren
+
+Valideer bij **submit**, niet on-blur en niet tijdens het typen.
+
+Gebruik `noValidate` op het `<form>`-element om browser-validatie uit te schakelen:
+
+```tsx
+<form noValidate>
+```
+
+### Forgiving validatie
+
+Verwijder onnodige spaties aan de achterkant stil (trimmen). Leg die verantwoordelijkheid niet bij de gebruiker.
+
+### Foutmelding structuur
+
+Bij één of meer fouten na submit:
+
+1. Pas de **paginatitel** (`<title>`) aan zodat het aantal fouten daarin vermeld staat. Schermlezers lezen de titel voor bij het inladen van de pagina. Gebruik het formaat: `{n} foutmeldingen - {Titel van de stap} - {Naam van de organisatie}`. Voorbeeld: `2 foutmeldingen - Uw gegevens - Gemeente Voorbeeld`.
+2. Toon een **`Alert` variant="negative"** direct boven de titel van de stap (`<h2>`)
+3. Toon een **inline foutmelding** bij elk veld via de `error` prop op `FormField` of `FormFieldset`
+4. De tekst in de `Alert` en bij het veld is **identiek**
+5. In de `Alert` zijn de foutmeldingen ankerlinkjes die naar het betreffende veld springen
+
+**Eén fout:**
+
+```tsx
+<Alert variant="negative" heading="Er is een foutmelding">
+  <Link href="#veld-id">Foutmeldingstekst</Link>
+</Alert>
+```
+
+**Meerdere fouten:**
+
+```tsx
+<Alert variant="negative" heading="Er zijn 3 foutmeldingen">
+  <UnorderedList>
+    <li>
+      <Link href="#veld-id-1">Foutmeldingstekst 1</Link>
+    </li>
+    <li>
+      <Link href="#veld-id-2">Foutmeldingstekst 2</Link>
+    </li>
+    <li>
+      <Link href="#veld-id-3">Foutmeldingstekst 3</Link>
+    </li>
+  </UnorderedList>
+</Alert>
+```
+
+Zie ook het template **Form step: Extended details** in Storybook voor een werkend voorbeeld met één en meerdere fouten.
+
+---
+
+## Foutmeldingsteksten
+
+### Verplicht veld niet ingevuld
+
+```
+Vul een {onderwerp} in.
+```
+
+Voorbeelden:
+
+- "Vul een e-mailadres in."
+- "Vul een voornaam in."
+- "Vul een KVK-nummer in."
+
+### Ingevuld maar ongeldig (minimaal)
+
+```
+Ingevulde {onderwerp} is niet toegestaan.
+```
+
+Gebruik dit als er geen specifieke reden of goed voorbeeld te geven is.
+
+Voorbeelden:
+
+- "Ingevulde e-mailadres is niet toegestaan."
+- "Ingevulde voornaam is niet toegestaan."
+
+### Ingevuld maar ongeldig + reden
+
+```
+Ingevulde {onderwerp} is niet toegestaan. {Reden}.
+```
+
+Voorbeelden:
+
+- "Ingevulde e-mailadres is niet toegestaan. Er mist een @."
+- "Ingevulde voornaam is niet toegestaan. Gebruik alleen letters."
+- "Ingevulde KVK-nummer is niet toegestaan. Gebruik alleen cijfers."
+- "Ingevulde datum is niet toegestaan. De datum moet in de toekomst liggen."
+
+### Ingevuld maar ongeldig + goed voorbeeld
+
+Gebruik dit als het formaat bepalend is én er nog geen voorbeeld als `FormFieldDescription` staat.
+
+```
+Ingevulde {onderwerp} is niet toegestaan. Vul een {onderwerp} in, zoals {voorbeeld}.
+```
+
+Voorbeelden:
+
+- "Ingevulde e-mailadres is niet toegestaan. Vul een e-mailadres in, zoals naam@emailadres.nl."
+- "Ingevulde postcode is niet toegestaan. Vul een Nederlandse postcode in, zoals 1234AB."
+
+Als het goede voorbeeld al als `FormFieldDescription` bij het veld staat: herhaal het niet in de foutmelding.
+
+### Patronen per type fout
+
+| Fouttype            | Patroon                                                           |
+| ------------------- | ----------------------------------------------------------------- |
+| Leeg verplicht veld | "Vul een {onderwerp} in."                                         |
+| Te lang             | "{Onderwerp} moet {aantal} tekens of minder zijn."                |
+| Te kort             | "{Onderwerp} moet {aantal} tekens of meer zijn."                  |
+| Ongeldige tekens    | "{Onderwerp} mag geen {karakter} bevatten."                       |
+| Ongeldig formaat    | "Ingevulde {onderwerp} is niet toegestaan. {reden of voorbeeld}." |
+
+### Patronen per inputtype
+
+| Inputtype                       | Patroon leeg veld                                                                   |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| `TextInput`, `EmailInput`, etc. | "Vul een {onderwerp} in."                                                           |
+| `CheckboxGroup`                 | "Kies een of meer {opties}."                                                        |
+| `RadioGroup`                    | "Kies een {onderwerp}."                                                             |
+| `Select`                        | "Kies een {onderwerp}."                                                             |
+| `FileInput`                     | "Het gekozen bestand is te groot." / "Het gekozen bestandstype is niet toegestaan." |
+
+### Schrijfregels voor foutmeldingen
+
+- Geen "uw": de gegevens zijn niet altijd van de persoon die het formulier invult
+- Geen "geldig" of "correct": niet eenvoudig taalgebruik en legt de schuld bij de gebruiker
+- Geen "selecteer": gebruik altijd "kies"
+- Geen lidwoord voor "ingevulde": schrijf "Ingevulde {onderwerp}...", niet "De/Het ingevulde {onderwerp}..."
+- Zet een punt aan het eind van elke foutmelding: dit geeft een pauze voor schermlezers
+- Schrijf foutmeldingen zo dat ze ook als opsomming in de foutmelding-samenvatting bovenaan het formulier werken
+
+---
+
+## Reviewpagina
+
+De reviewpagina toont alle ingevulde gegevens, gegroepeerd per stap.
+
+**Structuur per stap:**
+
+1. `<h3>` met de titel van de stap
+2. `Link` met "Wijzig" + visueel verborgen contexttekst (bijv. `<span className="dsn-visually-hidden"> Uw gegevens</span>`) en `pencil`-icoon
+3. `SummaryList` met de ingevulde waarden
+
+**ActionGroup onderaan de reviewpagina:**
+
+```tsx
+<ActionGroup
+  direction="vertical"
+  style={{ marginBlockStart: 'var(--dsn-space-block-3xl)' }}
+>
+  <Button variant="strong-positive" type="submit">
+    Versturen
+  </Button>
+  <LinkButton>Opslaan en later verder</LinkButton>
+  <LinkButton>Stoppen met het formulier</LinkButton>
+</ActionGroup>
+```
+
+Zie ook het template **Review page** in Storybook.
+
+---
+
+## Aanpassen vanuit de reviewpagina
+
+Als de gebruiker op "Wijzig" klikt bij een stap op de reviewpagina:
+
+1. De gebruiker gaat naar de bewuste formulierstap, met de al ingevulde gegevens pre-filled
+2. Dit is een uitstapje vanuit de reviewpagina: geen stap in de reguliere flow
+3. De pagina toont een navigatielink "Terug" (niet "Vorige stap") linksboven
+4. De ActionGroup op deze pagina heeft:
+   - "Opslaan en terug" als primaire knop (`Button` variant="strong")
+   - "Annuleren" als secundaire knop (`Button` variant="default")
+5. Na "Opslaan en terug" keert de gebruiker terug naar de reviewpagina
+
+Zie ook het template **Form step: Edit from review** in Storybook.
+
+---
+
+## Bevestigingspagina
+
+**Structuur:**
+
+1. `Note variant="positive"` als eerste element:
+   - Heading: "{Onderwerp} is verstuurd"
+   - Body: kenmerk of referentienummer
+
+2. Sectie "Dit gaat er nu gebeuren":
+   - `<h2>` met de sectietitel
+   - `UnorderedList` met wat de gebruiker kan verwachten (tijdsindicaties, vervolgstappen)
+
+3. `ActionGroup` met vervolgacties:
+   - Print-link (`Link` met `printer`-icoon)
+   - Download als PDF-link (`Link` met `download`-icoon)
+   - Terug naar website-link
+
+De bevestigingspagina is de plek om de relatie met de gebruiker te beginnen: geef duidelijkheid over wat er nu gaat gebeuren en hoe men de voortgang kan volgen.
+
+Zie ook het template **Confirmation page** in Storybook.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,12 @@ Complete documentation voor het Design System Starter Kit.
 
 ### Core Documentation
 
+0. **[Getting Started](./00-getting-started.md)**
+   - Install from npm
+   - CSS setup per framework (Vite, Next.js)
+   - First component example
+   - Theming and dark mode
+
 1. **[Architecture](./01-architecture.md)**
    - Token architecture (3-tier structure)
    - Three-axis configuration model (Theme × Mode × Project Type)
@@ -71,7 +77,7 @@ Complete documentation voor het Design System Starter Kit.
 
 ### New to this Design System?
 
-1. Start with the **[Main README](../README.md)** for installation
+1. Start with **[Getting Started](./00-getting-started.md)** — install to first component in 5 minutes
 2. Read **[Architecture](./01-architecture.md)** to understand the token system
 3. Browse **[Components](./03-components.md)** to see what's available
 4. Check **[Development Workflow](./04-development-workflow.md)** for contribution guidelines

--- a/packages/storybook/src/FormFlowPatterns.docs.md
+++ b/packages/storybook/src/FormFlowPatterns.docs.md
@@ -1,0 +1,379 @@
+# Formulierpatronen
+
+Richtlijnen voor het ontwerpen en uitwerken van formulierflows.
+
+---
+
+## Enkelvoudig vs meerstappenformulier
+
+Gebruik een **enkelvoudig formulier** (één pagina) als:
+
+- Het formulier weinig velden heeft
+- Het geen gevoelige informatie betreft of een gevoelig onderwerp
+- Groepering in stappen geen meerwaarde heeft
+
+Bij een enkelvoudig formulier:
+
+- Geen introductiepagina
+- Geen reviewpagina: na submit direct naar de bevestigingspagina
+- Voorbeelden: zoekfilter, simpele aanmelding, voorkeurinstellingen
+
+Gebruik een **meerstappenformulier** zodra het formulier substantieel is, gevoelige informatie bevat, of de gebruiker er baat bij heeft om stap voor stap begeleid te worden.
+
+---
+
+## Flow structuur meerstappenformulier
+
+```
+Introductiepagina (optioneel, zie richtlijn)
+  ↓
+Formulierstap 1
+  ↓
+Formulierstap 2
+  ↓  (...)
+Reviewpagina
+  ↓
+Bevestigingspagina
+```
+
+---
+
+## Introductiepagina
+
+Gebruik een introductiepagina:
+
+- Bij formulieren met meer dan 3 stappen, zodat de gebruiker weet wat er komen gaat
+- Als de gebruiker iets moet voorbereiden om het formulier in te kunnen vullen (denk aan documenten, referentienummers, inloggegevens)
+
+Bij twijfel: voeg de introductiepagina toe. Het is vrijwel altijd een verbetering.
+
+**Wat staat er op de introductiepagina:**
+
+- Een korte introductie van het formulier
+- Wat de gebruiker nodig heeft om het formulier in te vullen
+- De stappen die doorlopen worden, bij naam. Bijvoorbeeld: "Dit formulier bestaat uit de volgende stappen: X, Y, Z en het controleren van de ingevulde informatie."
+- Dat niet-verplichte velden worden aangegeven
+- Of het formulier tussendoor opgeslagen kan worden
+- Wat er na het versturen gebeurt (bevestigingsmail, downloadoptie)
+
+**Knop op introductiepagina:** "Doorgaan" (`ButtonLink` variant="strong")
+
+Zie ook het template **Introduction page** in Storybook.
+
+---
+
+## Formulierstappen
+
+### Indeling van stappen
+
+Groepeer gerelateerde vragen samen op één stap. Als een logische groepering moeilijk te maken is en het formulier daardoor niet te lang wordt, mag één vraag per stap ook.
+
+Gebruik voor elke stap:
+
+- `Heading` level 1 voor de **titel van het formulier** (consistent op elke stap)
+- `<h2>` voor de **titel van de stap**
+- `Paragraph` als instructietekst: "Vul alles in. Als iets niet verplicht is, staat dat erbij."
+- `<form noValidate>` met `Stack space="3xl"` voor de velden
+- Navigatielink "Vorige stap" (`Link` met `arrow-left` icoon) boven de titel van de stap
+
+### Niet-verplichte velden
+
+Ga er vanuit dat een formulier alleen de broodnodige velden bevat. De meeste velden zijn daardoor verplicht. Niet-verplichte velden zijn de uitzondering: markeer ze door de tekst "(niet verplicht)" op te nemen als `labelSuffix` op `FormField` of `FormFieldset`.
+
+```tsx
+<FormField
+  label="Tussenvoegsel"
+  htmlFor="tussenvoegsel"
+  labelSuffix="(niet verplicht)"
+>
+  <TextInput id="tussenvoegsel" width="xs" />
+</FormField>
+```
+
+### ActionGroup per stap
+
+```tsx
+<ActionGroup
+  direction="vertical"
+  style={{ marginBlockStart: 'var(--dsn-space-block-3xl)' }}
+>
+  <Button variant="strong" type="submit">
+    Volgende stap
+  </Button>
+  <LinkButton onClick={() => setActiveModal('save')}>
+    Opslaan en later verder
+  </LinkButton>
+  <LinkButton onClick={() => setActiveModal('stop')}>
+    Stoppen met het formulier
+  </LinkButton>
+</ActionGroup>
+```
+
+"Opslaan en later verder" en "Stoppen met het formulier" openen elk een `ModalDialog` ter bevestiging.
+
+Zie ook de templates **Form step: Simple details** en **Form step: Extended details** in Storybook.
+
+### Voortgang tonen
+
+Standaard: toon geen voortgangsindicator. Voeg er een toe alleen als gebruikersonderzoek aantoont dat gebruikers hier behoefte aan hebben.
+
+---
+
+## Formuliercontroles kiezen
+
+### RadioGroup vs Select
+
+- Gebruik **`RadioGroup`** bij 12 opties of minder
+- Gebruik **`RadioGroup`** als de stap puur bestaat uit een keuzelijst, ongeacht het aantal opties: toon alle opties direct en gebruik nooit een `Select`
+- Gebruik **`Select`** alleen als er meer dan 12 opties zijn én de keuze onderdeel is van een bredere stap met meer velden
+
+### Checkbox
+
+- Checkboxen komen vrijwel altijd in een **`CheckboxGroup`**
+- Een alleenstaande `Checkbox` is bedoeld voor het akkoord gaan met iets (bijv. voorwaarden)
+- Zet **nooit een link in het label** van een checkbox of radiobutton. Zet de link vóór de checkbox:
+
+```tsx
+{/* ✅ Link vóór de checkbox */}
+<Link href="/voorwaarden">Bekijk de voorwaarden</Link>
+<CheckboxOption id="akkoord" name="akkoord" label="Ik ga akkoord met de voorwaarden" />
+
+{/* ❌ Link ín het label */}
+<CheckboxOption label={<>Ik ga akkoord met de <Link href="/voorwaarden">voorwaarden</Link></>} />
+```
+
+### Datum uitvragen
+
+Kies op basis van de situatie:
+
+| Situatie                                                                 | Gebruik                                                                      |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| Datum die men uit het hoofd weet (geboortedatum, vervaldatum creditcard) | `DateInputGroup`                                                             |
+| Keuze uit een beperkt aantal aanstaande datums                           | `RadioGroup` met labels zoals "morgen", "overmorgen", "maandag 22 juni 2026" |
+| Datum die verderweg in de toekomst kan liggen, of vrije datumkeuze       | `DateInput`                                                                  |
+
+Gebruik `DateInputGroup` altijd voor data die men kent of kan opzoeken. Gebruik `DateInput` wanneer de gebruiker een datum moet kiezen en de precieze datum niet van tevoren kent.
+
+### Veldbreedte
+
+De breedte van een invulveld communiceert de verwachte invoerlengte. Beschikbare breedtes: `xs`, `sm`, `md`, `lg`, `xl`, `full` (default).
+
+| Invulveld                   | Breedte          |
+| --------------------------- | ---------------- |
+| Huisnummer, postcode, getal | `xs`             |
+| Tussenvoegsel, toevoeging   | `xs`             |
+| Telefoonnummer              | `md`             |
+| Straat, woonplaats          | `xl`             |
+| E-mailadres                 | `xl`             |
+| Naam, achternaam            | `full` (default) |
+| Tekstvlak (`TextArea`)      | `full` (default) |
+
+---
+
+## Validatie
+
+### Wanneer valideren
+
+Valideer bij **submit**, niet on-blur en niet tijdens het typen.
+
+Gebruik `noValidate` op het `<form>`-element om browser-validatie uit te schakelen:
+
+```tsx
+<form noValidate>
+```
+
+### Forgiving validatie
+
+Verwijder onnodige spaties aan de achterkant stil (trimmen). Leg die verantwoordelijkheid niet bij de gebruiker.
+
+### Foutmelding structuur
+
+Bij één of meer fouten na submit:
+
+1. Pas de **paginatitel** (`<title>`) aan zodat het aantal fouten daarin vermeld staat. Schermlezers lezen de titel voor bij het inladen van de pagina. Gebruik het formaat: `{n} foutmeldingen - {Titel van de stap} - {Naam van de organisatie}`. Voorbeeld: `2 foutmeldingen - Uw gegevens - Gemeente Voorbeeld`.
+2. Toon een **`Alert` variant="negative"** direct boven de titel van de stap (`<h2>`)
+3. Toon een **inline foutmelding** bij elk veld via de `error` prop op `FormField` of `FormFieldset`
+4. De tekst in de `Alert` en bij het veld is **identiek**
+5. In de `Alert` zijn de foutmeldingen ankerlinkjes die naar het betreffende veld springen
+
+**Eén fout:**
+
+```tsx
+<Alert variant="negative" heading="Er is een foutmelding">
+  <Link href="#veld-id">Foutmeldingstekst</Link>
+</Alert>
+```
+
+**Meerdere fouten:**
+
+```tsx
+<Alert variant="negative" heading="Er zijn 3 foutmeldingen">
+  <UnorderedList>
+    <li>
+      <Link href="#veld-id-1">Foutmeldingstekst 1</Link>
+    </li>
+    <li>
+      <Link href="#veld-id-2">Foutmeldingstekst 2</Link>
+    </li>
+    <li>
+      <Link href="#veld-id-3">Foutmeldingstekst 3</Link>
+    </li>
+  </UnorderedList>
+</Alert>
+```
+
+Zie ook het template **Form step: Extended details** in Storybook voor een werkend voorbeeld met één en meerdere fouten.
+
+---
+
+## Foutmeldingsteksten
+
+### Verplicht veld niet ingevuld
+
+```
+Vul een {onderwerp} in.
+```
+
+Voorbeelden:
+
+- "Vul een e-mailadres in."
+- "Vul een voornaam in."
+- "Vul een KVK-nummer in."
+
+### Ingevuld maar ongeldig (minimaal)
+
+```
+Ingevulde {onderwerp} is niet toegestaan.
+```
+
+Gebruik dit als er geen specifieke reden of goed voorbeeld te geven is.
+
+Voorbeelden:
+
+- "Ingevulde e-mailadres is niet toegestaan."
+- "Ingevulde voornaam is niet toegestaan."
+
+### Ingevuld maar ongeldig + reden
+
+```
+Ingevulde {onderwerp} is niet toegestaan. {Reden}.
+```
+
+Voorbeelden:
+
+- "Ingevulde e-mailadres is niet toegestaan. Er mist een @."
+- "Ingevulde voornaam is niet toegestaan. Gebruik alleen letters."
+- "Ingevulde KVK-nummer is niet toegestaan. Gebruik alleen cijfers."
+- "Ingevulde datum is niet toegestaan. De datum moet in de toekomst liggen."
+
+### Ingevuld maar ongeldig + goed voorbeeld
+
+Gebruik dit als het formaat bepalend is én er nog geen voorbeeld als `FormFieldDescription` staat.
+
+```
+Ingevulde {onderwerp} is niet toegestaan. Vul een {onderwerp} in, zoals {voorbeeld}.
+```
+
+Voorbeelden:
+
+- "Ingevulde e-mailadres is niet toegestaan. Vul een e-mailadres in, zoals naam@emailadres.nl."
+- "Ingevulde postcode is niet toegestaan. Vul een Nederlandse postcode in, zoals 1234AB."
+
+Als het goede voorbeeld al als `FormFieldDescription` bij het veld staat: herhaal het niet in de foutmelding.
+
+### Patronen per type fout
+
+| Fouttype            | Patroon                                                           |
+| ------------------- | ----------------------------------------------------------------- |
+| Leeg verplicht veld | "Vul een {onderwerp} in."                                         |
+| Te lang             | "{Onderwerp} moet {aantal} tekens of minder zijn."                |
+| Te kort             | "{Onderwerp} moet {aantal} tekens of meer zijn."                  |
+| Ongeldige tekens    | "{Onderwerp} mag geen {karakter} bevatten."                       |
+| Ongeldig formaat    | "Ingevulde {onderwerp} is niet toegestaan. {reden of voorbeeld}." |
+
+### Patronen per inputtype
+
+| Inputtype                       | Patroon leeg veld                                                                   |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| `TextInput`, `EmailInput`, etc. | "Vul een {onderwerp} in."                                                           |
+| `CheckboxGroup`                 | "Kies een of meer {opties}."                                                        |
+| `RadioGroup`                    | "Kies een {onderwerp}."                                                             |
+| `Select`                        | "Kies een {onderwerp}."                                                             |
+| `FileInput`                     | "Het gekozen bestand is te groot." / "Het gekozen bestandstype is niet toegestaan." |
+
+### Schrijfregels voor foutmeldingen
+
+- Geen "uw": de gegevens zijn niet altijd van de persoon die het formulier invult
+- Geen "geldig" of "correct": niet eenvoudig taalgebruik en legt de schuld bij de gebruiker
+- Geen "selecteer": gebruik altijd "kies"
+- Geen lidwoord voor "ingevulde": schrijf "Ingevulde {onderwerp}...", niet "De/Het ingevulde {onderwerp}..."
+- Zet een punt aan het eind van elke foutmelding: dit geeft een pauze voor schermlezers
+- Schrijf foutmeldingen zo dat ze ook als opsomming in de foutmelding-samenvatting bovenaan het formulier werken
+
+---
+
+## Reviewpagina
+
+De reviewpagina toont alle ingevulde gegevens, gegroepeerd per stap.
+
+**Structuur per stap:**
+
+1. `<h3>` met de titel van de stap
+2. `Link` met "Wijzig" + visueel verborgen contexttekst (bijv. `<span className="dsn-visually-hidden"> Uw gegevens</span>`) en `pencil`-icoon
+3. `SummaryList` met de ingevulde waarden
+
+**ActionGroup onderaan de reviewpagina:**
+
+```tsx
+<ActionGroup
+  direction="vertical"
+  style={{ marginBlockStart: 'var(--dsn-space-block-3xl)' }}
+>
+  <Button variant="strong-positive" type="submit">
+    Versturen
+  </Button>
+  <LinkButton>Opslaan en later verder</LinkButton>
+  <LinkButton>Stoppen met het formulier</LinkButton>
+</ActionGroup>
+```
+
+Zie ook het template **Review page** in Storybook.
+
+---
+
+## Aanpassen vanuit de reviewpagina
+
+Als de gebruiker op "Wijzig" klikt bij een stap op de reviewpagina:
+
+1. De gebruiker gaat naar de bewuste formulierstap, met de al ingevulde gegevens pre-filled
+2. Dit is een uitstapje vanuit de reviewpagina: geen stap in de reguliere flow
+3. De pagina toont een navigatielink "Terug" (niet "Vorige stap") linksboven
+4. De ActionGroup op deze pagina heeft:
+   - "Opslaan en terug" als primaire knop (`Button` variant="strong")
+   - "Annuleren" als secundaire knop (`Button` variant="default")
+5. Na "Opslaan en terug" keert de gebruiker terug naar de reviewpagina
+
+Zie ook het template **Form step: Edit from review** in Storybook.
+
+---
+
+## Bevestigingspagina
+
+**Structuur:**
+
+1. `Note variant="positive"` als eerste element:
+   - Heading: "{Onderwerp} is verstuurd"
+   - Body: kenmerk of referentienummer
+
+2. Sectie "Dit gaat er nu gebeuren":
+   - `<h2>` met de sectietitel
+   - `UnorderedList` met wat de gebruiker kan verwachten (tijdsindicaties, vervolgstappen)
+
+3. `ActionGroup` met vervolgacties:
+   - Print-link (`Link` met `printer`-icoon)
+   - Download als PDF-link (`Link` met `download`-icoon)
+   - Terug naar website-link
+
+De bevestigingspagina is de plek om de relatie met de gebruiker te beginnen: geef duidelijkheid over wat er nu gaat gebeuren en hoe men de voortgang kan volgen.
+
+Zie ook het template **Confirmation page** in Storybook.

--- a/packages/storybook/src/FormFlowPatterns.mdx
+++ b/packages/storybook/src/FormFlowPatterns.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/addon-docs/blocks';
+import docs from './FormFlowPatterns.docs.md?raw';
+
+<Meta title="Patronen/Formulieren" />
+
+<Markdown>{docs}</Markdown>


### PR DESCRIPTION
## Summary

- Nieuwe richtlijnen voor formulierflows toegevoegd in `docs/07-form-flow-patterns.md`
- Storybook-pagina aangemaakt onder **Patronen/Formulieren** (`FormFlowPatterns.mdx`)
- `CLAUDE.md` uitgebreid met verwijzing naar de nieuwe doc, zodat formulierflow-opdrachten altijd de richtlijnen raadplegen

De documentatie dekt: enkelvoudig vs meerstappenformulier, introductiepagina, stap-indeling, niet-verplichte velden, formuliercontroles kiezen (RadioGroup/Select/Checkbox/datum), veldbreedte, validatie, foutmeldingstekstpatronen, reviewpagina, aanpassen-vanuit-review-flow en bevestigingspagina.

## Test plan

- [ ] Controleer of de pagina **Patronen/Formulieren** zichtbaar is in Storybook na deployment
- [ ] Controleer of alle verwijzingen naar templates kloppen met de bestaande stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)