### PR TITLE
fix(Alert,Note): voeg visueel verborgen variant-label toe voor screenreaders

### DIFF
--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1558,7 +1558,7 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 
 **Variants (4 total):** `info` (default), `positive`, `negative`, `warning`
 
-**Props:** `variant`, `heading`, `headingLevel`, `iconStart`, `children`
+**Props:** `variant`, `heading`, `headingLevel`, `iconStart`, `variantLabel`, `children`
 
 **Features:**
 
@@ -1567,6 +1567,7 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 - `grid-template-columns: var(--dsn-icon-size-xl) 1fr`
 - Voorkeurspicoon per variant; overschrijfbaar via `iconStart` (`null` = geen icoon)
 - `heading` verplicht; `headingLevel` default `2` (visueel als `heading-3`)
+- Visueel verborgen variant-label vóór de heading benoemt de variant voor screenreaders: `Informatie: ` / `Succes: ` / `Foutmelding: ` / `Let op: `. Aanpasbaar via `variantLabel` (eigen tekst voor andere talen; `''` onderdrukt het label als de heading de variant al benoemt). Bewust echte verborgen tekst in plaats van `aria-label` op de svg: wordt meevertaald door vertaaltools, werkt in braille en blijft beschikbaar zonder icoon
 - Volledige border rondom (niet alleen inline-start)
 - Body content via `children`: gebruik `<Paragraph>` voor tekst, `<UnorderedList>` voor lijsten
 
@@ -1575,19 +1576,24 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 ```html
 <div class="dsn-alert" role="alert">
   <span class="dsn-alert__icon" aria-hidden="true">
-    <svg class="dsn-icon" aria-hidden="true"><!-- info-circle --></svg>
+    <svg class="dsn-icon dsn-icon--xl" aria-hidden="true">
+      <!-- info-circle -->
+    </svg>
   </span>
-  <h2 class="dsn-alert__heading dsn-heading dsn-heading--3">Heading</h2>
+  <h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading">
+    <span class="dsn-visually-hidden">Informatie: </span>Heading
+  </h2>
   <div class="dsn-alert__content">
     <p class="dsn-paragraph">Body content.</p>
   </div>
 </div>
 
 <!-- Varianten: dsn-alert--positive / dsn-alert--negative / dsn-alert--warning -->
-<!-- Geen icoon: dsn-alert--no-icon (klasse op root, span weglaten) -->
+<!-- Variant-label per variant: Informatie: / Succes: / Foutmelding: / Let op: -->
+<!-- Geen icoon: dsn-alert--no-icon (klasse op root, span weglaten; variant-label blijft) -->
 ```
 
-**Tests:** React (15 tests)
+**Tests:** React (38 tests)
 
 ### Note
 
@@ -1599,7 +1605,7 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 
 **Variants (5 total):** `neutral` (default), `info`, `positive`, `negative`, `warning`
 
-**Props:** `as`, `variant`, `heading`, `headingLevel`, `iconStart`, `children`
+**Props:** `as`, `variant`, `heading`, `headingLevel`, `iconStart`, `variantLabel`, `children`
 
 **Features:**
 
@@ -1611,22 +1617,28 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 - `as` prop: `div` (default), `aside`, `nav`, `section`: semantiek losgekoppeld van visuele stijl
 - Automatische `aria-labelledby` via `useId()` voor landmark-elementen met heading
 - `heading` optioneel (Alert: verplicht); `headingLevel` default `3`
+- Visueel verborgen variant-label benoemt de niet-neutrale varianten voor screenreaders (zelfde teksten en `variantLabel` prop als Alert); `neutral` heeft bewust geen label. Met heading komt het label vóór de heading-tekst, zonder heading als losse `<span class="dsn-visually-hidden">` vóór de content
 
 **HTML/CSS:**
 
 ```html
-<div class="dsn-note">
+<div class="dsn-note dsn-note--info">
   <span class="dsn-note__icon" aria-hidden="true">
-    <svg class="dsn-icon" aria-hidden="true"><!-- info-circle --></svg>
+    <svg class="dsn-icon dsn-icon--xl" aria-hidden="true">
+      <!-- info-circle -->
+    </svg>
   </span>
-  <h3 class="dsn-heading dsn-heading--3 dsn-note__heading">Heading</h3>
+  <h3 class="dsn-heading dsn-heading--heading-3 dsn-note__heading">
+    <span class="dsn-visually-hidden">Informatie: </span>Heading
+  </h3>
   <div class="dsn-note__content">
     <p class="dsn-paragraph">Body content.</p>
   </div>
 </div>
 
 <!-- Varianten: dsn-note--info / dsn-note--positive / dsn-note--negative / dsn-note--warning -->
-<!-- Zonder heading: dsn-note--no-heading -->
+<!-- Neutral (default, geen modifier) heeft geen variant-label -->
+<!-- Zonder heading: dsn-note--no-heading; variant-label als losse span vóór de content -->
 <!-- Landmark: <aside>, <nav>, <section> i.p.v. <div> -->
 ```
 
@@ -1651,7 +1663,7 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 </Note>
 ```
 
-**Tests:** React (18 tests)
+**Tests:** React (50 tests)
 
 ### Table
 

--- a/docs/07-form-flow-patterns.md
+++ b/docs/07-form-flow-patterns.md
@@ -196,10 +196,12 @@ Bij één of meer fouten na submit:
 4. De tekst in de `Alert` en bij het veld is **identiek**
 5. In de `Alert` zijn de foutmeldingen ankerlinkjes die naar het betreffende veld springen
 
+De heading benoemt de fout al, dus onderdruk het automatische variant-label van de Alert met `variantLabel=""` om een dubbele aankondiging ("Foutmelding: Er is een foutmelding") te voorkomen.
+
 **Eén fout:**
 
 ```tsx
