### PR TITLE
docs: synchroniseer documentatie t/m v1.0.6 (TableOfContents, codeblokken-conventie)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pnpm --filter @dsn-starter-kit/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (1549 tests across 75 test suites)
+# Run tests (1593 tests across 78 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -239,7 +239,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **SummaryList** | Yes      | Yes   | No            |
 | **Table**       | Yes      | Yes   | No            |
 
-**Navigation Components (6)**
+**Navigation Components (7)**
 
 | Component                | HTML/CSS | React | Web Component |
 | ------------------------ | -------- | ----- | ------------- |
@@ -249,6 +249,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **MenuLink**             | Yes      | Yes   | No            |
 | **PageFooter**           | Yes      | Yes   | No            |
 | **PageHeader**           | Yes      | Yes   | No            |
+| **TableOfContents**      | Yes      | Yes   | No            |
 
 **Branding Components (1)**
 
@@ -436,7 +437,7 @@ Comprehensive documentation is available in the `/docs` folder:
 
 - **Pre-commit hooks** via Husky + lint-staged (ESLint + Prettier)
 - **Type checking** across all packages (`pnpm type-check`)
-- **1549 tests** covering React components, Web Components, and utilities
+- **1593 tests** covering React components, Web Components, and utilities
 - **CI/CD** via GitHub Actions (lint, type-check, test, build)
 
 ## Tech Stack

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1,6 +1,6 @@
 # Components
 
-**Last Updated:** May 30, 2026
+**Last Updated:** July 10, 2026
 
 Complete component specifications and guidelines for the Design System Starter Kit.
 
@@ -2200,7 +2200,7 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 ## Navigation Components
 
-**Status:** Complete (HTML/CSS, React): 6 components total
+**Status:** Complete (HTML/CSS, React): 7 components total
 
 ### Menu
 
