### PR TITLE
docs(changelog): voeg lege Unreleased-kop toe

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented in this file.
 
 ---
 
+## Unreleased
+
+Nog niet gepubliceerde wijzigingen. Schrijf nieuwe changelog-entries hieronder; bij de volgende release wordt deze kop gepromoveerd naar het definitieve versienummer.
+
+---
+
 ## Version 2.0.0 (July 12, 2026)
 
 Grote release die alle wijzigingen sinds v1.0.2 bundelt en publiceert naar npm. Bevat één breaking change in de HTML/CSS-laag (ActionGroup-markup). React-consumers zijn niet geraakt, afgezien van een gewijzigde DOM-structuur.


### PR DESCRIPTION
Voegt een lege `## Unreleased`-kop bovenaan de changelog toe, zodat nieuwe PR's hun changelog-entries daar meteen onder kunnen schrijven.

Bij de volgende release wordt deze kop gepromoveerd naar het definitieve versienummer, zodat de changelog-nummering en de npm-tags synchroon blijven (voorkomt de drift die vóór v2.0.0 ontstond, toen de changelog t/m 1.0.6 doorliep terwijl npm op 1.0.2 stond).

🤖 Generated with [Claude Code](https://claude.com/claude-code)