-<Alert variant="negative" heading="Er is een foutmelding">
+<Alert variant="negative" heading="Er is een foutmelding" variantLabel="">
   <Link href="#veld-id">Foutmeldingstekst</Link>
 </Alert>
 ```
@@ -207,7 +209,7 @@ Bij één of meer fouten na submit:
 **Meerdere fouten:**
 
 ```tsx
-<Alert variant="negative" heading="Er zijn 3 foutmeldingen">
+<Alert variant="negative" heading="Er zijn 3 foutmeldingen" variantLabel="">
   <UnorderedList>
     <li>
       <Link href="#veld-id-1">Foutmeldingstekst 1</Link>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Unreleased
+
+### Alert & Note: variant hoorbaar voor screenreaders
+
+#### Changed
+
+- **Visueel verborgen variant-label** (PR [#312](https://github.com/jeffreylauwers/design-system-starter-kit/pull/312), issue [#297](https://github.com/jeffreylauwers/design-system-starter-kit/issues/297)): Alert en Note benoemen de variant nu ook voor screenreadergebruikers via een `<span class="dsn-visually-hidden">` vóór de heading (of als losse span vóór de content bij een Note zonder heading). Defaults per variant: `Informatie: ` / `Succes: ` / `Foutmelding: ` / `Let op: `; Note-variant `neutral` heeft bewust geen label.
+  - Nieuwe prop `variantLabel` op beide componenten: eigen tekst (bijv. andere taal) of `''` om het label te onderdrukken wanneer de heading de variant al benoemt
+  - Bewust echte verborgen tekst in plaats van `aria-label` op de svg: wordt meevertaald door vertaaltools, werkt in braille en blijft beschikbaar als het icoon wordt onderdrukt via `iconStart={null}`; het icoon blijft decoratief (`aria-hidden`)
+  - Let op: geen API-breaking change, maar de voorgelezen output van elke bestaande Alert en niet-neutrale Note verandert (het label komt erbij)
+  - Het foutmelding-summary patroon (FormFlowPatterns, `docs/07-form-flow-patterns.md`, FormStepExtendedPage-template) gebruikt `variantLabel=""` omdat de heading "Er is een foutmelding" de variant daar al benoemt
+
 ## Version 1.0.6 (July 10, 2026)
 
 ### TableOfContents: nieuw component

--- a/packages/components-html/src/alert/alert.css
+++ b/packages/components-html/src/alert/alert.css
@@ -2,11 +2,19 @@
  * Alert Component
  * Important message that informs the user about the current activity or state.
  *
+ * The icon is decorative (aria-hidden); a visually hidden variant label at the
+ * start of the heading announces the variant to screen reader users. Real text
+ * (not aria-label on the svg) so it gets translated by translation tools,
+ * works in braille and stays available when the icon is omitted.
+ * Default labels: "Informatie: " / "Succes: " / "Foutmelding: " / "Let op: ".
+ *
  * Usage:
  * <!-- Info variant (default), with icon -->
  * <div class="dsn-alert" role="alert">
- *   <svg class="dsn-icon dsn-alert__icon" aria-hidden="true"><!-- info-circle --></svg>
- *   <strong class="dsn-alert__heading">Heading</strong>
+ *   <span class="dsn-alert__icon" aria-hidden="true">
+ *     <svg class="dsn-icon dsn-icon--xl" aria-hidden="true"><!-- info-circle --></svg>
+ *   </span>
+ *   <h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading"><span class="dsn-visually-hidden">Informatie: </span>Heading</h2>
  *   <div class="dsn-alert__content">
  *     <p>Body text or any content.</p>
  *   </div>
@@ -14,8 +22,10 @@
  *
  * <!-- Positive variant -->
  * <div class="dsn-alert dsn-alert--positive" role="alert">
- *   <svg class="dsn-icon dsn-alert__icon" aria-hidden="true"><!-- circle-check --></svg>
- *   <strong class="dsn-alert__heading">Gelukt</strong>
+ *   <span class="dsn-alert__icon" aria-hidden="true">
+ *     <svg class="dsn-icon dsn-icon--xl" aria-hidden="true"><!-- circle-check --></svg>
+ *   </span>
+ *   <h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading"><span class="dsn-visually-hidden">Succes: </span>Gelukt</h2>
  *   <div class="dsn-alert__content">
  *     <p>Uw aanvraag is succesvol ingediend.</p>
  *   </div>
@@ -23,8 +33,10 @@
  *
  * <!-- Negative variant -->
  * <div class="dsn-alert dsn-alert--negative" role="alert">
- *   <svg class="dsn-icon dsn-alert__icon" aria-hidden="true"><!-- exclamation-circle --></svg>
- *   <strong class="dsn-alert__heading">Er is een fout opgetreden</strong>
+ *   <span class="dsn-alert__icon" aria-hidden="true">
+ *     <svg class="dsn-icon dsn-icon--xl" aria-hidden="true"><!-- exclamation-circle --></svg>
+ *   </span>
+ *   <h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading"><span class="dsn-visually-hidden">Foutmelding: </span>Er is een fout opgetreden</h2>
  *   <div class="dsn-alert__content">
  *     <p>Controleer uw gegevens en probeer het opnieuw.</p>
  *   </div>
@@ -32,16 +44,18 @@
  *
  * <!-- Warning variant -->
  * <div class="dsn-alert dsn-alert--warning" role="alert">
- *   <svg class="dsn-icon dsn-alert__icon" aria-hidden="true"><!-- alert-triangle --></svg>
- *   <strong class="dsn-alert__heading">Let op</strong>
+ *   <span class="dsn-alert__icon" aria-hidden="true">
+ *     <svg class="dsn-icon dsn-icon--xl" aria-hidden="true"><!-- alert-triangle --></svg>
+ *   </span>
+ *   <h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading"><span class="dsn-visually-hidden">Let op: </span>Uw sessie verloopt binnenkort</h2>
  *   <div class="dsn-alert__content">
- *     <p>Uw sessie verloopt binnenkort.</p>
+ *     <p>Sla uw werk op om gegevensverlies te voorkomen.</p>
  *   </div>
  * </div>
  *
- * <!-- Without icon -->
+ * <!-- Without icon: keep the visually hidden variant label -->
  * <div class="dsn-alert dsn-alert--no-icon" role="alert">
- *   <strong class="dsn-alert__heading">Heading</strong>
+ *   <h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading"><span class="dsn-visually-hidden">Informatie: </span>Heading</h2>
  *   <div class="dsn-alert__content">
  *     <p>Body text without an icon.</p>
  *   </div>

--- a/packages/components-html/src/note/note.css
+++ b/packages/components-html/src/note/note.css
@@ -3,34 +3,42 @@
  * Visually highlighted message for supplementary or important information.
  * Passive counterpart to Alert — no live region, read on navigation only.
  *
+ * The icon is decorative (aria-hidden); the non-neutral variants (info,
+ * positive, negative, warning) carry a visually hidden variant label that
+ * announces the variant to screen reader users: "Informatie: " / "Succes: " /
+ * "Foutmelding: " / "Let op: ". With a heading the label is the first child of
+ * the heading; without a heading it is a standalone span before the content.
+ * Neutral has no label: that variant deliberately carries no semantic signal.
+ *
  * Usage:
- * <!-- Neutral (default), with icon and heading -->
+ * <!-- Neutral (default), with icon and heading — no variant label -->
  * <div class="dsn-note">
  *   <span class="dsn-note__icon" aria-hidden="true">
- *     <svg class="dsn-icon" aria-hidden="true"><!-- info-circle --></svg>
+ *     <svg class="dsn-icon dsn-icon--xl" aria-hidden="true"><!-- info-circle --></svg>
  *   </span>
- *   <strong class="dsn-heading dsn-heading--3 dsn-note__heading">Let op</strong>
+ *   <h3 class="dsn-heading dsn-heading--heading-3 dsn-note__heading">Let op</h3>
  *   <div class="dsn-note__content">
  *     <p>Aanvullende informatie over dit onderwerp.</p>
  *   </div>
  * </div>
  *
- * <!-- Info variant -->
+ * <!-- Info variant, with visually hidden variant label -->
  * <div class="dsn-note dsn-note--info">
  *   <span class="dsn-note__icon" aria-hidden="true">
- *     <svg class="dsn-icon" aria-hidden="true"><!-- info-circle --></svg>
+ *     <svg class="dsn-icon dsn-icon--xl" aria-hidden="true"><!-- info-circle --></svg>
  *   </span>
- *   <strong class="dsn-heading dsn-heading--3 dsn-note__heading">Informatie</strong>
+ *   <h3 class="dsn-heading dsn-heading--heading-3 dsn-note__heading"><span class="dsn-visually-hidden">Informatie: </span>Heading</h3>
  *   <div class="dsn-note__content">
  *     <p>Body content.</p>
  *   </div>
  * </div>
  *
- * <!-- Without heading — icon spans both rows -->
- * <div class="dsn-note dsn-note--no-heading">
+ * <!-- Without heading — icon spans both rows, variant label as standalone span -->
+ * <div class="dsn-note dsn-note--warning dsn-note--no-heading">
  *   <span class="dsn-note__icon" aria-hidden="true">
- *     <svg class="dsn-icon" aria-hidden="true"><!-- info-circle --></svg>
+ *     <svg class="dsn-icon dsn-icon--xl" aria-hidden="true"><!-- alert-triangle --></svg>
  *   </span>
+ *   <span class="dsn-visually-hidden">Let op: </span>
  *   <div class="dsn-note__content">
  *     <p>Aanvullende informatie.</p>
  *   </div>
@@ -44,12 +52,12 @@
  * <!-- as="nav" — standalone navigation section (not a page table of contents: use TableOfContents) -->
  * <nav class="dsn-note" aria-labelledby="note-heading-id">
  *   <span class="dsn-note__icon" aria-hidden="true">
- *     <svg class="dsn-icon" aria-hidden="true"><!-- info-circle --></svg>
+ *     <svg class="dsn-icon dsn-icon--xl" aria-hidden="true"><!-- info-circle --></svg>
  *   </span>
- *   <strong class="dsn-heading dsn-heading--3 dsn-note__heading" id="note-heading-id">Related pages</strong>
- *   <nav class="dsn-note__content">
+ *   <h3 class="dsn-heading dsn-heading--heading-3 dsn-note__heading" id="note-heading-id">Related pages</h3>
+ *   <div class="dsn-note__content">
  *     <ul>...</ul>
- *   </nav>
+ *   </div>
  * </nav>
  */
 

--- a/packages/components-react/src/Alert/Alert.test.tsx
+++ b/packages/components-react/src/Alert/Alert.test.tsx
@@ -83,7 +83,10 @@ describe('Alert', () => {
   it('renders heading as h2 by default', () => {
     render(<Alert heading="Standaard heading" />);
     expect(
-      screen.getByRole('heading', { level: 2, name: 'Standaard heading' })
+      screen.getByRole('heading', {
+        level: 2,
+        name: /^Informatie:\s?Standaard heading$/,
+      })
     ).toBeInTheDocument();
   });
 
@@ -92,7 +95,10 @@ describe('Alert', () => {
     (level) => {
       render(<Alert heading="Heading" headingLevel={level} />);
       expect(
-        screen.getByRole('heading', { level, name: 'Heading' })
+        screen.getByRole('heading', {
+          level,
+          name: /^Informatie:\s?Heading$/,
+        })
       ).toBeInTheDocument();
     }
   );
@@ -147,6 +153,50 @@ describe('Alert', () => {
     expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
     const iconSpan = document.querySelector('.dsn-alert__icon');
     expect(iconSpan).toBeInTheDocument();
+  });
+
+  // ===========================
+  // Variant label
+  // ===========================
+
+  it.each([
+    ['info', 'Informatie: '],
+    ['positive', 'Succes: '],
+    ['negative', 'Foutmelding: '],
+    ['warning', 'Let op: '],
+  ] as const)(
+    'prefixes heading with visually hidden default label for %s variant',
+    (variant, label) => {
+      render(<Alert variant={variant} heading="Heading" />);
+      expect(
+        screen.getByRole('heading', {
+          name: new RegExp(`^${label.trim()}\\s?Heading$`),
+        })
+      ).toBeInTheDocument();
+      const hidden = document.querySelector(
+        '.dsn-alert__heading .dsn-visually-hidden'
+      );
+      expect(hidden).toHaveTextContent(label.trim());
+    }
+  );
+
+  it('renders custom variantLabel', () => {
+    render(
+      <Alert variant="negative" heading="Heading" variantLabel="Error: " />
+    );
+    expect(
+      screen.getByRole('heading', { name: /^Error:\s?Heading$/ })
+    ).toBeInTheDocument();
+  });
+
+  it('renders no visually hidden label when variantLabel=""', () => {
+    render(<Alert variant="negative" heading="Foutmelding" variantLabel="" />);
+    expect(
+      screen.getByRole('heading', { name: 'Foutmelding' })
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('.dsn-visually-hidden')
+    ).not.toBeInTheDocument();
   });
 
   // ===========================
@@ -211,7 +261,9 @@ describe('Alert', () => {
         Uw gegevens zijn opgeslagen.
       </Alert>
     );
-    expect(screen.getByRole('heading', { name: 'Gelukt' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /^Succes:\s?Gelukt$/ })
+    ).toBeInTheDocument();
     expect(
       screen.getByText('Uw gegevens zijn opgeslagen.')
     ).toBeInTheDocument();

--- a/packages/components-react/src/Alert/Alert.tsx
+++ b/packages/components-react/src/Alert/Alert.tsx
@@ -13,6 +13,13 @@ const PREFERRED_ICONS: Record<AlertVariant, string> = {
   warning: 'alert-triangle',
 };
 
+const VARIANT_LABELS: Record<AlertVariant, string> = {
+  info: 'Informatie: ',
+  positive: 'Succes: ',
+  negative: 'Foutmelding: ',
+  warning: 'Let op: ',
+};
+
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Semantische variant die de signaalkleur bepaalt
@@ -38,6 +45,16 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
    * - `ReactNode` — aangepast icoon
    */
   iconStart?: React.ReactNode;
+
+  /**
+   * Visueel verborgen tekst vóór de heading die de variant benoemt voor
+   * screenreadergebruikers (inclusief scheidingsteken en spatie).
+   * - `undefined` (default) — standaardtekst per variant:
+   *   `'Informatie: '` / `'Succes: '` / `'Foutmelding: '` / `'Let op: '`
+   * - `''` — geen variant-label (bijv. als de heading de variant al benoemt)
+   * - `string` — eigen tekst, bijv. voor een andere taal
+   */
+  variantLabel?: string;
 
   /**
    * Optionele body content (tekst, lijst, links, etc.)
@@ -80,6 +97,11 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
  * <Alert variant="info" heading="Tip" iconStart={<Icon name="star" aria-hidden />}>
  *   Gebruik de zoekfunctie om snel te navigeren.
  * </Alert>
+ *
+ * // Variant-label onderdrukken (heading benoemt de variant al)
+ * <Alert variant="negative" heading="Foutmelding" variantLabel="">
+ *   Controleer uw gegevens.
+ * </Alert>
  * ```
  */
 export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
@@ -90,12 +112,14 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
       heading,
       headingLevel = 2,
       iconStart,
+      variantLabel,
       children,
       ...props
     },
     ref
   ) => {
     const noIcon = iconStart === null;
+    const resolvedVariantLabel = variantLabel ?? VARIANT_LABELS[variant];
 
     const resolvedIcon =
       iconStart === undefined ? (
@@ -127,6 +151,9 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
           appearance="heading-3"
           className="dsn-alert__heading"
         >
+          {resolvedVariantLabel && (
+            <span className="dsn-visually-hidden">{resolvedVariantLabel}</span>
+          )}
           {heading}
         </Heading>
         {children && <div className="dsn-alert__content">{children}</div>}

--- a/packages/components-react/src/Note/Note.test.tsx
+++ b/packages/components-react/src/Note/Note.test.tsx
@@ -146,6 +146,77 @@ describe('Note', () => {
   });
 
   // ===========================
+  // Variant label
+  // ===========================
+
+  it('renders no visually hidden label for neutral variant (default)', () => {
+    render(<Note heading="Heading">Inhoud</Note>);
+    expect(
+      screen.getByRole('heading', { name: 'Heading' })
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('.dsn-visually-hidden')
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['info', 'Informatie: '],
+    ['positive', 'Succes: '],
+    ['negative', 'Foutmelding: '],
+    ['warning', 'Let op: '],
+  ] as const)(
+    'prefixes heading with visually hidden default label for %s variant',
+    (variant, label) => {
+      render(
+        <Note variant={variant} heading="Heading">
+          Inhoud
+        </Note>
+      );
+      expect(
+        screen.getByRole('heading', {
+          name: new RegExp(`^${label.trim()}\\s?Heading$`),
+        })
+      ).toBeInTheDocument();
+      const hidden = document.querySelector(
+        '.dsn-note__heading .dsn-visually-hidden'
+      );
+      expect(hidden).toHaveTextContent(label.trim());
+    }
+  );
+
+  it('renders standalone visually hidden label when no heading', () => {
+    const { container } = render(<Note variant="warning">Inhoud</Note>);
+    const hidden = container.querySelector('.dsn-visually-hidden');
+    expect(hidden).toBeInTheDocument();
+    expect(hidden).toHaveTextContent('Let op:');
+  });
+
+  it('renders custom variantLabel', () => {
+    render(
+      <Note variant="negative" heading="Heading" variantLabel="Error: ">
+        Inhoud
+      </Note>
+    );
+    expect(
+      screen.getByRole('heading', { name: /^Error:\s?Heading$/ })
+    ).toBeInTheDocument();
+  });
+
+  it('renders no visually hidden label when variantLabel=""', () => {
+    render(
+      <Note variant="warning" heading="Waarschuwing" variantLabel="">
+        Inhoud
+      </Note>
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Waarschuwing' })
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('.dsn-visually-hidden')
+    ).not.toBeInTheDocument();
+  });
+
+  // ===========================
   // Content
   // ===========================
 
@@ -278,7 +349,9 @@ describe('Note', () => {
       </Note>
     );
     expect(
-      screen.getByRole('complementary', { name: 'Achtergrondinformatie' })
+      screen.getByRole('complementary', {
+        name: /^Informatie:\s?Achtergrondinformatie$/,
+      })
     ).toBeInTheDocument();
   });
 });

--- a/packages/components-react/src/Note/Note.tsx
+++ b/packages/components-react/src/Note/Note.tsx
@@ -20,6 +20,14 @@ const PREFERRED_ICONS: Record<NoteVariant, string> = {
   warning: 'alert-triangle',
 };
 
+const VARIANT_LABELS: Record<NoteVariant, string> = {
+  neutral: '',
+  info: 'Informatie: ',
+  positive: 'Succes: ',
+  negative: 'Foutmelding: ',
+  warning: 'Let op: ',
+};
+
 export interface NoteProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * HTML-element — ontkoppelt semantiek van visuele stijl
@@ -51,6 +59,17 @@ export interface NoteProps extends React.HTMLAttributes<HTMLElement> {
    * - `ReactNode` — aangepast icoon
    */
   iconStart?: React.ReactNode;
+
+  /**
+   * Visueel verborgen tekst die de variant benoemt voor screenreadergebruikers
+   * (inclusief scheidingsteken en spatie). Komt vóór de heading, of vóór de
+   * content als er geen heading is.
+   * - `undefined` (default) — standaardtekst per variant:
+   *   `''` (neutral) / `'Informatie: '` / `'Succes: '` / `'Foutmelding: '` / `'Let op: '`
+   * - `''` — geen variant-label (bijv. als de heading de variant al benoemt)
+   * - `string` — eigen tekst, bijv. voor een andere taal
+   */
+  variantLabel?: string;
 
   /**
    * Body-content: tekst, lijst, links, etc.
@@ -96,6 +115,11 @@ export interface NoteProps extends React.HTMLAttributes<HTMLElement> {
  * <Note variant="info" heading="Opmerking" iconStart={null}>
  *   <Paragraph>Zonder icoon.</Paragraph>
  * </Note>
+ *
+ * // Variant-label onderdrukken (heading benoemt de variant al)
+ * <Note variant="warning" heading="Waarschuwing" variantLabel="">
+ *   <Paragraph>Dit heeft gevolgen voor uw aanvraag.</Paragraph>
+ * </Note>
  * ```
  */
 export const Note = React.forwardRef<HTMLElement, NoteProps>(
@@ -107,6 +131,7 @@ export const Note = React.forwardRef<HTMLElement, NoteProps>(
       heading,
       headingLevel = 3,
       iconStart,
+      variantLabel,
       children,
       ...props
     },
@@ -115,6 +140,7 @@ export const Note = React.forwardRef<HTMLElement, NoteProps>(
     const headingId = useId();
     const noIcon = iconStart === null;
     const noHeading = !heading;
+    const resolvedVariantLabel = variantLabel ?? VARIANT_LABELS[variant];
 
     const resolvedIcon =
       iconStart === undefined ? (
@@ -160,8 +186,16 @@ export const Note = React.forwardRef<HTMLElement, NoteProps>(
             className="dsn-note__heading"
             id={isLandmark ? headingId : undefined}
           >
+            {resolvedVariantLabel && (
+              <span className="dsn-visually-hidden">
+                {resolvedVariantLabel}
+              </span>
+            )}
             {heading}
           </Heading>
+        )}
+        {noHeading && resolvedVariantLabel && (
+          <span className="dsn-visually-hidden">{resolvedVariantLabel}</span>
         )}
         {children && <div className="dsn-note__content">{children}</div>}
       </As>

--- a/packages/storybook/src/Alert.docs.md
+++ b/packages/storybook/src/Alert.docs.md
@@ -4,7 +4,7 @@ Belangrijk bericht dat de gebruiker informeert over de huidige activiteit of toe
 
 ## Doel
 
-De Alert component toont een prominent bericht op de pagina: bij een succesvolle actie, een foutmelding, een waarschuwing of een informatief bericht. Vier varianten: **info**, **positive**, **negative** en **warning**: geven elk een eigen signaalkleur, linkerborder en achtergrond. Een decoratief icoon versterkt de status visueel, maar de heading draagt altijd de betekenis.
+De Alert component toont een prominent bericht op de pagina: bij een succesvolle actie, een foutmelding, een waarschuwing of een informatief bericht. Vier varianten: **info**, **positive**, **negative** en **warning**: geven elk een eigen signaalkleur, linkerborder en achtergrond. Een decoratief icoon versterkt de status visueel; een visueel verborgen variant-label vóór de heading maakt de variant ook voor screenreadergebruikers expliciet.
 
 <!-- VOORBEELD -->
 
@@ -50,6 +50,13 @@ Een Alert communiceert altijd een toestand die het systeem heeft vastgesteld. El
 - Houd de heading beknopt: één zin die de kern van het bericht weergeeft.
 - Pas `headingLevel` aan op de documentstructuur (standaard `h2`).
 
+### Variant-label (screenreaders)
+
+- Elke variant krijgt automatisch een visueel verborgen tekst vóór de heading: **info** → `Informatie: `, **positive** → `Succes: `, **negative** → `Foutmelding: `, **warning** → `Let op: `. Screenreadergebruikers krijgen zo dezelfde signaalinformatie die ziende gebruikers uit kleur en icoon halen.
+- In de HTML/CSS-laag is dit een `<span class="dsn-visually-hidden">Foutmelding: </span>` als eerste kind van de heading.
+- Benoemt de heading de variant zelf al (bijv. `"Foutmelding"`)? Onderdruk het label dan met `variantLabel=""` om een dubbele aankondiging te voorkomen.
+- Gebruik `variantLabel` met eigen tekst voor anderstalige interfaces, bijv. `variantLabel="Error: "`. Neem het scheidingsteken en de spatie op in de waarde.
+
 ### Content
 
 - Body content (`children`) is optioneel. Gebruik het voor aanvullende uitleg, een opsomming van validatiefouten of een link.
@@ -94,6 +101,6 @@ Een Alert communiceert altijd een toestand die het systeem heeft vastgesteld. El
 
 - `role="alert"` maakt de component een assertieve live region: screenreaders lezen het voor zodra het in de DOM verschijnt.
 - Het icoon heeft altijd `aria-hidden="true"`: de heading is de informatiedrager.
-- De heading (`<strong class="dsn-alert__heading">`) geeft semantisch gewicht aan het bericht.
+- Een visueel verborgen variant-label vóór de heading-tekst benoemt de variant voor screenreadergebruikers (`Informatie: `, `Succes: `, `Foutmelding: `, `Let op: `). Aanpasbaar of te onderdrukken via de `variantLabel` prop. Er is bewust gekozen voor echte (verborgen) tekst in plaats van een `aria-label` op het icoon: tekst wordt wél meevertaald door vertaaltools, werkt in braille-weergave en blijft beschikbaar wanneer het icoon wordt onderdrukt via `iconStart={null}`.
 - Pas `headingLevel` aan op de documenthiërarchie zodat de heading in de juiste nesting valt.
 - Alert is niet klikbaar: voor interactieve alertberichten: voeg links of knoppen toe via `children`.

--- a/packages/storybook/src/Alert.stories.tsx
+++ b/packages/storybook/src/Alert.stories.tsx
@@ -103,6 +103,17 @@ const meta: Meta<typeof Alert> = {
           ? `\n  <span class="dsn-alert__icon" aria-hidden="true">\n    <svg class="dsn-icon dsn-icon--xl" aria-hidden="true"><!-- ${iconName} --></svg>\n  </span>`
           : '';
 
+        const variantLabels: Record<string, string> = {
+          info: 'Informatie: ',
+          positive: 'Succes: ',
+          negative: 'Foutmelding: ',
+          warning: 'Let op: ',
+        };
+        const variantLabel = args.variantLabel ?? variantLabels[variant];
+        const srLabel = variantLabel
+          ? `<span class="dsn-visually-hidden">${variantLabel}</span>`
+          : '';
+
         const heading = args.heading ?? 'Heading';
         const level = args.headingLevel ?? 2;
         const childrenText =
@@ -111,7 +122,7 @@ const meta: Meta<typeof Alert> = {
           ? `\n  <div class="dsn-alert__content">\n    <p class="dsn-paragraph">${childrenText}</p>\n  </div>`
           : '';
 
-        return `<div class="${cls}" role="alert">${icon}\n  <h${level} class="dsn-heading dsn-heading--heading-3 dsn-alert__heading">${heading}</h${level}>${children}\n</div>`;
+        return `<div class="${cls}" role="alert">${icon}\n  <h${level} class="dsn-heading dsn-heading--heading-3 dsn-alert__heading">${srLabel}${heading}</h${level}>${children}\n</div>`;
       },
     },
   },
@@ -141,6 +152,11 @@ const meta: Meta<typeof Alert> = {
           {} as Record<string, React.ReactNode>
         ),
       },
+    },
+    variantLabel: {
+      control: 'text',
+      description:
+        'Visueel verborgen tekst vóór de heading die de variant benoemt voor screenreaders. Leeg laten (undefined) = standaardtekst per variant; lege string = geen label.',
     },
     children: { control: false },
   },

--- a/packages/storybook/src/FormFlowPatterns.docs.md
+++ b/packages/storybook/src/FormFlowPatterns.docs.md
@@ -196,10 +196,12 @@ Bij één of meer fouten na submit:
 4. De tekst in de `Alert` en bij het veld is **identiek**
 5. In de `Alert` zijn de foutmeldingen ankerlinkjes die naar het betreffende veld springen
 
+De heading benoemt de fout al, dus onderdruk het automatische variant-label van de Alert met `variantLabel=""` om een dubbele aankondiging ("Foutmelding: Er is een foutmelding") te voorkomen.
+
 **Eén fout:**
 
 ```tsx
-<Alert variant="negative" heading="Er is een foutmelding">
+<Alert variant="negative" heading="Er is een foutmelding" variantLabel="">
   <Link href="#veld-id">Foutmeldingstekst</Link>
 </Alert>
 ```
@@ -207,7 +209,7 @@ Bij één of meer fouten na submit:
 **Meerdere fouten:**
 
 ```tsx
-<Alert variant="negative" heading="Er zijn 3 foutmeldingen">
+<Alert variant="negative" heading="Er zijn 3 foutmeldingen" variantLabel="">
   <UnorderedList>
     <li>
       <Link href="#veld-id-1">Foutmeldingstekst 1</Link>

--- a/packages/storybook/src/Note.docs.md
+++ b/packages/storybook/src/Note.docs.md
@@ -4,7 +4,7 @@ Visueel uitgelicht bericht voor aanvullende of belangrijke informatie binnen de 
 
 ## Doel
 
-De Note component plaatst extra context of een tip op een opvallende maar niet-urgente manier in de pagina. Het is de passieve tegenhanger van Alert: screenreaders lezen de Note alleen bij navigatie: niet spontaan. Vijf varianten: **neutral**, **info**, **positive**, **negative** en **warning**: geven elk een eigen signaalkleur en linkerborder. Een decoratief icoon versterkt de variant visueel.
+De Note component plaatst extra context of een tip op een opvallende maar niet-urgente manier in de pagina. Het is de passieve tegenhanger van Alert: screenreaders lezen de Note alleen bij navigatie: niet spontaan. Vijf varianten: **neutral**, **info**, **positive**, **negative** en **warning**: geven elk een eigen signaalkleur en linkerborder. Een decoratief icoon versterkt de variant visueel; bij de niet-neutrale varianten maakt een visueel verborgen variant-label de variant ook voor screenreadergebruikers expliciet.
 
 <!-- VOORBEELD -->
 
@@ -48,6 +48,13 @@ Een Note wordt bewust door een ontwerper of ontwikkelaar geplaatst. De variant k
 - De heading is optioneel. Zonder heading overspant het icoon beide rijen.
 - Houd de heading beknopt: één of twee woorden.
 - Pas `headingLevel` aan op de documenthiërarchie (standaard `h3`).
+
+### Variant-label (screenreaders)
+
+- De varianten **info**, **positive**, **negative** en **warning** krijgen automatisch een visueel verborgen tekst: `Informatie: `, `Succes: `, `Foutmelding: ` en `Let op: `. **Neutral** heeft geen label: die variant claimt bewust geen semantisch signaal.
+- Met heading komt het label vóór de heading-tekst; zonder heading staat het als losse `<span class="dsn-visually-hidden">` vóór de content.
+- Benoemt de heading de variant zelf al (bijv. `"Waarschuwing"`)? Onderdruk het label dan met `variantLabel=""` om een dubbele aankondiging te voorkomen.
+- Gebruik `variantLabel` met eigen tekst voor anderstalige interfaces, bijv. `variantLabel="Warning: "`. Neem het scheidingsteken en de spatie op in de waarde.
 
 ### Landmark semantiek
 
@@ -98,6 +105,8 @@ Bij `as="nav"`, `as="aside"` of `as="section"` + een `heading` prop: de Note kop
 ## Accessibility
 
 - Het icoon heeft altijd `aria-hidden="true"`: de heading (of body) is de informatiedrager.
+- Een visueel verborgen variant-label benoemt de niet-neutrale varianten voor screenreadergebruikers (`Informatie: `, `Succes: `, `Foutmelding: `, `Let op: `). Aanpasbaar of te onderdrukken via de `variantLabel` prop. Er is bewust gekozen voor echte (verborgen) tekst in plaats van een `aria-label` op het icoon: tekst wordt wél meevertaald door vertaaltools, werkt in braille-weergave en blijft beschikbaar wanneer het icoon wordt onderdrukt via `iconStart={null}`.
+- Bij landmark-gebruik (`as="nav"` etc.) met heading wordt het variant-label onderdeel van de landmark-naam via `aria-labelledby`.
 - Geen live region: de Note heeft geen `role="alert"` en wordt niet spontaan voorgelezen.
 - Bij `as="nav"`, `as="aside"` of `as="section"` + `heading`: automatisch `aria-labelledby` gekoppeld.
 - Pas `headingLevel` aan op de documenthiërarchie zodat de heading in de juiste nesting valt.

--- a/packages/storybook/src/Note.stories.tsx
+++ b/packages/storybook/src/Note.stories.tsx
@@ -105,10 +105,24 @@ const meta: Meta<typeof Note> = {
           ? `\n  <span class="dsn-note__icon" aria-hidden="true">\n    <svg class="dsn-icon dsn-icon--xl" aria-hidden="true"><!-- ${iconName} --></svg>\n  </span>`
           : '';
 
+        const variantLabels: Record<string, string> = {
+          neutral: '',
+          info: 'Informatie: ',
+          positive: 'Succes: ',
+          negative: 'Foutmelding: ',
+          warning: 'Let op: ',
+        };
+        const variantLabel = args.variantLabel ?? variantLabels[variant];
+        const srLabel = variantLabel
+          ? `<span class="dsn-visually-hidden">${variantLabel}</span>`
+          : '';
+
         const level = args.headingLevel ?? 3;
         const heading = args.heading
-          ? `\n  <h${level} class="dsn-heading dsn-heading--heading-3 dsn-note__heading"${args.as && args.as !== 'div' ? ' id="note-heading"' : ''}>${args.heading}</h${level}>`
+          ? `\n  <h${level} class="dsn-heading dsn-heading--heading-3 dsn-note__heading"${args.as && args.as !== 'div' ? ' id="note-heading"' : ''}>${srLabel}${args.heading}</h${level}>`
           : '';
+        const standaloneLabel =
+          !args.heading && srLabel ? `\n  ${srLabel}` : '';
         const childrenText =
           typeof args.children === 'string' ? args.children : TEKST;
         const children = args.children
@@ -118,7 +132,7 @@ const meta: Meta<typeof Note> = {
         const as = args.as ?? 'div';
         const labelledBy =
           as !== 'div' && args.heading ? ' aria-labelledby="note-heading"' : '';
-        return `<${as} class="${cls}"${labelledBy}>${icon}${heading}${children}\n</${as}>`;
+        return `<${as} class="${cls}"${labelledBy}>${icon}${heading}${standaloneLabel}${children}\n</${as}>`;
       },
     },
   },
@@ -152,6 +166,11 @@ const meta: Meta<typeof Note> = {
           {} as Record<string, React.ReactNode>
         ),
       },
+    },
+    variantLabel: {
+      control: 'text',
+      description:
+        'Visueel verborgen tekst die de variant benoemt voor screenreaders. Leeg laten (undefined) = standaardtekst per variant (neutral heeft geen); lege string = geen label.',
     },
     children: { control: false },
   },

--- a/packages/storybook/src/templates/FormStepExtendedPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepExtendedPage.stories.tsx
@@ -330,7 +330,11 @@ function SingleErrorPage() {
                     Vorige stap
                   </Link>
 
-                  <Alert variant="negative" heading="Er is een foutmelding">
+                  <Alert
+                    variant="negative"
+                    heading="Er is een foutmelding"
+                    variantLabel=""
+                  >
                     <Link href="#single-error-email">{EMAIL_ERROR}</Link>
                   </Alert>
 
@@ -549,7 +553,11 @@ function MultipleErrorsPage() {
                     Vorige stap
                   </Link>
 
-                  <Alert variant="negative" heading="Er zijn 3 foutmeldingen">
+                  <Alert
+                    variant="negative"
+                    heading="Er zijn 3 foutmeldingen"
+                    variantLabel=""
+                  >
                     <UnorderedList>
                       <li>
                         <Link href="#multi-error-voornaam">


### PR DESCRIPTION
Closes #297

## Wat

Screenreadergebruikers kregen de variant van een Alert of Note (**info**, **positive**, **negative**, **warning**) niet mee: kleur en icoon waren de enige informatiedragers. Beide componenten renderen nu een visueel verborgen variant-label:

```html
<h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading">
  <span class="dsn-visually-hidden">Foutmelding: </span>Er is een fout opgetreden
</h2>
```

Default teksten per variant: `Informatie: ` / `Succes: ` / `Foutmelding: ` / `Let op: `. Bij Note heeft **neutral** bewust geen label (geen semantisch signaal), en zonder heading staat het label als losse span voor de content.

## Nieuwe prop: `variantLabel`

- `undefined` (default): standaardtekst per variant
- `''`: geen label (voor headings die de variant al benoemen)
- eigen string: bijv. `variantLabel="Error: "` voor anderstalige interfaces

Ook als Storybook-control beschikbaar op Alert en Note.

## Waarom niet aria-label op de svg (voorstel uit het issue)

- Echte (verborgen) tekst wordt meevertaald door vertaaltools; `aria-label` vaak niet, en tekst werkt in braille-weergave.
- Het label zit in de accessible name van de heading: gebruikers die per heading navigeren horen de variant direct; een label op het icoon wordt bij heading-navigatie overgeslagen.
- Het blijft werken wanneer het icoon wordt onderdrukt via `iconStart={null}`; een svg-label verdwijnt dan mee.
- Het icoon blijft decoratief (`aria-hidden`): een enkele bron van variant-informatie, geen dubbele aankondiging.

## Overig

- htmlTemplates van Alert en Note spiegelen de nieuwe markup (DR-2026-04) en volgen de `variantLabel` arg.
- Het foutmelding-summary patroon (FormFlowPatterns-docs, `docs/07-form-flow-patterns.md`, FormStepExtendedPage-template) gebruikt `variantLabel=""`: de heading "Er is een foutmelding" benoemt de variant daar al.
- Usage-comments in `alert.css`/`note.css` bijgewerkt naar de werkelijke markup (h-element i.p.v. verouderde `<strong>`).
- Docs (Alert/Note): nieuwe sectie "Variant-label (screenreaders)" + accessibility-secties bijgewerkt.

## Impact op bestaande gebruikers

Geen API-breaking change, maar de voorgelezen output van elke bestaande Alert en niet-neutrale Note verandert (het label komt erbij). Wie de variant al in de heading benoemt kan `variantLabel=""` zetten.

## Kwaliteitscontrole

- `pnpm test`: 1607 tests groen (nieuwe tests voor defaults per variant, custom label, onderdrukking en standalone label bij Note zonder heading)
- `pnpm --filter storybook exec tsc --noEmit`: 0 fouten
- `pnpm lint`: 0 fouten (96 pre-existing warnings, ongewijzigd)
- In Storybook geverifieerd: span aanwezig en visueel verborgen (`clip-path: inset(50%)`), codeblok-tab spiegelt de render, geen visuele wijziging

🤖 Generated with [Claude Code](https://claude.com/claude-code)