### PR TITLE
feat(TableOfContents): component + detailpage templates met inhoudsopgave

### DIFF
--- a/packages/components-html/manifest.json
+++ b/packages/components-html/manifest.json
@@ -554,6 +554,20 @@
       "primaryProps": []
     },
     {
+      "name": "TableOfContents",
+      "cssBlock": "dsn-table-of-contents",
+      "category": "navigation",
+      "purpose": "In-page table of contents with anchor links to the H2 sections of the current page.",
+      "platforms": ["html-css", "react"],
+      "primaryProps": [
+        {
+          "name": "appearance",
+          "values": ["framed", "plain"],
+          "default": "framed"
+        }
+      ]
+    },
+    {
       "name": "TextInput",
       "cssBlock": "dsn-text-input",
       "category": "form-input",

--- a/packages/components-html/package.json
+++ b/packages/components-html/package.json
@@ -57,6 +57,7 @@
     "./status-badge": "./src/status-badge/status-badge.css",
     "./summary-list": "./src/summary-list/summary-list.css",
     "./table": "./src/table/table.css",
+    "./table-of-contents": "./src/table-of-contents/table-of-contents.css",
     "./text-area": "./src/text-area/text-area.css",
     "./text-input": "./src/text-input/text-input.css",
     "./unordered-list": "./src/unordered-list/unordered-list.css"

--- a/packages/components-html/src/note/note.css
+++ b/packages/components-html/src/note/note.css
@@ -41,12 +41,12 @@
  *   ...
  * </aside>
  *
- * <!-- as="nav" — table of contents -->
+ * <!-- as="nav" — standalone navigation section (not a page table of contents: use TableOfContents) -->
  * <nav class="dsn-note" aria-labelledby="note-heading-id">
  *   <span class="dsn-note__icon" aria-hidden="true">
  *     <svg class="dsn-icon" aria-hidden="true"><!-- info-circle --></svg>
  *   </span>
- *   <strong class="dsn-heading dsn-heading--3 dsn-note__heading" id="note-heading-id">Op deze pagina</strong>
+ *   <strong class="dsn-heading dsn-heading--3 dsn-note__heading" id="note-heading-id">Related pages</strong>
  *   <nav class="dsn-note__content">
  *     <ul>...</ul>
  *   </nav>

--- a/packages/components-html/src/page-body/page-body.css
+++ b/packages/components-html/src/page-body/page-body.css
@@ -66,3 +66,33 @@
 .dsn-sidebar-layout__sidebar .dsn-menu-link__link[aria-current='page'] {
   background-color: transparent;
 }
+
+/* =============================================================================
+   Sidebar layout — Table of Contents kolom (rechts)
+   De ToC-inhoud wordt twee keer gerenderd: één keer inline (onder H1/lead,
+   zichtbaar tot 80em) en één keer als rechterkolom (zichtbaar vanaf 80em).
+   `display: none` sluit de verborgen kopie uit van de accessibility tree,
+   dus er is nooit dubbele content voor schermlezers.
+   ============================================================================= */
+
+.dsn-sidebar-layout__toc-inline {
+  display: block;
+}
+
+.dsn-sidebar-layout__toc {
+  display: none;
+}
+
+@media (min-width: 80em) {
+  .dsn-sidebar-layout__toc-inline {
+    display: none;
+  }
+
+  .dsn-sidebar-layout__toc {
+    display: block;
+    flex-shrink: 0;
+    inline-size: var(--dsn-sidebar-layout-toc-inline-size, 16rem);
+    padding-inline-start: var(--dsn-space-inline-2xl);
+    padding-block: var(--dsn-space-block-3xl);
+  }
+}

--- a/packages/components-html/src/table-of-contents/table-of-contents.css
+++ b/packages/components-html/src/table-of-contents/table-of-contents.css
@@ -1,0 +1,53 @@
+/**
+ * Table Of Contents Component
+ * Inhoudsopgave met ankerlinks naar de secties op de huidige pagina.
+ * Alleen H2-secties horen hierin opgenomen te worden.
+ *
+ * Twee appearances:
+ * - Default ("framed"): accent-1 achtergrond + linkerborder, heading als heading-3.
+ *   Bedoeld voor gebruik inline in de content-flow (bijv. onder de lead paragraph).
+ * - `dsn-table-of-contents--plain`: geen kader, heading als heading-5.
+ *   Bedoeld voor gebruik in een losstaande kolom naast de hoofdinhoud.
+ *
+ * Usage:
+ * <!-- Framed (default) -->
+ * <nav class="dsn-table-of-contents" aria-labelledby="toc-heading">
+ *   <h2 class="dsn-heading dsn-heading--heading-3 dsn-table-of-contents__heading" id="toc-heading">Op deze pagina</h2>
+ *   <ul class="dsn-unordered-list">
+ *     <li><a class="dsn-link" href="#sectie-1">Sectie 1</a></li>
+ *   </ul>
+ * </nav>
+ *
+ * <!-- Plain -->
+ * <nav class="dsn-table-of-contents dsn-table-of-contents--plain" aria-labelledby="toc-heading-plain">
+ *   <h2 class="dsn-heading dsn-heading--heading-5 dsn-table-of-contents__heading" id="toc-heading-plain">Op deze pagina</h2>
+ *   <ul class="dsn-unordered-list">
+ *     <li><a class="dsn-link" href="#sectie-1">Sectie 1</a></li>
+ *   </ul>
+ * </nav>
+ */
+
+.dsn-table-of-contents {
+  border-inline-start: var(--dsn-table-of-contents-border-inline-start-width)
+    solid var(--dsn-table-of-contents-border-inline-start-color);
+  background-color: var(--dsn-table-of-contents-background-color);
+  padding-block: var(--dsn-table-of-contents-padding-block);
+  padding-inline-start: var(--dsn-table-of-contents-padding-inline-start);
+  padding-inline-end: var(--dsn-table-of-contents-padding-inline-end);
+}
+
+.dsn-table-of-contents__heading {
+  margin-block-end: var(--dsn-table-of-contents-heading-gap);
+}
+
+/* =============================================================================
+   Plain appearance — geen kader, voor gebruik in een losstaande kolom
+   ============================================================================= */
+
+.dsn-table-of-contents--plain {
+  border-inline-start: none;
+  background-color: transparent;
+  padding-block: 0;
+  padding-inline-start: 0;
+  padding-inline-end: 0;
+}

--- a/packages/components-react/src/Note/Note.test.tsx
+++ b/packages/components-react/src/Note/Note.test.tsx
@@ -256,19 +256,19 @@ describe('Note', () => {
   // Content examples
   // ===========================
 
-  it('renders inhoudsopgave patroon (as="nav")', () => {
+  it('renders eigenstandige navigatiesectie patroon (as="nav")', () => {
     render(
-      <Note as="nav" heading="Op deze pagina" headingLevel={2}>
+      <Note as="nav" heading="Gerelateerde pagina's" headingLevel={2}>
         <ul>
-          <li>Sectie 1</li>
-          <li>Sectie 2</li>
+          <li>Pagina 1</li>
+          <li>Pagina 2</li>
         </ul>
       </Note>
     );
     expect(
-      screen.getByRole('navigation', { name: 'Op deze pagina' })
+      screen.getByRole('navigation', { name: "Gerelateerde pagina's" })
     ).toBeInTheDocument();
-    expect(screen.getByText('Sectie 1')).toBeInTheDocument();
+    expect(screen.getByText('Pagina 1')).toBeInTheDocument();
   });
 
   it('renders aside patroon', () => {

--- a/packages/components-react/src/Note/Note.tsx
+++ b/packages/components-react/src/Note/Note.tsx
@@ -85,10 +85,10 @@ export interface NoteProps extends React.HTMLAttributes<HTMLElement> {
  *   <Paragraph>Meer context.</Paragraph>
  * </Note>
  *
- * // as="nav" — inhoudsopgave
- * <Note as="nav" variant="neutral" heading="Op deze pagina" headingLevel={2}>
+ * // as="nav" — eigenstandige navigatiesectie (niet voor een pagina-inhoudsopgave: gebruik TableOfContents)
+ * <Note as="nav" variant="neutral" heading="Gerelateerde pagina's" headingLevel={2}>
  *   <UnorderedList>
- *     <li><Link href="#sectie-1">Sectie 1</Link></li>
+ *     <li><Link href="/gerelateerd-1">Gerelateerde pagina 1</Link></li>
  *   </UnorderedList>
  * </Note>
  *

--- a/packages/components-react/src/TableOfContents/TableOfContents.css
+++ b/packages/components-react/src/TableOfContents/TableOfContents.css
@@ -1,0 +1,6 @@
+/**
+ * TableOfContents component styles for React
+ * Re-exports the base TableOfContents styles from components-html
+ */
+
+@import '../../../components-html/src/table-of-contents/table-of-contents.css';

--- a/packages/components-react/src/TableOfContents/TableOfContents.test.tsx
+++ b/packages/components-react/src/TableOfContents/TableOfContents.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TableOfContents } from './TableOfContents';
+
+const items = [
+  { id: 'sectie-1', label: 'Sectie 1' },
+  { id: 'sectie-2', label: 'Sectie 2' },
+];
+
+describe('TableOfContents', () => {
+  // ===========================
+  // Rendering
+  // ===========================
+
+  it('renders as a nav landmark', () => {
+    render(<TableOfContents items={items} />);
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+  });
+
+  it('renders default heading text', () => {
+    render(<TableOfContents items={items} />);
+    expect(screen.getByText('Op deze pagina')).toBeInTheDocument();
+  });
+
+  it('renders custom heading text', () => {
+    render(<TableOfContents heading="Inhoud" items={items} />);
+    expect(screen.getByText('Inhoud')).toBeInTheDocument();
+  });
+
+  it('renders a link for every item with the correct href', () => {
+    render(<TableOfContents items={items} />);
+    expect(screen.getByRole('link', { name: 'Sectie 1' })).toHaveAttribute(
+      'href',
+      '#sectie-1'
+    );
+    expect(screen.getByRole('link', { name: 'Sectie 2' })).toHaveAttribute(
+      'href',
+      '#sectie-2'
+    );
+  });
+
+  // ===========================
+  // Heading level
+  // ===========================
+
+  it('renders heading at level 2 by default', () => {
+    render(<TableOfContents items={items} />);
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Op deze pagina' })
+    ).toBeInTheDocument();
+  });
+
+  it.each([1, 2, 3, 4, 5, 6] as const)(
+    'renders heading at level %i when headingLevel=%i',
+    (level) => {
+      render(<TableOfContents headingLevel={level} items={items} />);
+      expect(
+        screen.getByRole('heading', { level, name: 'Op deze pagina' })
+      ).toBeInTheDocument();
+    }
+  );
+
+  // ===========================
+  // Appearance
+  // ===========================
+
+  it('does not add the plain modifier class by default (framed)', () => {
+    const { container } = render(<TableOfContents items={items} />);
+    expect(container.firstChild).not.toHaveClass(
+      'dsn-table-of-contents--plain'
+    );
+  });
+
+  it('renders the heading as heading-3 for the framed appearance', () => {
+    render(<TableOfContents items={items} />);
+    expect(screen.getByRole('heading')).toHaveClass('dsn-heading--heading-3');
+  });
+
+  it('adds the plain modifier class when appearance="plain"', () => {
+    const { container } = render(
+      <TableOfContents appearance="plain" items={items} />
+    );
+    expect(container.firstChild).toHaveClass('dsn-table-of-contents--plain');
+  });
+
+  it('renders the heading as heading-5 for the plain appearance', () => {
+    render(<TableOfContents appearance="plain" items={items} />);
+    expect(screen.getByRole('heading')).toHaveClass('dsn-heading--heading-5');
+  });
+
+  // ===========================
+  // Landmark aria-labelledby
+  // ===========================
+
+  it('labels the nav via aria-labelledby pointing at the heading', () => {
+    const { container } = render(<TableOfContents items={items} />);
+    const nav = container.firstChild as HTMLElement;
+    const headingId = nav.getAttribute('aria-labelledby');
+    expect(headingId).toBeTruthy();
+    expect(document.getElementById(headingId!)).toBeInTheDocument();
+  });
+
+  it('exposes the heading text as the nav accessible name', () => {
+    render(<TableOfContents heading="Inhoud" items={items} />);
+    expect(
+      screen.getByRole('navigation', { name: 'Inhoud' })
+    ).toBeInTheDocument();
+  });
+
+  // ===========================
+  // Classes + ref + HTML attributes
+  // ===========================
+
+  it('always has base dsn-table-of-contents class', () => {
+    const { container } = render(<TableOfContents items={items} />);
+    expect(container.firstChild).toHaveClass('dsn-table-of-contents');
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <TableOfContents items={items} className="custom-toc" />
+    );
+    expect(container.firstChild).toHaveClass('dsn-table-of-contents');
+    expect(container.firstChild).toHaveClass('custom-toc');
+  });
+
+  it('forwards ref to the nav element', () => {
+    const ref = { current: null as HTMLElement | null };
+    render(<TableOfContents ref={ref} items={items} />);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.nodeName).toBe('NAV');
+  });
+
+  it('spreads additional HTML attributes', () => {
+    render(<TableOfContents items={items} id="toc-1" data-testid="my-toc" />);
+    expect(screen.getByTestId('my-toc')).toHaveAttribute('id', 'toc-1');
+  });
+});

--- a/packages/components-react/src/TableOfContents/TableOfContents.tsx
+++ b/packages/components-react/src/TableOfContents/TableOfContents.tsx
@@ -1,0 +1,122 @@
+import React, { useId } from 'react';
+import { classNames } from '@dsn-starter-kit/core';
+import { Heading, type HeadingLevel } from '../Heading';
+import { Link } from '../Link';
+import { UnorderedList } from '../UnorderedList';
+import './TableOfContents.css';
+
+export type TableOfContentsAppearance = 'framed' | 'plain';
+
+export interface TableOfContentsItem {
+  /**
+   * Anchor target — moet overeenkomen met het `id` van de bijbehorende H2 op de pagina
+   */
+  id: string;
+
+  /**
+   * Zichtbare linktekst
+   */
+  label: string;
+}
+
+export interface TableOfContentsProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * Zichtbare heading-tekst
+   * @default 'Op deze pagina'
+   */
+  heading?: string;
+
+  /**
+   * Semantisch heading-niveau
+   * @default 2
+   */
+  headingLevel?: HeadingLevel;
+
+  /**
+   * Visuele weergave:
+   * - `'framed'` — accent-1 achtergrond + linkerborder, heading als heading-3 (voor gebruik inline in de content-flow)
+   * - `'plain'` — geen kader, heading als heading-5 (voor gebruik in een losstaande kolom)
+   * @default 'framed'
+   */
+  appearance?: TableOfContentsAppearance;
+
+  /**
+   * Secties waarnaar gelinkt wordt — alleen H2's horen hierin opgenomen te worden
+   */
+  items: TableOfContentsItem[];
+
+  /**
+   * Additional CSS class names
+   */
+  className?: string;
+}
+
+/**
+ * TableOfContents component
+ * Inhoudsopgave met ankerlinks naar de H2-secties op de huidige pagina.
+ *
+ * @example
+ * ```tsx
+ * // Framed (default) — inline in de content-flow
+ * <TableOfContents
+ *   items={[
+ *     { id: 'sectie-1', label: 'Sectie 1' },
+ *     { id: 'sectie-2', label: 'Sectie 2' },
+ *   ]}
+ * />
+ *
+ * // Plain — in een losstaande kolom naast de hoofdinhoud
+ * <TableOfContents appearance="plain" items={items} />
+ * ```
+ */
+export const TableOfContents = React.forwardRef<
+  HTMLElement,
+  TableOfContentsProps
+>(
+  (
+    {
+      heading = 'Op deze pagina',
+      headingLevel = 2,
+      appearance = 'framed',
+      items,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const headingId = useId();
+
+    const classes = classNames(
+      'dsn-table-of-contents',
+      appearance === 'plain' && 'dsn-table-of-contents--plain',
+      className
+    );
+
+    return (
+      <nav
+        ref={ref as React.Ref<HTMLElement>}
+        className={classes}
+        aria-labelledby={headingId}
+        {...props}
+      >
+        <Heading
+          level={headingLevel}
+          appearance={appearance === 'plain' ? 'heading-5' : 'heading-3'}
+          className="dsn-table-of-contents__heading"
+          id={headingId}
+        >
+          {heading}
+        </Heading>
+        <UnorderedList>
+          {items.map((item) => (
+            <li key={item.id}>
+              <Link href={`#${item.id}`}>{item.label}</Link>
+            </li>
+          ))}
+        </UnorderedList>
+      </nav>
+    );
+  }
+);
+
+TableOfContents.displayName = 'TableOfContents';

--- a/packages/components-react/src/TableOfContents/index.ts
+++ b/packages/components-react/src/TableOfContents/index.ts
@@ -1,0 +1,6 @@
+export { TableOfContents } from './TableOfContents';
+export type {
+  TableOfContentsProps,
+  TableOfContentsAppearance,
+  TableOfContentsItem,
+} from './TableOfContents';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -80,6 +80,7 @@ export * from './PageBody';
 export * from './PageFooter';
 export * from './PageHeader';
 export * from './PageLayout';
+export * from './TableOfContents';
 
 // Form Field Components
 export * from './FormField';

--- a/packages/design-tokens/src/tokens/components/table-of-contents.json
+++ b/packages/design-tokens/src/tokens/components/table-of-contents.json
@@ -1,0 +1,41 @@
+{
+  "dsn": {
+    "table-of-contents": {
+      "border-inline-start-width": {
+        "$value": "{dsn.border.width.medium}",
+        "$type": "dimension",
+        "$description": "Breedte van de linkerborder (framed appearance)"
+      },
+      "border-inline-start-color": {
+        "$value": "{dsn.color.accent-1.border-default}",
+        "$type": "color",
+        "$description": "Kleur van de linkerborder (framed appearance)"
+      },
+      "background-color": {
+        "$value": "{dsn.color.accent-1.bg-default}",
+        "$type": "color",
+        "$description": "Achtergrondkleur (framed appearance)"
+      },
+      "padding-block": {
+        "$value": "{dsn.space.block.xl}",
+        "$type": "dimension",
+        "$description": "Verticale padding (framed appearance)"
+      },
+      "padding-inline-start": {
+        "$value": "{dsn.space.inline.xl}",
+        "$type": "dimension",
+        "$description": "Horizontale padding aan het begin, na de border (framed appearance)"
+      },
+      "padding-inline-end": {
+        "$value": "{dsn.space.inline.xl}",
+        "$type": "dimension",
+        "$description": "Horizontale padding aan het einde (framed appearance)"
+      },
+      "heading-gap": {
+        "$value": "{dsn.space.row.md}",
+        "$type": "dimension",
+        "$description": "Ruimte tussen de heading en de lijst met ankerlinks"
+      }
+    }
+  }
+}

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -61,7 +61,7 @@ function App() {
 
 ## Componenten overzicht
 
-**54 componenten totaal**: alle beschikbaar als HTML/CSS én React.
+**55 componenten totaal**: alle beschikbaar als HTML/CSS én React.
 
 ### Layout Components (6)
 
@@ -116,7 +116,7 @@ function App() {
 
 - **SkipLink**: Eerste focusbaar element op de pagina: verborgen totdat de gebruiker er met Tab op focust, zodat toetsenbordgebruikers herhalende navigatie kunnen overslaan (WCAG 2.4.1)
 
-### Navigation Components (8)
+### Navigation Components (9)
 
 - **BreadcrumbNavigation**: Hiërarchisch navigatiepad met compacte variant via container query
 - **Menu**: Containercomponent voor MenuLink- en MenuButton-items in verticale of horizontale navigatielijst
@@ -126,6 +126,7 @@ function App() {
 - **PageFooter**: Paginavoettekst met accent-1 achtergrond, dikke topborder en 4-koloms grid: logo, tussenslot, content en footerlinks
 - **PageHeader**: Paginabrede koptekstbalk met logo-slot, navigatie-slot en acties-slot: theme-aware achtergrond via design tokens
 - **PageLayout**: Structurele full-page wrapper die `PageHeader`, `PageBody` en `PageFooter` verticaal stapelt met `min-block-size: 100dvh`
+- **TableOfContents**: Inhoudsopgave met ankerlinks naar de H2-secties van de huidige pagina: framed appearance (accent-1 kader) voor inline gebruik, plain appearance voor een losstaande kolom
 
 ### Form Components (25)
 
@@ -191,4 +192,4 @@ MIT License: zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.39.0 | **Laatste update:** 28 mei 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.39.0 | **Laatste update:** 7 juli 2026 | **Auteur:** Jeffrey Lauwers

--- a/packages/storybook/src/Note.docs.md
+++ b/packages/storybook/src/Note.docs.md
@@ -12,14 +12,15 @@ De Note component plaatst extra context of een tip op een opvallende maar niet-u
 
 - Aanvullende context geven bij een formulierveld, een processtap of een sectie.
 - Een tip, best practice of aanbeveling tonen die niet blokkerend is.
-- Een inhoudsopgave ("Op deze pagina") met ankerlinks tonen bovenaan een lange pagina (`as="nav"`).
 - Tangentieel aanvullende informatie naast de hoofdcontent plaatsen (`as="aside"`).
+- Een eigenstandige, benoemde navigatiesectie labelen (`as="nav"`) die geen inhoudsopgave is: gebruik voor een pagina-inhoudsopgave het **TableOfContents** component.
 
 ## Don't use when
 
 - Het bericht urgent is of na een gebruikersactie verschijnt: gebruik een **Alert**.
 - De informatie één zin is zonder visuele nadruk: gebruik een **Paragraph** of **FormFieldDescription**.
 - Je een interactief label wilt: gebruik een **StatusBadge** of **Button**.
+- Je een inhoudsopgave ("Op deze pagina") met ankerlinks naar de secties van de pagina wilt tonen: gebruik het **TableOfContents** component.
 
 ## Best practices
 
@@ -35,12 +36,12 @@ Een Note wordt bewust door een ontwerper of ontwikkelaar geplaatst. De variant k
 
 ### `as` prop
 
-| Waarde            | Wanneer                                                              |
-| ----------------- | -------------------------------------------------------------------- |
-| `'div'` (default) | Inline tip, aanvullende context: de meeste gevallen                  |
-| `'aside'`         | Echt tangentieel aanvullende content in een artikel of lang document |
-| `'nav'`           | Inhoudsopgave met ankerlinks (`"Op deze pagina"`)                    |
-| `'section'`       | Zelfstandige, benoemde inhoudssectie met heading als label           |
+| Waarde            | Wanneer                                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------------------------ |
+| `'div'` (default) | Inline tip, aanvullende context: de meeste gevallen                                                    |
+| `'aside'`         | Echt tangentieel aanvullende content in een artikel of lang document                                   |
+| `'nav'`           | Eigenstandige navigatiesectie; voor een pagina-inhoudsopgave gebruik je **TableOfContents**, niet Note |
+| `'section'`       | Zelfstandige, benoemde inhoudssectie met heading als label                                             |
 
 ### Heading
 

--- a/packages/storybook/src/Note.stories.tsx
+++ b/packages/storybook/src/Note.stories.tsx
@@ -3,7 +3,6 @@ import {
   Icon,
   Note,
   Paragraph,
-  Link,
   UnorderedList,
 } from '@dsn-starter-kit/components-react';
 import type { IconName } from '@dsn-starter-kit/components-react/icon-registry.generated';
@@ -218,25 +217,6 @@ export const WithList: Story = {
         <li>Voornaam is verplicht</li>
         <li>E-mailadres is ongeldig</li>
         <li>Telefoonnummer ontbreekt</li>
-      </UnorderedList>
-    </Note>
-  ),
-};
-
-export const AsNav: Story = {
-  name: 'As nav (inhoudsopgave)',
-  render: () => (
-    <Note as="nav" variant="neutral" heading="Op deze pagina" headingLevel={2}>
-      <UnorderedList>
-        <li>
-          <Link href="#sectie-1">Sectie 1: Inleiding</Link>
-        </li>
-        <li>
-          <Link href="#sectie-2">Sectie 2: Aanvraag</Link>
-        </li>
-        <li>
-          <Link href="#sectie-3">Sectie 3: Documenten</Link>
-        </li>
       </UnorderedList>
     </Note>
   ),

--- a/packages/storybook/src/TableOfContents.docs.md
+++ b/packages/storybook/src/TableOfContents.docs.md
@@ -1,0 +1,61 @@
+# TableOfContents
+
+Inhoudsopgave met ankerlinks naar de H2-secties van de huidige pagina.
+
+## Doel
+
+De TableOfContents component toont een lijst van ankerlinks waarmee een gebruiker snel naar een sectie verderop op de pagina kan springen. Alleen H2-secties horen hierin opgenomen te worden: dat houdt de lijst overzichtelijk en voorkomt een te diepe navigatiestructuur. Twee appearances: **framed** (accent-1 achtergrond en linkerborder, voor gebruik inline in de content-flow) en **plain** (geen kader, voor gebruik in een losstaande kolom naast de hoofdinhoud).
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Een lange pagina met meerdere H2-secties waar de gebruiker snel naartoe wil kunnen springen.
+- `appearance="framed"` (default) voor gebruik inline in de content-flow, bijvoorbeeld direct onder de introductietekst op kleinere viewports.
+- `appearance="plain"` voor gebruik in een losstaande kolom naast de hoofdinhoud op bredere viewports.
+
+## Don't use when
+
+- De pagina maar één of twee secties heeft: een inhoudsopgave voegt dan geen waarde toe.
+- Je een paginabrede navigatiestructuur nodig hebt: gebruik **Menu**/**MenuLink**.
+- Je een algemene, niet-navigatiegerelateerde tip of waarschuwing wilt tonen: gebruik **Note**.
+
+## Best practices
+
+### Alleen H2-secties
+
+Neem alleen H2's op in `items`. H3's en dieper horen niet in de inhoudsopgave.
+
+### `appearance` prop
+
+| Waarde               | Wanneer                                                                                                                    |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `'framed'` (default) | Inline in de content-flow: accent-1 achtergrond en linkerborder maken het blok visueel herkenbaar tussen de lopende tekst  |
+| `'plain'`            | In een losstaande kolom naast de hoofdinhoud: de kolompositie geeft al voldoende visuele scheiding, een kader is overbodig |
+
+### Twee keer renderen voor responsive gedrag
+
+Wanneer een pagina zowel inline (mobiel/tablet) als in een kolom (desktop) een inhoudsopgave toont, render je het component twee keer: één keer met `appearance="framed"` en één keer met `appearance="plain"`, en toon je per breakpoint telkens één via CSS (`display: none` op de andere). Een `display: none`-element valt buiten de accessibility tree, dus er is nooit dubbele content voor schermlezers.
+
+### Ids
+
+Elk item's `id` moet exact overeenkomen met het `id` van de bijbehorende `Heading level={2}` op de pagina.
+
+## Design tokens
+
+| Token                                               | Beschrijving                                            |
+| --------------------------------------------------- | ------------------------------------------------------- |
+| `--dsn-table-of-contents-border-inline-start-width` | Breedte van de linkerborder (framed appearance)         |
+| `--dsn-table-of-contents-border-inline-start-color` | Kleur van de linkerborder (framed appearance), accent-1 |
+| `--dsn-table-of-contents-background-color`          | Achtergrondkleur (framed appearance), accent-1          |
+| `--dsn-table-of-contents-padding-block`             | Verticale padding (framed appearance)                   |
+| `--dsn-table-of-contents-padding-inline-start`      | Horizontale padding aan het begin (framed appearance)   |
+| `--dsn-table-of-contents-padding-inline-end`        | Horizontale padding aan het einde (framed appearance)   |
+| `--dsn-table-of-contents-heading-gap`               | Ruimte tussen de heading en de lijst met ankerlinks     |
+
+## Accessibility
+
+- Rendert als `<nav>` met `aria-labelledby` gekoppeld aan de heading: de accessible name is de zichtbare heading-tekst.
+- Pas `headingLevel` aan op de documenthiërarchie (standaard `h2`, gelijk aan de secties waarnaar gelinkt wordt).
+- Ankerlinks zijn gewone `Link`-elementen: toetsenbordgebruikers kunnen er doorheen tabben en met Enter activeren.
+- Bij dubbele weergave (inline + kolom): verberg de niet-actieve kopie met `display: none`, niet met `visibility: hidden` of `opacity: 0`, zodat schermlezers hem niet dubbel tegenkomen.

--- a/packages/storybook/src/TableOfContents.docs.mdx
+++ b/packages/storybook/src/TableOfContents.docs.mdx
@@ -1,0 +1,50 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/addon-docs/blocks';
+import * as TableOfContentsStories from './TableOfContents.stories';
+import docs from './TableOfContents.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={TableOfContentsStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={TableOfContentsStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={TableOfContentsStories.Default}
+  html={`<nav class="dsn-table-of-contents" aria-labelledby="toc-heading">
+  <h2 class="dsn-heading dsn-heading--heading-3 dsn-table-of-contents__heading" id="toc-heading">Op deze pagina</h2>
+  <ul class="dsn-unordered-list">
+    <li><a class="dsn-link" href="#sectie-kenmerken">Kenmerken</a></li>
+    <li><a class="dsn-link" href="#sectie-gebruik">Gebruik</a></li>
+    <li><a class="dsn-link" href="#sectie-toegankelijkheid">Toegankelijkheid</a></li>
+  </ul>
+</nav>`}
+/>
+
+<Controls of={TableOfContentsStories.Default} />
+
+## Plain appearance
+
+<PreviewFrame>
+  <Story of={TableOfContentsStories.Plain} />
+</PreviewFrame>
+
+<CodeTabs
+  of={TableOfContentsStories.Plain}
+  html={`<nav class="dsn-table-of-contents dsn-table-of-contents--plain" aria-labelledby="toc-heading-plain">
+  <h2 class="dsn-heading dsn-heading--heading-5 dsn-table-of-contents__heading" id="toc-heading-plain">Op deze pagina</h2>
+  <ul class="dsn-unordered-list">
+    <li><a class="dsn-link" href="#sectie-kenmerken">Kenmerken</a></li>
+    <li><a class="dsn-link" href="#sectie-gebruik">Gebruik</a></li>
+    <li><a class="dsn-link" href="#sectie-toegankelijkheid">Toegankelijkheid</a></li>
+  </ul>
+</nav>`}
+/>
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/TableOfContents.stories.tsx
+++ b/packages/storybook/src/TableOfContents.stories.tsx
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { TableOfContents } from '@dsn-starter-kit/components-react';
+import DocsPage from './TableOfContents.docs.mdx';
+import {
+  WEINIG_TEKST,
+  VEEL_TEKST,
+  TEKST_AR,
+  VEEL_TEKST_AR,
+  rtlDecorator,
+} from './story-helpers';
+
+const demoItems = [
+  { id: 'sectie-kenmerken', label: 'Kenmerken' },
+  { id: 'sectie-gebruik', label: 'Gebruik' },
+  { id: 'sectie-toegankelijkheid', label: 'Toegankelijkheid' },
+];
+
+const meta: Meta<typeof TableOfContents> = {
+  title: 'Components/TableOfContents',
+  component: TableOfContents,
+  parameters: {
+    docs: { page: DocsPage },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        const appearance = args.appearance ?? 'framed';
+        const headingLevel = args.headingLevel ?? 2;
+        const headingAppearance =
+          appearance === 'plain' ? 'heading-5' : 'heading-3';
+        const heading = args.heading ?? 'Op deze pagina';
+        const cls = [
+          'dsn-table-of-contents',
+          appearance === 'plain' && 'dsn-table-of-contents--plain',
+        ]
+          .filter(Boolean)
+          .join(' ');
+
+        return `<nav class="${cls}" aria-labelledby="toc-heading">
+  <h${headingLevel} class="dsn-heading dsn-heading--${headingAppearance} dsn-table-of-contents__heading" id="toc-heading">${heading}</h${headingLevel}>
+  <ul class="dsn-unordered-list">
+    <li><a class="dsn-link" href="#sectie-kenmerken">Kenmerken</a></li>
+    <li><a class="dsn-link" href="#sectie-gebruik">Gebruik</a></li>
+    <li><a class="dsn-link" href="#sectie-toegankelijkheid">Toegankelijkheid</a></li>
+  </ul>
+</nav>`;
+      },
+    },
+  },
+  argTypes: {
+    heading: { control: 'text' },
+    headingLevel: {
+      control: 'select',
+      options: [1, 2, 3, 4, 5, 6],
+    },
+    appearance: {
+      control: 'select',
+      options: ['framed', 'plain'],
+    },
+    items: { control: false },
+  },
+  args: {
+    heading: 'Op deze pagina',
+    headingLevel: 2,
+    appearance: 'framed',
+    items: demoItems,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TableOfContents>;
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {};
+
+// =============================================================================
+// VARIANTEN
+// =============================================================================
+
+export const Plain: Story = {
+  name: 'Plain',
+  args: {
+    appearance: 'plain',
+  },
+};
+
+// =============================================================================
+// OVERZICHTSSTORIES
+// =============================================================================
+
+export const AllVariants: Story = {
+  name: 'All variants',
+  render: () => (
+    <div style={{ display: 'flex', gap: '2rem', alignItems: 'flex-start' }}>
+      <TableOfContents items={demoItems} />
+      <TableOfContents appearance="plain" items={demoItems} />
+    </div>
+  ),
+};
+
+// =============================================================================
+// TEKST VARIANTEN
+// =============================================================================
+
+export const ShortText: Story = {
+  name: 'Short text',
+  args: {
+    heading: WEINIG_TEKST,
+    items: [{ id: 'sectie-1', label: WEINIG_TEKST }],
+  },
+};
+
+export const LongText: Story = {
+  name: 'Long text',
+  args: {
+    heading: VEEL_TEKST,
+    items: [
+      { id: 'sectie-1', label: VEEL_TEKST },
+      { id: 'sectie-2', label: 'Gebruik' },
+    ],
+  },
+};
+
+// =============================================================================
+// RTL
+// =============================================================================
+
+export const RTL: Story = {
+  name: 'RTL',
+  decorators: [rtlDecorator],
+  render: () => (
+    <div dir="rtl" lang="ar">
+      <TableOfContents
+        heading={TEKST_AR}
+        items={[{ id: 'sectie-1', label: TEKST_AR }]}
+      />
+    </div>
+  ),
+};
+
+export const RTLLongText: Story = {
+  name: 'RTL long text',
+  decorators: [rtlDecorator],
+  render: () => (
+    <div dir="rtl" lang="ar">
+      <TableOfContents
+        heading={VEEL_TEKST_AR}
+        items={[{ id: 'sectie-1', label: VEEL_TEKST_AR }]}
+      />
+    </div>
+  ),
+};

--- a/packages/storybook/src/templates/WithSidebarPage.stories.tsx
+++ b/packages/storybook/src/templates/WithSidebarPage.stories.tsx
@@ -19,6 +19,7 @@ import {
   SearchInput,
   SkipLink,
   Stack,
+  TableOfContents,
 } from '@dsn-starter-kit/components-react';
 import {
   logoSlot,
@@ -367,6 +368,63 @@ function MainContent({ pageName }: { pageName: string }) {
 }
 
 // =============================================================================
+// TABLE OF CONTENTS
+// Alleen H2's worden in de Table of Contents opgenomen.
+// =============================================================================
+
+const tocItems = [
+  { id: 'sectie-kenmerken', label: 'Kenmerken' },
+  { id: 'sectie-gebruik', label: 'Gebruik' },
+  { id: 'sectie-toegankelijkheid', label: 'Toegankelijkheid' },
+];
+
+// =============================================================================
+// PAGINA-INHOUD MET H2-SECTIES EN TABLE OF CONTENTS
+// =============================================================================
+
+function MainContentWithToc({ pageName }: { pageName: string }) {
+  return (
+    <Stack space="2xl">
+      <Heading level={1}>{pageName}</Heading>
+      <Paragraph variant="lead">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut enim ad
+        minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+        ex ea commodo consequat.
+      </Paragraph>
+      <div className="dsn-sidebar-layout__toc-inline">
+        <TableOfContents appearance="framed" items={tocItems} />
+      </div>
+      <Heading level={2} id="sectie-kenmerken">
+        Kenmerken
+      </Heading>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris.
+      </Paragraph>
+      <Heading level={2} id="sectie-gebruik">
+        Gebruik
+      </Heading>
+      <Paragraph>
+        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+        dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </Paragraph>
+      <Heading level={2} id="sectie-toegankelijkheid">
+        Toegankelijkheid
+      </Heading>
+      <Paragraph>
+        Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+        accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
+        illo inventore veritatis et quasi architecto beatae vitae dicta sunt
+        explicabo.
+      </Paragraph>
+      <GridContent />
+    </Stack>
+  );
+}
+
+// =============================================================================
 // META
 // =============================================================================
 
@@ -427,6 +485,51 @@ export const Default: Story = {
   ),
 };
 
+export const WithToc: Story = {
+  name: 'With Sidebar + Table of Contents',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout>
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation currentPage="level-1a" />}
+          primaryNavigationLarge={
+            <PrimaryNavigationLarge currentPage="level-1a" />
+          }
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <div className="dsn-sidebar-layout">
+            <aside className="dsn-sidebar-layout__sidebar">
+              <SidebarNavigation currentPage="level-1a" />
+            </aside>
+            <main
+              id="main-content"
+              tabIndex={-1}
+              className="dsn-sidebar-layout__main"
+              style={mainStyle}
+            >
+              <MainContentWithToc pageName="Level 1a" />
+            </main>
+            <aside className="dsn-sidebar-layout__toc">
+              <TableOfContents appearance="plain" items={tocItems} />
+            </aside>
+          </div>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};
+
 export const FullWidth: Story = {
   name: 'Full Width + Sidebar',
   render: () => (
@@ -458,6 +561,53 @@ export const FullWidth: Story = {
             >
               <GridContent />
             </main>
+          </div>
+        </PageBody>
+        <PageFooter
+          slot1={footerSlot1}
+          slot2={footerSlot2}
+          slot3={footerSlot3}
+          slot4={footerSlot4}
+        />
+      </PageLayout>
+    </Body>
+  ),
+};
+
+export const FullWidthWithToc: Story = {
+  name: 'Full Width + Sidebar + Table of Contents',
+  render: () => (
+    <Body>
+      <SkipLink href="#main-content" />
+      <PageLayout
+        style={{ '--dsn-page-max-inline-size': 'none' } as React.CSSProperties}
+      >
+        <PageHeader
+          logoSlot={logoSlot}
+          primaryNavigation={<PrimaryNavigation currentPage="level-1a" />}
+          primaryNavigationLarge={
+            <PrimaryNavigationLarge currentPage="level-1a" />
+          }
+          secondaryNavigation={secondaryNavigation}
+          secondaryNavigationLarge={secondaryNavigationLarge}
+          searchSlot={searchSlot}
+        />
+        <PageBody>
+          <div className="dsn-sidebar-layout">
+            <aside className="dsn-sidebar-layout__sidebar">
+              <SidebarNavigation currentPage="level-1a" />
+            </aside>
+            <main
+              id="main-content"
+              tabIndex={-1}
+              className="dsn-sidebar-layout__main"
+              style={mainStyle}
+            >
+              <MainContentWithToc pageName="Level 1a" />
+            </main>
+            <aside className="dsn-sidebar-layout__toc">
+              <TableOfContents appearance="plain" items={tocItems} />
+            </aside>
           </div>
         </PageBody>
         <PageFooter


### PR DESCRIPTION
## Summary

- Nieuwe **TableOfContents** component (HTML/CSS + React, volledig gedocumenteerd): inhoudsopgave met ankerlinks naar de H2-secties van een pagina.
  - `appearance="framed"` (default): accent-1 achtergrond + linkerborder, heading als `heading-3` — voor gebruik inline in de content-flow.
  - `appearance="plain"`: geen kader, heading als `heading-5` — voor gebruik in een losstaande kolom naast de hoofdinhoud.
  - Vervangt het `Note as="nav"` patroon voor inhoudsopgaven; `Note`'s docs/stories/tests zijn bijgewerkt om naar `TableOfContents` te verwijzen.
- Twee nieuwe Detailpage-templates in `WithSidebarPage.stories.tsx`: **With Sidebar + Table of Contents** en **Full Width + Sidebar + Table of Contents**. Alleen H2-secties worden opgenomen in de inhoudsopgave.
- Responsive gedrag: de inhoudsopgave wordt twee keer gerenderd (framed inline onder de lead paragraph, plain in de rechterkolom) en per breakpoint (80em) via CSS `display: none` getoond — geen dubbele content voor schermlezers.
- Design token `table-of-contents.json` (accent-1 gebaseerd) toegevoegd; exports/manifest/Introduction.mdx bijgewerkt (55 componenten totaal).

## Test plan

- [x] `pnpm test` — 1591 tests groen (incl. 21 nieuwe TableOfContents tests, bijgewerkte Note tests)
- [x] `pnpm --filter storybook exec tsc --noEmit` — 0 fouten
- [x] `pnpm lint` — 0 fouten (bestaande warnings ongewijzigd)
- [x] Handmatig getest in Storybook: TableOfContents (framed/plain), WithSidebarPage templates op 1100px (inline framed) en 1440px (rechterkolom plain), Full Width variant

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>