### PR TITLE
chore(release): 2.0.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,13 @@ All notable changes to this project are documented in this file.
 
 ---
 
-## Unreleased
+## Version 2.0.0 (July 12, 2026)
+
+Grote release die alle wijzigingen sinds v1.0.2 bundelt en publiceert naar npm. Bevat één breaking change in de HTML/CSS-laag (ActionGroup-markup). React-consumers zijn niet geraakt, afgezien van een gewijzigde DOM-structuur.
+
+### Breaking changes
+
+- **ActionGroup: `role="group"` vervangen door `<ul>`/`<li>` + `aria-label`** (issue [#295](https://github.com/jeffreylauwers/design-system-starter-kit/issues/295)): bestaande markup met `<div class="dsn-action-group" role="group">` moet migreren naar `<ul class="dsn-action-group" aria-label="...">`, met elke actie gewrapt in `<li class="dsn-action-group__item">`. Nieuwe `aria-label` (React-prop / HTML-attribuut) met default `"Acties"`. Achtergrond en CSS-details staan in de ActionGroup-sectie hieronder.
 
 ### Alert & Note: variant hoorbaar voor screenreaders
 
@@ -17,8 +23,6 @@ All notable changes to this project are documented in this file.
   - Bewust echte verborgen tekst in plaats van `aria-label` op de svg: wordt meevertaald door vertaaltools, werkt in braille en blijft beschikbaar als het icoon wordt onderdrukt via `iconStart={null}`; het icoon blijft decoratief (`aria-hidden`)
   - Let op: geen API-breaking change, maar de voorgelezen output van elke bestaande Alert en niet-neutrale Note verandert (het label komt erbij)
   - Het foutmelding-summary patroon (FormFlowPatterns, `docs/07-form-flow-patterns.md`, FormStepExtendedPage-template) gebruikt `variantLabel=""` omdat de heading "Er is een foutmelding" de variant daar al benoemt
-
-## Version 1.0.6 (July 10, 2026)
 
 ### TableOfContents: nieuw component
 
@@ -60,10 +64,6 @@ All notable changes to this project are documented in this file.
 - Alle WCAG-verwijzingen bijgewerkt van 2.1 naar 2.2 (PR [#304](https://github.com/jeffreylauwers/design-system-starter-kit/pull/304))
 - Token descriptions thema-onafhankelijk gemaakt en volledig Nederlands (PR [#290](https://github.com/jeffreylauwers/design-system-starter-kit/pull/290))
 
----
-
-## Version 1.0.5 (July 7, 2026)
-
 ### ActionGroup — accessibiliteit
 
 #### Fixed
@@ -72,10 +72,6 @@ All notable changes to this project are documented in this file.
   - Nieuwe `aria-label`-prop (React) / attribuut (HTML) met default `"Acties"`, zodat de groep altijd een zinnige toegankelijke naam heeft, ook zonder expliciete keuze. Geef een specifieker label mee waar dat de context verduidelijkt (bijv. `"Formulierknoppen"`, `"Dialoogacties"`).
   - **Breaking change voor eigen HTML-implementaties**: bestaande markup met `<div class="dsn-action-group" role="group">` moet migreren naar `<ul class="dsn-action-group" aria-label="...">` met elke actie gewrapt in `<li class="dsn-action-group__item">`. Consumenten van het React-component zijn niet geraakt behalve een DOM-structuurwijziging (geen prop-wijziging).
   - CSS: `.dsn-action-group` reset nu `list-style`, `margin` en `padding`; de eerdere `align-self`-reset voor directe `dsn-link`/`dsn-link-button` children is verwijderd omdat die children niet meer direct in de flex-container zitten.
-
----
-
-## Version 1.0.4 (June 10, 2026)
 
 ### Hero — dark mode contrast
 
@@ -99,10 +95,6 @@ All notable changes to this project are documented in this file.
 #### Changed
 
 - **Grid `margin` token hernoemd naar `padding-inline`** (PR #286): `dsn.grid.margin` → `dsn.grid.padding-inline`; CSS custom property `--dsn-grid-margin` → `--dsn-grid-padding-inline`. Alle template stories bijgewerkt. De `dsn-full-bleed` klasse gebruikt nu `calc(-1 * var(--dsn-grid-padding-inline))`.
-
----
-
-## Version 1.0.3 (June 4, 2026)
 
 ### Accessibility — Forced Colors Mode
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system-starter-kit",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "private": true,
   "description": "Production-ready white-label design system starter kit",
   "author": "Jeffrey Lauwers",

--- a/packages/color-palette-generator/package.json
+++ b/packages/color-palette-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsn-starter-kit/color-palette-generator",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "private": true,
   "description": "Interactive OKLCH color palette generator for white-label themes",
   "scripts": {

--- a/packages/components-html/package.json
+++ b/packages/components-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsn-starter-kit/components-html",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Pure HTML/CSS components for the design system",
   "style": "dist/components.css",
   "main": "dist/components.css",

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsn-starter-kit/components-react",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "React components for the design system",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/components-web/package.json
+++ b/packages/components-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsn-starter-kit/components-web",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Web Components for the design system",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsn-starter-kit/core",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Core styles and utilities for the design system",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsn-starter-kit/design-tokens",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Design tokens for the design system",
   "main": "dist/js/tokens.js",
   "types": "dist/js/tokens.d.ts",


### PR DESCRIPTION
## Release 2.0.0

Bundelt alle wijzigingen sinds de laatst gepubliceerde npm-versie (v1.0.2) en bumpt alle publishbare packages naar 2.0.0.

### Waarom major?
Deze release bevat een **breaking change** in de HTML/CSS-laag: ActionGroup rendert nu als `<ul>`/`<li>` in plaats van `<div role="group">` (issue #295). Handgeschreven HTML-implementaties moeten migreren; React-consumers zien alleen een gewijzigde DOM-structuur (geen prop-wijziging).

### Wat zit erin (changelog geconsolideerd onder `## Version 2.0.0`)
- **Breaking**: ActionGroup `role="group"` → `<ul>`/`<li>` + `aria-label`
- **Nieuw**: TableOfContents-component + detailpage-templates
- **Changed**: Alert & Note variant-label voor screenreaders (#312); WCAG 2.1 → 2.2; Grid `margin` → `padding-inline`
- **Fixed**: HTML/CSS-codeblokken audit (#310); Hero dark mode contrast; Forced Colors Mode voor 11 componenten
- **Docs**: focusvolgorde-richtlijnen, formulierpatronen, getting started gids

### Nummering rechtgetrokken
De changelog had 1.0.3 t/m 1.0.6 al gebruikt voor ongepubliceerd werk terwijl npm op 1.0.2 stond. Die secties zijn samengevoegd onder één `2.0.0`-kop die overeenkomt met de git-tag en npm-release.

### Kwaliteitspoort
- `pnpm test`: 1607 tests groen
- `pnpm --filter storybook exec tsc --noEmit`: 0 fouten
- `pnpm lint`: 0 errors (alleen pre-existing warnings)

### Publiceren
Na merge wordt de release getriggerd door tag `v2.0.0` te pushen op `main`. Dit is het onomkeerbare publish-moment (5 packages naar npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)