@@ -2863,6 +2863,105 @@ const [isOpen, setIsOpen] = React.useState(false);
 ```
 
 **Tests:** React (11 tests)
+
+---
+
+### TableOfContents
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-{html|react}/src/TableOfContents/`
+
+**Tokens:** `tokens/components/table-of-contents.json`
+
+**Props:** `heading` (default `'Op deze pagina'`), `headingLevel` (default `2`), `appearance` (`'framed'` | `'plain'`, default `'framed'`), `items` (`{ id, label }[]`), `className` + alle native `<nav>` attributen
+
+**Features:**
+
+- Inhoudsopgave met ankerlinks naar de H2-secties op de huidige pagina: alleen H2's horen in `items`
+- `appearance="framed"` (standaard): accent-1 achtergrond + linkerborder, heading als `heading-3`, voor gebruik inline in de content-flow (bijv. onder de lead paragraph)
+- `appearance="plain"`: geen kader, heading als `heading-5`, ankerlinks zonder onderstreping in rust (onderstreping op hover), voor gebruik in een losstaande kolom naast de hoofdinhoud, uitgelijnd met de Sidebar/Sub-navigatie
+- Rendert `<nav aria-labelledby>` gekoppeld aan de heading (auto-gegenereerd id via `useId`)
+- Componeert intern `Heading`, `UnorderedList` en `Link`
+
+**CSS-klassen:**
+
+| Klasse                           | Element   | Beschrijving                          |
+| -------------------------------- | --------- | ------------------------------------- |
+| `dsn-table-of-contents`          | `<nav>`   | Basiscomponent: altijd aanwezig       |
+| `dsn-table-of-contents--plain`   | `<nav>`   | Plain appearance: geen kader          |
+| `dsn-table-of-contents__heading` | `<h2-h6>` | Heading boven de lijst met ankerlinks |
+
+**Design tokens:**
+
+| Token                                                           | Waarde                      | Beschrijving                                                  |
+| --------------------------------------------------------------- | --------------------------- | ------------------------------------------------------------- |
+| `--dsn-table-of-contents-border-inline-start-width`             | `{dsn.border.width.medium}` | Breedte van de linkerborder (framed)                          |
+| `--dsn-table-of-contents-border-inline-start-color`             | accent-1 border             | Kleur van de linkerborder (framed)                            |
+| `--dsn-table-of-contents-background-color`                      | accent-1 bg                 | Achtergrondkleur (framed)                                     |
+| `--dsn-table-of-contents-padding-block`                         | `{dsn.space.block.xl}`      | Verticale padding (framed)                                    |
+| `--dsn-table-of-contents-padding-inline-start`                  | `{dsn.space.inline.xl}`     | Horizontale padding aan het begin, na de border (framed)      |
+| `--dsn-table-of-contents-padding-inline-end`                    | `{dsn.space.inline.xl}`     | Horizontale padding aan het einde (framed)                    |
+| `--dsn-table-of-contents-heading-gap`                           | `{dsn.space.row.xl}`        | Ruimte tussen de heading en de lijst met ankerlinks           |
+| `--dsn-table-of-contents-plain-padding-block`                   | `{dsn.space.block.md}`      | Plain: verticale padding, lijnt uit met Sidebar/Sub-navigatie |
+| `--dsn-table-of-contents-plain-list-gap`                        | `{dsn.space.row.lg}`        | Plain: ruimte tussen de ankerlinks                            |
+| `--dsn-table-of-contents-plain-link-text-decoration-line`       | `none`                      | Plain: ankerlinks zonder onderstreping in rust                |
+| `--dsn-table-of-contents-plain-link-hover-text-decoration-line` | `underline`                 | Plain: onderstreping op hover                                 |
+
+**Usage:**
+
+```html
+<!-- HTML/CSS: framed (default) -->
+<nav class="dsn-table-of-contents" aria-labelledby="toc-heading">
+  <h2
+    class="dsn-heading dsn-heading--heading-3 dsn-table-of-contents__heading"
+    id="toc-heading"
+  >
+    Op deze pagina
+  </h2>
+  <ul class="dsn-unordered-list">
+    <li>
+      <a class="dsn-link dsn-link--size-default" href="#sectie-1">Sectie 1</a>
+    </li>
+    <li>
+      <a class="dsn-link dsn-link--size-default" href="#sectie-2">Sectie 2</a>
+    </li>
+  </ul>
+</nav>
+
+<!-- HTML/CSS: plain -->
+<nav
+  class="dsn-table-of-contents dsn-table-of-contents--plain"
+  aria-labelledby="toc-heading-plain"
+>
+  <h2
+    class="dsn-heading dsn-heading--heading-5 dsn-table-of-contents__heading"
+    id="toc-heading-plain"
+  >
+    Op deze pagina
+  </h2>
+  <ul class="dsn-unordered-list">
+    <li>
+      <a class="dsn-link dsn-link--size-default" href="#sectie-1">Sectie 1</a>
+    </li>
+  </ul>
+</nav>
+```
+
+```tsx
+// React: framed (default): inline in de content-flow
+<TableOfContents
+  items={[
+    { id: 'sectie-1', label: 'Sectie 1' },
+    { id: 'sectie-2', label: 'Sectie 2' },
+  ]}
+/>
+
+// React: plain: in een losstaande kolom naast de hoofdinhoud
+<TableOfContents appearance="plain" items={items} />
+```
+
+**Tests:** React (15 tests)
 
 ---
 

--- a/docs/05-storybook-configuration.md
+++ b/docs/05-storybook-configuration.md
@@ -1,6 +1,6 @@
 # Storybook Configuration
 
-**Last Updated:** March 15, 2026
+**Last Updated:** July 10, 2026
 
 Documentation for the Storybook setup, runtime theme switching, UI components, and documentation structure.
 
@@ -336,7 +336,9 @@ import { PreviewFrame, CodeTabs } from './components';
 
 ### `htmlTemplate` patroon
 
