### PR TITLE
docs: verwijs naar WCAG 2.2 in plaats van 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Components are designed to compose together:
 
 Accessibility is built-in from the start:
 
-- WCAG 2.1 Level AA compliant
+- WCAG 2.2 Level AA compliant
 - Proper semantic HTML
 - Keyboard navigation support
 - Focus management

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -2962,7 +2962,7 @@ const [isOpen, setIsOpen] = React.useState(false);
 - Standaard verborgen via `clip-path: inset(50%)`: blijft in de accessibility tree (screenreaders kunnen het vinden)
 - Zichtbaar bij `:focus-visible`: gepositioneerd in de hoek van het viewport met focus-stijlen
 - Z-index 600: boven modals (500), drawer (500) en backdrop (400)
-- Voldoet aan WCAG 2.1 succescriterium 2.4.1 (Bypass Blocks, Level A)
+- Voldoet aan WCAG 2.2 succescriterium 2.4.1 (Bypass Blocks, Level A)
 - `React.forwardRef<HTMLAnchorElement>`
 
 **CSS-klassen:**

--- a/docs/05-storybook-configuration.md
+++ b/docs/05-storybook-configuration.md
@@ -694,7 +694,7 @@ pnpm --filter storybook exec tsc --noEmit 2>&1 | grep "TS2304\|TS6133"
 
 Every story automatically includes accessibility checks via `@storybook/addon-a11y`:
 
-- WCAG 2.1 Level AA violations
+- WCAG 2.2 Level AA violations
 - Color contrast issues
 - Missing ARIA attributes
 - Keyboard navigation problems

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@ Complete documentation voor het Design System Starter Kit.
 
 - **Scalable** - Built for growth from day one
 - **Themeable** - Full multi-theme and light/dark mode support
-- **Accessible** - WCAG 2.1 Level AA compliant
+- **Accessible** - WCAG 2.2 Level AA compliant
 - **Framework Agnostic** - Tokens work everywhere
 - **Developer Friendly** - Clear naming, good DX
 - **Mobile-First** - Responsive design from smallest screens up

--- a/packages/components-react/README.md
+++ b/packages/components-react/README.md
@@ -101,7 +101,7 @@ function App() {
 - **TypeScript Support** - All components are fully typed
 - **JSDoc Documentation** - Comprehensive documentation with usage examples
 - **ForwardRef** - All components support ref forwarding
-- **Accessibility** - WCAG 2.1 Level AA compliant
+- **Accessibility** - WCAG 2.2 Level AA compliant
 - **Composable** - Components are designed to work together
 - **Themeable** - Uses design tokens for easy customization
 

--- a/packages/components-react/src/SkipLink/SkipLink.tsx
+++ b/packages/components-react/src/SkipLink/SkipLink.tsx
@@ -26,7 +26,7 @@ export interface SkipLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElem
  * SkipLink — toegankelijkheidskoppeling om herhalende navigatie te omzeilen.
  *
  * Plaatst de link als **eerste focusbaar element** in de DOM, vóór `<header>` en `<nav>`.
- * Voldoet aan WCAG 2.1 succescriterium 2.4.1 (Bypass Blocks, Level A).
+ * Voldoet aan WCAG 2.2 succescriterium 2.4.1 (Bypass Blocks, Level A).
  *
  * @example
  * ```tsx

--- a/packages/storybook/src/Body.docs.md
+++ b/packages/storybook/src/Body.docs.md
@@ -30,7 +30,7 @@ In Storybook is `dsn-body` als global decorator toegepast op alle stories en 'Vo
 
 ## Accessibility
 
-Body heeft geen directe invloed op toegankelijkheid. De tokens die het instelt: met name kleur en achtergrond: zijn afgestemd op een voldoende contrastverhouding volgens WCAG 2.1 AA.
+Body heeft geen directe invloed op toegankelijkheid. De tokens die het instelt: met name kleur en achtergrond: zijn afgestemd op een voldoende contrastverhouding volgens WCAG 2.2 AA.
 
 ## Design tokens
 

--- a/packages/storybook/src/SkipLink.docs.md
+++ b/packages/storybook/src/SkipLink.docs.md
@@ -6,7 +6,7 @@ Een toegankelijkheidskoppeling waarmee toetsenbordgebruikers herhalende navigati
 
 De SkipLink is het **eerste focusbare element** op elke pagina. Het is standaard onzichtbaar, maar wordt zichtbaar wanneer de gebruiker er met Tab op focust. Door op Enter te drukken springt de gebruiker direct naar de hoofdinhoud, zonder alle navigatie-elementen (header, menu, breadcrumbs) te hoeven doorlopen.
 
-De component voldoet aan WCAG 2.1 succescriterium **2.4.1 Bypass Blocks (Level A)**: pagina's moeten een mechanisme bieden waarmee blokken die op meerdere pagina's terugkeren overgeslagen kunnen worden.
+De component voldoet aan WCAG 2.2 succescriterium **2.4.1 Bypass Blocks (Level A)**: pagina's moeten een mechanisme bieden waarmee blokken die op meerdere pagina's terugkeren overgeslagen kunnen worden.
 
 <!-- VOORBEELD -->
 

--- a/packages/storybook/src/templates/BasePage.docs.md
+++ b/packages/storybook/src/templates/BasePage.docs.md
@@ -172,4 +172,4 @@ Screenreadergebruikers kunnen via landmark-navigatie direct naar elk onderdeel s
 
 ### Skip-link (WCAG 2.4.1)
 
-De skip-link is verborgen totdat de gebruiker er met Tab op focust, waarna hij zichtbaar wordt. Bij activeren springt de focus naar `<main id="main-content">`. Dit voldoet aan WCAG 2.1 succescriterium 2.4.1 (Bypass Blocks, Level A).
+De skip-link is verborgen totdat de gebruiker er met Tab op focust, waarna hij zichtbaar wordt. Bij activeren springt de focus naar `<main id="main-content">`. Dit voldoet aan WCAG 2.2 succescriterium 2.4.1 (Bypass Blocks, Level A).


### PR DESCRIPTION
## Summary
- Werkt alle huidige/toekomstgerichte verwijzingen naar "WCAG 2.1 Level AA" bij naar "WCAG 2.2 Level AA" (README's, component docs, JSDoc)
- SC 2.4.1 (Bypass Blocks) bestaat ongewijzigd in WCAG 2.2, dus verwijzingen daarnaar zijn simpelweg hernummerd naar de nieuwe versie-aanduiding
- Historische changelog-entry (`docs/changelog.md`) blijft ongewijzigd, want dat is een verslag van de staat op het moment van die release

Closes #293

## Test plan
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [x] Enkel documentatie/comment-wijzigingen, geen functionele/CSS/JS-wijzigingen