-Elke story file (behalve wrapper componenten) definieert een `htmlTemplate` functie in `parameters.dsn`. Deze functie genereert de HTML string op basis van de huidige args en wordt door de CodeTabs HTML tab aangeroepen via `transform`.
+Elke story file definieert een `htmlTemplate` functie in `parameters.dsn`. Deze functie genereert de HTML string op basis van de huidige args en wordt door de CodeTabs HTML tab aangeroepen via `transform`.
+
+De template **spiegelt de daadwerkelijke component-render** (elementen, klassen, attributen) en volgt de story-args zodat het codeblok live meebeweegt met de Controls. Zie [DR-2026-04](./decisions/DR-2026-04-htmltemplate-spiegelt-echte-render.md) voor de conventie en de toegestane bewuste afwijkingen (statische id's in plaats van `useId`-waarden, svg-inhoud als comment, didactische `onclick`/`popovertarget`-attributen, story-scaffolding buiten het codeblok).
 
 **Pattern:**
 
@@ -366,14 +368,7 @@ const meta: Meta<typeof Button> = {
 };
 ```
 
-**Uitzonderingen: geen `htmlTemplate`:**
-
-| Component      | Reden                                                             |
-| -------------- | ----------------------------------------------------------------- |
-| CheckboxGroup  | Wrapper component met custom render: toont statische `html` prop  |
-| RadioGroup     | Wrapper component met custom render: toont statische `html` prop  |
-| DateInputGroup | Wrapper component met custom render: toont statische `html` prop  |
-| UnorderedList  | Geen zinvolle Controls beschikbaar om HTML dynamisch te genereren |
+**Geen uitzonderingen meer:** sinds PR #310 hebben alle componenten een `htmlTemplate`, ook wrapper componenten zoals CheckboxGroup, RadioGroup en DateInputGroup. De statische `html` prop van CodeTabs bestaat nog als fallback, maar wordt in de praktijk niet meer gebruikt.
 
 ### TokenControls
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,50 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Version 1.0.6 (July 10, 2026)
+
+### TableOfContents: nieuw component
+
+#### Added
+
+- **TableOfContents** (PR [#305](https://github.com/jeffreylauwers/design-system-starter-kit/pull/305)): inhoudsopgave met ankerlinks naar de H2-secties van een pagina (HTML/CSS + React).
+  - `appearance="framed"` (default): accent-1 achtergrond + linkerborder, heading als `heading-3`, voor gebruik inline in de content-flow
+  - `appearance="plain"`: geen kader, heading als `heading-5`, voor gebruik in een losstaande kolom naast de hoofdinhoud
+  - Vervangt het `Note as="nav"` patroon voor inhoudsopgaven; de docs, stories en tests van `Note` verwijzen nu naar `TableOfContents`
+  - Nieuw token-bestand `tokens/components/table-of-contents.json` (accent-1 gebaseerd)
+- Twee nieuwe Detailpage-templates in `WithSidebarPage.stories.tsx`: **With Sidebar + Table of Contents** en **Full Width + Sidebar + Table of Contents**. De inhoudsopgave wordt twee keer gerenderd (framed inline, plain in de rechterkolom) en per breakpoint (80em) via CSS `display: none` getoond, zonder dubbele content voor schermlezers.
+
+#### Fixed
+
+- **TableOfContents verfijning** (PR [#306](https://github.com/jeffreylauwers/design-system-starter-kit/pull/306)): `heading-gap` token toegevoegd voor de ruimte tussen heading en lijst; Plain-appearance ankerlinks tonen geen onderstreping in rust en wel op hover (omgekeerd t.o.v. de standaard Link), met eigen `plain-*` tokens
+
+### Storybook: codeblokken in lijn met echte component-markup
+
+#### Fixed
+
+- **HTML/CSS-codeblokken kloppen nu met de daadwerkelijke render** (PR [#310](https://github.com/jeffreylauwers/design-system-starter-kit/pull/310)): audit over alle 70 componenten waarbij de `htmlTemplate`-output automatisch is vergeleken met de echte React-render. 28 templates gecorrigeerd, onder andere:
+  - Alert/Note: `<strong>` vervangen door `<h2>`/`<h3>` (volgt de `headingLevel`-prop), heading-klasse `dsn-heading--heading-3`, icoon kreeg `dsn-icon--xl`
+  - Niet-bestaande klassen gecorrigeerd: `dsn-button--size-medium` naar `dsn-button--size-default` (Drawer, ModalDialog, Popover), `dsn-heading--level-1` naar `dsn-heading--heading-1` (Hero)
+  - Ontbrekende markup toegevoegd: `type="button"` (ActionGroup), `dsn-link--size-default` (Link), `dsn-page-body__inner` (PageBody, PageLayout), LinkButton-markup voor de verwijder-knop in File, volledige small/large-layout-structuur in PageHeader
+  - Losse icoon-comments vervangen door echte `<svg class="dsn-icon">` elementen met de icoonnaam als comment
+- **Codeblokken bewegen live mee met Controls**: templates volgen nu de story-args (o.a. Select-opties en lijst-items geserialiseerd uit `children`, Hero-variant, MenuLink-href). Zes componenten zonder `htmlTemplate` kregen er een: CheckboxGroup, DateInputGroup, PreHeading, RadioGroup, SummaryList, UnorderedList
+
+### Documentatie
+
+#### Added
+
+- Accessibility-richtlijn over focusvolgorde bij verschillende schermweergaves in de ActionGroup-docs (issue [#296](https://github.com/jeffreylauwers/design-system-starter-kit/issues/296), PR [#309](https://github.com/jeffreylauwers/design-system-starter-kit/pull/309))
+- Accessibility-richtlijn over focusvolgorde en CSS `order` in de Grid-docs (PR [#307](https://github.com/jeffreylauwers/design-system-starter-kit/pull/307))
+- Formulierpatronen-richtlijnen: `docs/07-form-flow-patterns.md` (PR [#292](https://github.com/jeffreylauwers/design-system-starter-kit/pull/292))
+- Consumer-gerichte getting started gids (PR [#291](https://github.com/jeffreylauwers/design-system-starter-kit/pull/291))
+
+#### Changed
+
+- Alle WCAG-verwijzingen bijgewerkt van 2.1 naar 2.2 (PR [#304](https://github.com/jeffreylauwers/design-system-starter-kit/pull/304))
+- Token descriptions thema-onafhankelijk gemaakt en volledig Nederlands (PR [#290](https://github.com/jeffreylauwers/design-system-starter-kit/pull/290))
+
+---
+
 ## Version 1.0.5 (July 7, 2026)
 
 ### ActionGroup — accessibiliteit

--- a/docs/decisions/DR-2026-04-htmltemplate-spiegelt-echte-render.md
+++ b/docs/decisions/DR-2026-04-htmltemplate-spiegelt-echte-render.md
@@ -1,0 +1,94 @@
+# DR-2026-04: htmlTemplate spiegelt de echte component-render
+
+**ID:** DR-2026-04
+**Datum:** Juli 2026
+**Status:** Accepted
+**Auteurs:** Jeffrey Lauwers
+
+---
+
+## Context
+
+Elke Storybook docs-pagina toont onder de preview een twee-tabs codeblok (`CodeTabs`): een React-tab en een HTML/CSS-tab. De HTML/CSS-tab wordt gegenereerd door een `htmlTemplate(args)`-functie in `parameters.dsn` van het stories-bestand. Deze templates werden met de hand geschreven en dreven in de loop van de tijd af van de werkelijke component-markup: Alert en Note toonden een `<strong>` waar de component een `<h2>`/`<h3>` rendert, er stonden niet-bestaande klassen in (`dsn-button--size-medium`, `dsn-heading--level-1`) en zes componenten hadden helemaal geen template, waardoor hun codeblok statisch bleef als een gebruiker props wijzigde via Controls.
+
+Voor een design system met een twee-lagenpatroon (DR-2026-02) is de HTML/CSS-tab de primaire documentatie van de HTML/CSS-laag. Een codeblok dat afwijkt van wat de component werkelijk rendert, leidt tot foutieve eigen implementaties bij consumenten.
+
+---
+
+## Opties overwogen
+
+### Optie 1: HTML automatisch genereren uit de live render
+
+De HTML/CSS-tab zou de daadwerkelijke DOM van de preview kunnen serialiseren.
+
+**Voordeel:** Kan nooit afwijken van de werkelijkheid.
+**Nadeel:** Toont React-implementatiedetails die in een HTML-voorbeeld niet thuishoren (`useId`-waarden zoals `:R2:`, ontbrekende `onclick`-gedrag omdat React events niet in de DOM zichtbaar zijn) en volledige inline SVG-paden die het voorbeeld onleesbaar maken. Het voorbeeld is dan correct maar onbruikbaar als documentatie.
+
+### Optie 2: Handgeschreven templates die de render spiegelen, met expliciete bewuste afwijkingen (gekozen)
+
+`htmlTemplate(args)` blijft handgeschreven, maar moet structureel exact overeenkomen met de echte render (elementen, klassen, attributen) en de story-args volgen zodat het codeblok live meebeweegt met Controls. Een beperkte, gedocumenteerde lijst afwijkingen is toegestaan.
+
+**Voordeel:** Leesbare, didactisch correcte HTML-voorbeelden die kloppen met de werkelijkheid.
+**Nadeel:** Vereist discipline: elke markup-wijziging in een component moet ook in de template landen.
+
+---
+
+## Beslissing
+
+**Elke `htmlTemplate` spiegelt de daadwerkelijke component-render en volgt de story-args. Elk component met een docs-pagina heeft een `htmlTemplate` (geen statische fallback).**
+
+De toegestane, bewuste afwijkingen van de letterlijke render zijn:
+
+1. **Statische id's in plaats van React `useId`-waarden**: `id="dialog-title"` in plaats van `:R2:`. De koppeling (`aria-labelledby` ↔ `id`) moet binnen het voorbeeld kloppen.
+2. **SVG-inhoud als comment**: `<svg class="dsn-icon" aria-hidden="true"><!-- icoon-naam --></svg>` in plaats van de volledige path-data. Het svg-element zelf, inclusief klassen zoals `dsn-icon--xl`, staat wél in het voorbeeld.
+3. **Didactische interactie-attributen voor de HTML/CSS-laag**: `onclick="this.closest('dialog').close()"`, `popovertarget`, `aria-expanded` mogen in het voorbeeld staan waar de React-laag dit via props/refs regelt.
+4. **Story-scaffolding blijft buiten het codeblok**: wrappers, paddings en gesimuleerde paginacontext uit de Default story horen niet in het voorbeeld; alleen de component-markup zelf.
+
+Verificatie gebeurt door de `htmlTemplate`-output te vergelijken met `renderToStaticMarkup` van de component met dezelfde args (zoals uitgevoerd in PR #310, waar 28 afwijkende templates zijn gecorrigeerd en 6 ontbrekende zijn toegevoegd).
+
+---
+
+## Impact
+
+| Dimension                     | Meting                                                                                                   |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Bestanden geraakt             | Alle `*.stories.tsx` in `packages/storybook/src/` (35 bestanden gecorrigeerd in PR #310)                 |
+| Componenten geraakt           | Alle 70+ componenten met een docs-pagina                                                                 |
+| Breaking changes              | Nee: alleen documentatie-output                                                                          |
+| Alternatief dat verwijderd is | Statische `html`-fallback als enige bron voor het HTML/CSS-tabblad; templates die afwijken van de render |
+
+---
+
+## Gevolgen
+
+**Wat makkelijker wordt:**
+
+- Consumenten van de HTML/CSS-laag kunnen codeblokken letterlijk kopiëren zonder verrassingen.
+- Props wijzigen via Controls toont direct het effect op de markup: het codeblok is een levend voorbeeld.
+- Afwijkingen zijn machinaal detecteerbaar (template vs `renderToStaticMarkup` vergelijken).
+
+**Wat moeilijker wordt:**
+
+- Elke markup-wijziging in een component (nieuw element, klasse, attribuut) vereist een bijbehorende update van de `htmlTemplate` in het stories-bestand. Dit sluit aan op de bestaande verificatie-grep-werkwijze na markup-wijzigingen.
+
+**Nieuwe verplichting voor contributors:**
+Bij een nieuw component hoort een `htmlTemplate` die de render spiegelt en args volgt. Bij een markup-wijziging hoort een template-update in dezelfde PR.
+
+---
+
+## Supersedes / superseded by
+
+Niet van toepassing: dit is een initieel besluit over de codeblok-conventie.
+
+---
+
+## Gerelateerde records
+
+- DR-2026-02 (twee-lagenpatroon): de HTML/CSS-tab documenteert de HTML/CSS-laag; deze conventie houdt die documentatie betrouwbaar
+- Zie ook: PR [#310](https://github.com/jeffreylauwers/design-system-starter-kit/pull/310)
+
+---
+
+## Review trigger
+
+Herzie dit besluit als Storybook een betrouwbare ingebouwde HTML-serialisatie introduceert die leesbare voorbeelden oplevert (zonder React-implementatiedetails), of als het aantal componenten het handmatig onderhouden van templates onwerkbaar maakt.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -11,6 +11,7 @@ Een decision record documenteert **waarom** iets is zoals het is — niet alleen
 | [DR-2026-01](DR-2026-01-button-label-span-over-aria-label.md)     | `dsn-button__label` span in plaats van `aria-label` op buttons       | Accepted |
 | [DR-2026-02](DR-2026-02-twee-lagenpatroon-html-css-plus-react.md) | HTML/CSS als bron van waarheid, React als wrapper                    | Accepted |
 | [DR-2026-03](DR-2026-03-breakpoints-als-reference-only-tokens.md) | Breakpoints als reference-only tokens, hardcoded in CSS @media rules | Accepted |
+| [DR-2026-04](DR-2026-04-htmltemplate-spiegelt-echte-render.md)    | Storybook `htmlTemplate` spiegelt de echte render en volgt de args   | Accepted |
 
 ## Een nieuw record toevoegen
 

--- a/packages/components-html/README.md
+++ b/packages/components-html/README.md
@@ -84,6 +84,7 @@ import '@dsn-starter-kit/components-html/modal-dialog';
 - `./form-field-status` — Form field status styles
 - `./grid` — Grid layout styles
 - `./heading` — Heading styles
+- `./heading-group` — Heading group styles
 - `./hero` — Hero section styles
 - `./icon` — Icon component styles
 - `./image` — Image component styles
@@ -103,6 +104,7 @@ import '@dsn-starter-kit/components-html/modal-dialog';
 - `./page-layout` — Page layout styles
 - `./paragraph` — Paragraph styles
 - `./popover` — Popover component styles
+- `./pre-heading` — Pre-heading styles
 - `./progress-bar` — Progress bar styles
 - `./skip-link` — Skip link styles
 - `./spinner` — Spinner component styles
@@ -110,6 +112,7 @@ import '@dsn-starter-kit/components-html/modal-dialog';
 - `./status-badge` — Status badge styles
 - `./summary-list` — Summary list styles
 - `./table` — Table component styles
+- `./table-of-contents` — Table of contents styles
 - `./text-area` — Text area styles
 - `./text-input` — Text input styles
 - `./unordered-list` — Unordered list styles
@@ -139,7 +142,8 @@ import '@dsn-starter-kit/components-html/modal-dialog';
 | FormFieldLabel        | `dsn-form-field-label`                                           | `./form-field-label`         |
 | FormFieldStatus       | `dsn-form-field-status`, `dsn-form-field-status--{variant}`      | `./form-field-status`        |
 | Grid                  | `dsn-grid`                                                       | `./grid`                     |
-| Heading               | `dsn-heading`, `dsn-heading--level-{level}`                      | `./heading`                  |
+| Heading               | `dsn-heading`, `dsn-heading--heading-{level}`                    | `./heading`                  |
+| HeadingGroup          | `dsn-heading-group`                                              | `./heading-group`            |
 | Hero                  | `dsn-hero`                                                       | `./hero`                     |
 | Icon                  | `dsn-icon`, `dsn-icon--size-{size}`                              | `./icon`                     |
 | Image                 | `dsn-image`                                                      | `./image`                    |
@@ -159,6 +163,7 @@ import '@dsn-starter-kit/components-html/modal-dialog';
 | PageLayout            | `dsn-page-layout`                                                | `./page-layout`              |
 | Paragraph             | `dsn-paragraph`, `dsn-paragraph--size-{size}`                    | `./paragraph`                |
 | Popover               | `dsn-popover`                                                    | `./popover`                  |
+| PreHeading            | `dsn-pre-heading`                                                | `./pre-heading`              |
 | ProgressBar           | `dsn-progress-bar`                                               | `./progress-bar`             |
 | SkipLink              | `dsn-skip-link`                                                  | `./skip-link`                |
 | Spinner               | `dsn-spinner`                                                    | `./spinner`                  |
@@ -166,6 +171,7 @@ import '@dsn-starter-kit/components-html/modal-dialog';
 | StatusBadge           | `dsn-status-badge`, `dsn-status-badge--{variant}`                | `./status-badge`             |
 | SummaryList           | `dsn-summary-list`                                               | `./summary-list`             |
 | Table                 | `dsn-table`                                                      | `./table`                    |
+| TableOfContents       | `dsn-table-of-contents`, `dsn-table-of-contents--plain`          | `./table-of-contents`        |
 | TextArea              | `dsn-text-area`, `dsn-text-area--size-{size}`                    | `./text-area`                |
 | TextInput             | `dsn-text-input`, `dsn-text-input--size-{size}`                  | `./text-input`               |
 | UnorderedList         | `dsn-unordered-list`                                             | `./unordered-list`           |


### PR DESCRIPTION
## Samenvatting

Documentatie-sync na de recente merges. TableOfContents (#305/#306) stond nog nergens in de projectdocumentatie, en de codeblokken-fix (#310) introduceerde een conventie die het vastleggen waard is.

## Wijzigingen

**Changelog**
- Nieuwe 1.0.6-entry: TableOfContents component (#305) en verfijning (#306), Storybook codeblokken in lijn met de echte render (#310), plus zes eerdere ongedocumenteerde PR's (#290 token descriptions, #291 getting started, #292 formulierpatronen, #304 WCAG 2.2, #307/#309 a11y-richtlijnen)

**Componentdocumentatie**
- `docs/03-components.md`: volledige TableOfContents-sectie onder Navigation Components (props, CSS-klassen, design tokens, usage-voorbeelden, 15 tests); telling 6 naar 7
- Root `README.md`: TableOfContents in de componenttabel (Navigation 6 naar 7), testaantal geactualiseerd van 1549 naar 1593 (78 suites)
- `packages/components-html/README.md`: `table-of-contents`, `heading-group` en `pre-heading` ontbraken in de exports-lijst en componententabel; alle drie toegevoegd. Heading-klasse gecorrigeerd van `dsn-heading--level-{level}` (bestaat niet) naar `dsn-heading--heading-{level}`

**Storybook-configuratie en decision record**
- `docs/05-storybook-configuration.md`: de tabel met "uitzonderingen zonder htmlTemplate" was achterhaald door #310 (alle componenten hebben er nu een); vervangen door de nieuwe conventie met verwijzing naar het decision record
- Nieuw `docs/decisions/DR-2026-04-htmltemplate-spiegelt-echte-render.md`: htmlTemplate spiegelt de daadwerkelijke component-render en volgt de story-args, met de vier toegestane bewuste afwijkingen (statische id's, svg-comments, didactische interactie-attributen, geen story-scaffolding); toegevoegd aan de index

## Verificatie

- Testaantal (1593 / 78 suites) en componenttelling (72 mappen in `packages/components-react/src/`) rechtstreeks uit de codebase gehaald
- Exports-lijst in components-html README programmatisch vergeleken met de `exports` map in `package.json`: geen ontbrekende entries meer

🤖 Generated with [Claude Code](https://claude.com/claude-code)