### PR TITLE
feat(figma-sync): genereer Figma variables en component specs uit code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,17 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-explicit-any': 'warn',
   },
+  overrides: [
+    {
+      // De Figma-plugin draait in de plugin-sandbox, niet in een browser of in
+      // Node. Die omgeving levert `figma` en `__html__` als globals aan.
+      files: ['packages/figma-plugin/src/**/*.js'],
+      globals: {
+        figma: 'readonly',
+        __html__: 'readonly',
+      },
+    },
+  ],
   ignorePatterns: [
     'dist',
     'build',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ Het bevat de projectregels, architectuurpatronen en navigatiekaart naar de volle
 | Hoe werkt Storybook?                               | `docs/05-storybook-configuration.md` |
 | Wat is er recent veranderd?                        | `docs/changelog.md`                  |
 | Hoe werken formulierflows en -patronen?            | `docs/07-form-flow-patterns.md`      |
+| Hoe komen tokens en componenten in Figma?          | `packages/figma-sync/README.md`      |
+| Waarom is een architectuurkeuze zo gemaakt?        | `docs/decisions/`                    |
 
 **Voor een nieuw component:** lees altijd `docs/06-css-naming-conventions.md` en `docs/03-components.md` eerst.
 

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -53,6 +53,8 @@ design-system-starter-kit/
 │   │   └── src/
 │   │       ├── config/
 │   │       │   ├── build.js     # Multi-config build script
+│   │       │   ├── build-figma.js # Schrijft dist/figma/variables.json
+│   │       │   ├── figma.js     # Token -> Figma variable conversie
 │   │       │   └── config.js    # Configuration matrix
 │   │       └── tokens/
 │   │           ├── themes/
@@ -108,6 +110,15 @@ design-system-starter-kit/
 │   │   └── scripts/
 │   │       └── generate-icons.js # Icon registry generator
 │   ├── components-web/          # @dsn-starter-kit/components-web
+│   ├── figma-sync/              # Genereert Figma node specs uit de HTML/CSS-laag
+│   │   └── src/
+│   │       ├── extract.js       # Headless render, leest computed styles
+│   │       ├── to-figma.js      # Computed DOM -> Figma node spec
+│   │       └── matrices/        # Variant-matrix per component
+│   ├── figma-plugin/            # Schrijft de gegenereerde JSON naar Figma
+│   │   ├── manifest.json        # Plugin-manifest (importeren in Figma Desktop)
+│   │   ├── scripts/             # Mock van de Plugin API + smoke test
+│   │   └── src/
 │   └── storybook/               # Documentation site
 │       ├── .storybook/
 │       │   ├── main.ts          # Storybook config + multilevel-sort
@@ -125,6 +136,7 @@ design-system-starter-kit/
 │   ├── 03-components.md
 │   ├── 04-development-workflow.md
 │   ├── 05-storybook-configuration.md
+│   ├── decisions/               # Decision records (DR-YYYY-NN)
 │   └── changelog.md
 ├── .eslintrc.js                 # ESLint config (ignores *.generated.*)
 ├── tsconfig.json                # Root TypeScript config

--- a/docs/04-development-workflow.md
+++ b/docs/04-development-workflow.md
@@ -31,6 +31,12 @@ pnpm build:core        # Core utilities
 pnpm build:components  # All component packages
 pnpm build:storybook   # Storybook static site
 
+pnpm build:figma       # Hele Figma-keten: tokens, variables, componenten, plugin
+pnpm build:figma-variables   # dist/figma/variables.json
+pnpm build:figma-components  # Node specs per component
+pnpm build:figma-plugin      # Plugin-bundle
+pnpm test:figma-plugin       # Smoke test met een mock van de Figma Plugin API
+
 # Watch design tokens for changes
 pnpm --filter @dsn-starter-kit/design-tokens watch
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,19 @@ All notable changes to this project are documented in this file.
 
 Nog niet gepubliceerde wijzigingen. Schrijf nieuwe changelog-entries hieronder; bij de volgende release wordt deze kop gepromoveerd naar het definitieve versienummer.
 
+### Figma-integratie
+
+#### Added
+
+- **Design tokens en componenten naar Figma** (PR [#319](https://github.com/jeffreylauwers/design-system-starter-kit/pull/319), [DR-2026-05](./decisions/DR-2026-05-figma-genereren-uit-code-via-plugin.md)): de tokens en de HTML/CSS-laag worden nu gegenereerd naar JSON die een eigen Figma-plugin inleest. Code blijft de bron van waarheid; alles wat naar Figma gaat staat als JSON in de repo en is dus reviewbaar in een PR.
+  - Twee nieuwe private packages: `figma-sync` (rendert elke variant headless en leest de computed styles, zodat flexbox 1-op-1 op Figma auto layout mapt) en `figma-plugin` (schrijft naar Figma via de Plugin API, geen token nodig)
+  - `design-tokens` heeft een `build:figma`-script dat `dist/figma/variables.json` schrijft: 1308 variables over drie collections, waarvan 783 als alias zodat de theme-schakelaar in Figma automatisch doorwerkt
+  - Fluid typografie krijgt een mode per viewport (`default-mobile` 375px, `default-desktop` 1440px) in plaats van één vastgeprikte waarde; er wordt mobile-first gemeten zodat component en variable dezelfde waarde geven
+  - Vijf componenten met een variant-matrix: Button, Alert, Card, Checkbox en Radio (54 varianten)
+  - `pnpm test:figma-plugin` draait de import-logica tegen een mock van de Plugin API en dwingt de volgorde-eisen af die in Figma echt fouten geven
+  - Alles wat niet naar een Figma-variable te vertalen is (box shadows, transitions, `ch`-eenheden) staat met reden in `dist/figma/variables-report.json`
+  - De Figma-build staat bewust los van `build:tokens`: de token-CSS is het hoofdproduct en hoort niet om te vallen door een generator die er alleen maar naast draait
+
 ---
 
 ## Version 2.0.0 (July 12, 2026)

--- a/docs/decisions/DR-2026-05-figma-genereren-uit-code-via-plugin.md
+++ b/docs/decisions/DR-2026-05-figma-genereren-uit-code-via-plugin.md
@@ -1,0 +1,127 @@
+# DR-2026-05: Figma-library genereren uit code, geschreven via een plugin
+
+**ID:** DR-2026-05
+**Datum:** Augustus 2026
+**Status:** Accepted
+**Auteurs:** Jeffrey Lauwers
+
+---
+
+## Context
+
+Het design system bestaat in code: tokens, componenten, patronen en templates, allemaal zichtbaar in Storybook. Designers werken in Figma, waar diezelfde tokens en componenten niet bestaan. Elke wijziging in code moet nu met de hand in Figma worden nagevoerd, of andersom, en dat loopt onvermijdelijk uit de pas.
+
+De vraag was hoe we tokens en componenten vanuit code naar Figma krijgen, en of een weg terug haalbaar is.
+
+Twee harde platformgrenzen bepalen het antwoord meer dan onze voorkeuren. Op ons **Figma Professional-plan** is de **Variables REST API niet beschikbaar** (Enterprise-only, ook voor lezen) en is **Code Connect niet beschikbaar** (Organization/Enterprise). De Plugin API kent die beperkingen niet en werkt op elk plan.
+
+---
+
+## Opties overwogen
+
+### Optie 1: De Figma-library met de hand bouwen, alleen tokens automatiseren
+
+Een designer bouwt de componenten in Figma; alleen de variables worden gegenereerd.
+
+**Voordeel:** Beste visuele kwaliteit. Een Figma-component is auto layout, variant-matrices en component properties, en dat is ontwerpwerk.
+**Nadeel:** 50+ componenten handwerk, en elke wijziging in code moet opnieuw met de hand worden nagevoerd. Precies het probleem dat we wilden oplossen.
+
+### Optie 2: Componenten genereren door de CSS te parsen
+
+**Voordeel:** Geen browser nodig.
+**Nadeel:** Werkt niet. Cascade, custom properties, `clamp()` en media queries bepalen samen pas de eindwaarde; die is uit de CSS-bron niet af te leiden.
+
+### Optie 3: Componenten genereren uit de _computed_ DOM, schrijven via een plugin (gekozen)
+
+Elke variant wordt headless gerenderd, waarna `getComputedStyle` en `getBoundingClientRect` de werkelijke waarden opleveren. Het resultaat is JSON in de repo; een Figma-plugin leest die JSON en bouwt de nodes.
+
+**Voordeel:** Flexbox mapt vrijwel 1-op-1 op Figma auto layout, dus je krijgt componenten die meeschalen in plaats van een dood, absoluut gepositioneerd blok. Alles wat naar Figma gaat staat als JSON in de repo en is dus reviewbaar in een PR. Geen token nodig: een plugin draait in Figma Desktop.
+**Nadeel:** Levert ongeveer 85%. Component properties (icon-slots, instance swap, text) en thumbnails blijven handwerk.
+
+### Optie 4: Een third-party MCP of CLI als schrijfpad
+
+Onderzocht: figma-console-mcp (Southleft) en silships/figma-cli.
+
+**Nadeel:** figma-console-mcp draait willekeurige Plugin API-code via een bridge-plugin; bruikbaar om te prototypen, maar niet als vaste infrastructuur. silships/figma-cli patcht de Figma Desktop-app, wat bij elke update breekt. De officiële Figma MCP is nuttig als assistent maar niet-deterministisch, en dus ongeschikt voor een build-pipeline.
+
+---
+
+## Beslissing
+
+**Genereren in de repo, schrijven via een eigen Figma-plugin. Code is de bron van waarheid voor tokens en componentgedrag; Figma is de bron voor visuele compositie.**
+
+```
+tokens + HTML/CSS  ──►  JSON in de repo  ──►  Figma-plugin  ──►  Figma
+     (bron)              (reviewbaar)          (geen token)
+```
+
+Bijbehorende deelbesluiten:
+
+**Tokens worden drie collections**, één per as, niet acht losse builds. `dsn/Primitives` (4 modes: theme × light/dark), `dsn/Density` (3 modes) en `dsn/Components` (1 mode). Component-tokens worden waar mogelijk een **alias** naar de primitives, zodat de theme-schakelaar in Figma automatisch doorwerkt, net als de delegatieketen in de token-JSON.
+
+**Fluid typografie krijgt een mode per viewport, geen aparte min/max-tokennamen.** Een Figma-variable is statisch, dus `clamp()` moet op een breedte worden vastgeprikt. Aparte namen zouden betekenen dat 37 component-tokens in 26 bestanden mee moeten splitsen; met modes blijven de aliassen ongewijzigd werken.
+
+**Er wordt mobile-first gemeten**, op een viewport van 375px met blok-componenten van 343px. Op 375px lossen alle clamps op hun ondergrens op, dus de gemeten typografie komt exact overeen met de `default-mobile` mode.
+
+**De weg terug is alleen voor tokens, en alleen als voorstel.** Een export van Figma-variables naar DTCG die een PR opent, nooit een automatische tweerichtingssync: die heeft geen merge-semantiek. Voor componenten is er geen weg terug.
+
+**De Figma-build staat los van de tokenbuild.** De token-CSS is het hoofdproduct waar Storybook, de componenten en npm-consumenten van afhangen, en die hoort niet om te vallen door een generator die er alleen maar naast draait.
+
+---
+
+## Impact
+
+Drie packages:
+
+| Package         | Rol                                                |
+| --------------- | -------------------------------------------------- |
+| `design-tokens` | `build:figma` schrijft `dist/figma/variables.json` |
+| `figma-sync`    | Rendert componenten headless, schrijft node specs  |
+| `figma-plugin`  | Leest die JSON en schrijft naar Figma              |
+
+Operationele details staan in de README's van `figma-sync` en `figma-plugin`.
+
+Omvang bij invoering: 1308 variables waarvan 783 aliassen, en vijf componenten (Button, Alert, Card, Checkbox, Radio) met 54 varianten.
+
+---
+
+## Gevolgen
+
+**Wat makkelijker wordt:**
+
+- Een tokenwijziging in code landt met één commando in Figma
+- Wat níet naar Figma te vertalen is wordt zichtbaar gemaakt in een report in plaats van stil af te wijken
+- Het report legt drift bloot: tokens die in het ene theme wel en in het andere niet bestaan vallen nu op
+
+**Wat moeilijker wordt:**
+
+- Component sets worden bij elke import opnieuw aangemaakt; bestaande instanties koppelen daar niet vanzelf aan
+- Zonder Code Connect is de koppeling tussen Figma-component en code-component alleen conventie (naamgeving, een link in de componentbeschrijving)
+
+**Nieuwe verplichting voor contributors:**
+
+- Een nieuw component dat ook in Figma moet landen heeft een matrix in `figma-sync/src/matrices/` nodig, met de variant-assen expliciet. Storybook-stories zijn losse voorbeelden en geen volledige matrix.
+- Draai `pnpm test:figma-plugin` voordat je iets in Figma laadt. Die smoke test mockt de Plugin API en dwingt de volgorde-eisen af die in Figma echt fouten geven.
+
+---
+
+## Supersedes / superseded by
+
+Geen.
+
+---
+
+## Gerelateerde records
+
+- [DR-2026-02](DR-2026-02-twee-lagenpatroon-html-css-plus-react.md): de HTML/CSS-laag is de bron waaruit de generator meet
+- [DR-2026-03](DR-2026-03-breakpoints-als-reference-only-tokens.md): breakpoints zijn reference-only en worden daarom niet naar Figma-variables gemapt
+
+---
+
+## Review trigger
+
+Herzie dit record wanneer:
+
+- We naar een Organization- of Enterprise-plan gaan. Dan komen Code Connect en (op Enterprise) de Variables REST API beschikbaar, en verandert zowel het schrijfpad als de koppeling tussen design en code.
+- Figma de Plugin API voor variables of grid-layout ingrijpend wijzigt.
+- Blijkt dat de gegenereerde componenten in de praktijk toch te veel handwerk vragen; dan is optie 1 (met de hand bouwen, alleen tokens automatiseren) alsnog de betere keuze.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -12,6 +12,7 @@ Een decision record documenteert **waarom** iets is zoals het is — niet alleen
 | [DR-2026-02](DR-2026-02-twee-lagenpatroon-html-css-plus-react.md) | HTML/CSS als bron van waarheid, React als wrapper                    | Accepted |
 | [DR-2026-03](DR-2026-03-breakpoints-als-reference-only-tokens.md) | Breakpoints als reference-only tokens, hardcoded in CSS @media rules | Accepted |
 | [DR-2026-04](DR-2026-04-htmltemplate-spiegelt-echte-render.md)    | Storybook `htmlTemplate` spiegelt de echte render en volgt de args   | Accepted |
+| [DR-2026-05](DR-2026-05-figma-genereren-uit-code-via-plugin.md)   | Figma-library genereren uit code, geschreven via een eigen plugin    | Accepted |
 
 ## Een nieuw record toevoegen
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "build:components": "pnpm --filter @dsn-starter-kit/components-html build && pnpm --filter @dsn-starter-kit/components-react build && pnpm --filter @dsn-starter-kit/components-web build",
     "build:storybook": "pnpm --filter @dsn-starter-kit/storybook build",
     "build:figma-components": "pnpm --filter @dsn-starter-kit/figma-sync build",
+    "build:figma-plugin": "pnpm --filter @dsn-starter-kit/figma-plugin build",
+    "test:figma-plugin": "pnpm --filter @dsn-starter-kit/figma-plugin test",
     "dev": "pnpm --filter @dsn-starter-kit/storybook dev",
     "storybook": "pnpm --filter @dsn-starter-kit/storybook dev",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:core": "pnpm --filter @dsn-starter-kit/core build",
     "build:components": "pnpm --filter @dsn-starter-kit/components-html build && pnpm --filter @dsn-starter-kit/components-react build && pnpm --filter @dsn-starter-kit/components-web build",
     "build:storybook": "pnpm --filter @dsn-starter-kit/storybook build",
+    "build:figma-components": "pnpm --filter @dsn-starter-kit/figma-sync build",
     "dev": "pnpm --filter @dsn-starter-kit/storybook dev",
     "storybook": "pnpm --filter @dsn-starter-kit/storybook dev",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "build:core": "pnpm --filter @dsn-starter-kit/core build",
     "build:components": "pnpm --filter @dsn-starter-kit/components-html build && pnpm --filter @dsn-starter-kit/components-react build && pnpm --filter @dsn-starter-kit/components-web build",
     "build:storybook": "pnpm --filter @dsn-starter-kit/storybook build",
+    "build:figma": "pnpm build:tokens && pnpm build:figma-variables && pnpm build:figma-components && pnpm build:figma-plugin",
+    "build:figma-variables": "pnpm --filter @dsn-starter-kit/design-tokens build:figma",
     "build:figma-components": "pnpm --filter @dsn-starter-kit/figma-sync build",
     "build:figma-plugin": "pnpm --filter @dsn-starter-kit/figma-plugin build",
     "test:figma-plugin": "pnpm --filter @dsn-starter-kit/figma-plugin test",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -29,6 +29,7 @@
   "type": "module",
   "scripts": {
     "build": "node src/config/build.js",
+    "build:figma": "node src/config/build-figma.js",
     "clean": "rm -rf dist",
     "watch": "node --watch-path=src src/config/build.js"
   },

--- a/packages/design-tokens/src/config/build-figma.js
+++ b/packages/design-tokens/src/config/build-figma.js
@@ -1,0 +1,125 @@
+/**
+ * Genereert dist/figma/variables.json (+ een report) uit de design tokens.
+ *
+ * Wordt aangeroepen vanuit build.js, maar is ook los te draaien:
+ *   node src/config/build-figma.js
+ */
+
+import StyleDictionary from 'style-dictionary';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { themes, modes, projectTypes } from './config.js';
+import { buildFigmaVariables } from './figma.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(__dirname, '..', '..');
+
+/**
+ * Laadt de volledig geresolvede tokenset voor één theme x mode x density.
+ * Dezelfde source-volgorde als createFullConfig: project-types komen als
+ * laatste zodat hun overrides winnen.
+ */
+async function loadTokens(theme, mode, projectType) {
+  const sd = new StyleDictionary(
+    {
+      source: [
+        `src/tokens/themes/${theme}/base.json`,
+        `src/tokens/themes/${theme}/colors-${mode}.json`,
+        'src/tokens/components/*.json',
+        `src/tokens/project-types/${projectType}/*.json`,
+      ],
+      platforms: { js: { transformGroup: 'js' } },
+      log: { verbosity: 'silent', warnings: 'disabled' },
+    },
+    { init: false }
+  );
+  await sd.init();
+  const dictionary = await sd.getPlatformTokens('js');
+  return dictionary.allTokens;
+}
+
+function summarise(payload) {
+  const lines = [];
+  for (const collection of payload.collections) {
+    const aliases = collection.variables.filter((v) => v.alias).length;
+    const types = collection.variables.reduce((acc, v) => {
+      acc[v.type] = (acc[v.type] ?? 0) + 1;
+      return acc;
+    }, {});
+    const typeSummary = Object.entries(types)
+      .map(([type, count]) => `${count} ${type}`)
+      .join(', ');
+    lines.push(
+      `   ${collection.name.padEnd(16)} ${String(collection.variables.length).padStart(4)} variables  ` +
+        `(${collection.modes.length} mode${collection.modes.length === 1 ? '' : 's'}: ${collection.modes.join(', ')})`
+    );
+    lines.push(
+      `   ${''.padEnd(16)}      ${typeSummary}${aliases ? `, waarvan ${aliases} als alias` : ''}`
+    );
+  }
+  return lines.join('\n');
+}
+
+export async function buildFigma() {
+  console.log('🎯 Building Figma variables...\n');
+
+  const payload = await buildFigmaVariables({
+    loadTokens,
+    themes,
+    modes,
+    densities: projectTypes,
+  });
+
+  const outputDir = path.join(packageRoot, 'dist', 'figma');
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(outputDir, 'variables.json'),
+    `${JSON.stringify(payload, null, 2)}\n`
+  );
+
+  // Het report is bewust een apart bestand: het hoort niet in de payload die
+  // naar Figma gaat, maar je wilt bij een review wel kunnen zien wat er afviel.
+  const grouped = payload.skipped.reduce((acc, entry) => {
+    (acc[entry.reason] ??= []).push(entry.token);
+    return acc;
+  }, {});
+  fs.writeFileSync(
+    path.join(outputDir, 'variables-report.json'),
+    `${JSON.stringify(
+      {
+        generatedAt: payload.generatedAt,
+        meta: payload.meta,
+        totals: Object.fromEntries(
+          payload.collections.map((c) => [c.name, c.variables.length])
+        ),
+        skippedCount: payload.skipped.length,
+        skippedByReason: grouped,
+        // Referenties die niet als Figma-alias gelegd konden worden omdat het
+        // doeltoken zelf niet naar een variable mapt. Deze variables krijgen een
+        // vaste waarde en volgen dus geen theme- of mode-wissel.
+        danglingReferences: payload.danglingReferences,
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  console.log(summarise(payload));
+  console.log(
+    `\n   ${payload.skipped.length} tokens overgeslagen (zie dist/figma/variables-report.json)`
+  );
+  console.log('\n✅ dist/figma/variables.json\n');
+
+  return payload;
+}
+
+// Direct uitgevoerd (niet geïmporteerd)? Dan zelf draaien.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  buildFigma().catch((error) => {
+    console.error('❌ Figma build failed:', error);
+    process.exit(1);
+  });
+}

--- a/packages/design-tokens/src/config/build-figma.js
+++ b/packages/design-tokens/src/config/build-figma.js
@@ -105,6 +105,9 @@ export async function buildFigma() {
         // met een andere mode-as en zijn daarom op één viewport vastgeprikt.
         viewportPinnedCount: payload.viewportPinned.length,
         viewportPinned: payload.viewportPinned,
+        // Variables die niet in elke mode een waarde hadden en daarom zijn
+        // weggelaten; in Figma zouden ze op een standaardwaarde terugvallen.
+        incomplete: payload.incomplete,
       },
       null,
       2
@@ -116,7 +119,12 @@ export async function buildFigma() {
     `\n   ${payload.skipped.length} tokens overgeslagen, ` +
       `${payload.viewportPinned.length} fluid waarden vastgeprikt op ${payload.meta.viewports.desktop}px`
   );
-  console.log('   (beide verantwoord in dist/figma/variables-report.json)');
+  if (payload.incomplete.length) {
+    console.log(
+      `   ${payload.incomplete.length} variables weggelaten: niet in elke mode een waarde`
+    );
+  }
+  console.log('   (alles verantwoord in dist/figma/variables-report.json)');
   console.log('\n✅ dist/figma/variables.json\n');
 
   return payload;

--- a/packages/design-tokens/src/config/build-figma.js
+++ b/packages/design-tokens/src/config/build-figma.js
@@ -101,6 +101,10 @@ export async function buildFigma() {
         // doeltoken zelf niet naar een variable mapt. Deze variables krijgen een
         // vaste waarde en volgen dus geen theme- of mode-wissel.
         danglingReferences: payload.danglingReferences,
+        // Fluid waarden buiten de typografieschaal. Die zitten in collections
+        // met een andere mode-as en zijn daarom op één viewport vastgeprikt.
+        viewportPinnedCount: payload.viewportPinned.length,
+        viewportPinned: payload.viewportPinned,
       },
       null,
       2
@@ -109,8 +113,10 @@ export async function buildFigma() {
 
   console.log(summarise(payload));
   console.log(
-    `\n   ${payload.skipped.length} tokens overgeslagen (zie dist/figma/variables-report.json)`
+    `\n   ${payload.skipped.length} tokens overgeslagen, ` +
+      `${payload.viewportPinned.length} fluid waarden vastgeprikt op ${payload.meta.viewports.desktop}px`
   );
+  console.log('   (beide verantwoord in dist/figma/variables-report.json)');
   console.log('\n✅ dist/figma/variables.json\n');
 
   return payload;

--- a/packages/design-tokens/src/config/build.js
+++ b/packages/design-tokens/src/config/build.js
@@ -2,6 +2,7 @@ import StyleDictionary from 'style-dictionary';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { buildFigma } from './build-figma.js';
 import {
   themes,
   modes,
@@ -221,6 +222,7 @@ async function main() {
   await appendReducedMotion();
   await buildScopedConfigs();
   await buildHeroImageForceLightConfigs();
+  await buildFigma();
   createBackwardCompatibilityAliases();
   printSummary();
 }

--- a/packages/design-tokens/src/config/build.js
+++ b/packages/design-tokens/src/config/build.js
@@ -2,7 +2,6 @@ import StyleDictionary from 'style-dictionary';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { buildFigma } from './build-figma.js';
 import {
   themes,
   modes,
@@ -222,7 +221,6 @@ async function main() {
   await appendReducedMotion();
   await buildScopedConfigs();
   await buildHeroImageForceLightConfigs();
-  await buildFigma();
   createBackwardCompatibilityAliases();
   printSummary();
 }

--- a/packages/design-tokens/src/config/figma.js
+++ b/packages/design-tokens/src/config/figma.js
@@ -1,0 +1,547 @@
+/**
+ * Figma Variables platform
+ *
+ * Zet de Style Dictionary tokens om naar een JSON die een Figma-plugin
+ * rechtstreeks kan inlezen om variable collections aan te maken/bij te werken.
+ *
+ * Waarom een eigen platform en geen Style Dictionary format?
+ * Figma-variables zijn niet plat: ze zitten in collections met modes, en een
+ * component-token wordt een *alias* naar een primitive-variable. Dat vraagt om
+ * meerdere builds (een per theme x mode x density) die daarna worden
+ * samengevoegd, en dat past niet in een enkel format-callback.
+ *
+ * Figma kent maar vier variable-types: COLOR, FLOAT, STRING en BOOLEAN.
+ * Alles wat daar niet in past (transitions, easings, shadows, breakpoints)
+ * wordt overgeslagen en verantwoord in het report-bestand.
+ */
+
+// =============================================================================
+// CONSTANTEN
+// =============================================================================
+
+/** Basis voor rem -> px conversie. */
+const ROOT_FONT_SIZE = 16;
+
+/**
+ * Referentie-viewport voor het uitrekenen van fluid waarden (clamp met vw).
+ * Figma-variables zijn statisch, dus een clamp() moet op één breedte worden
+ * vastgeprikt. 1440px is een gangbare desktop-artboardbreedte.
+ */
+const REFERENCE_VIEWPORT = 1440;
+
+export const COLLECTIONS = {
+  primitives: 'dsn/Primitives',
+  density: 'dsn/Density',
+  components: 'dsn/Components',
+};
+
+// =============================================================================
+// WAARDE-CONVERSIE
+// =============================================================================
+
+/**
+ * Zet een hex-kleur om naar Figma's RGBA-object (kanalen 0..1).
+ * Ondersteunt #RGB, #RGBA, #RRGGBB en #RRGGBBAA.
+ */
+function parseColor(input) {
+  const value = String(input).trim();
+  if (!value.startsWith('#')) return null;
+
+  let hex = value.slice(1);
+  if (hex.length === 3 || hex.length === 4) {
+    hex = hex
+      .split('')
+      .map((char) => char + char)
+      .join('');
+  }
+  if (hex.length !== 6 && hex.length !== 8) return null;
+  if (!/^[0-9a-fA-F]+$/.test(hex)) return null;
+
+  const channel = (offset) => parseInt(hex.slice(offset, offset + 2), 16) / 255;
+  return {
+    r: channel(0),
+    g: channel(2),
+    b: channel(4),
+    a: hex.length === 8 ? channel(6) : 1,
+  };
+}
+
+/**
+ * Vervangt CSS-eenheden door pixelwaarden zodat de rest een kale som wordt.
+ * vw wordt uitgerekend op REFERENCE_VIEWPORT, ch heeft geen betrouwbare
+ * conversie (hangt van het lettertype af) en levert daarom null op.
+ */
+function unitsToPixels(expression) {
+  if (/[\d.]ch\b/.test(expression)) return null;
+  if (/[\d.]e[m]\b/.test(expression)) return null;
+
+  return expression
+    .replace(/(-?[\d.]+)rem\b/g, (_, n) => String(Number(n) * ROOT_FONT_SIZE))
+    .replace(/(-?[\d.]+)vw\b/g, (_, n) =>
+      String((Number(n) / 100) * REFERENCE_VIEWPORT)
+    )
+    .replace(/(-?[\d.]+)px\b/g, (_, n) => String(Number(n)));
+}
+
+/**
+ * Rekent een kale rekenkundige expressie uit.
+ * Er wordt eerst gecontroleerd of er uitsluitend cijfers en operatoren in
+ * staan, zodat er niets anders dan rekenwerk uitgevoerd kan worden.
+ */
+function evaluateArithmetic(expression) {
+  if (!/^[\d\s.+\-*/()]+$/.test(expression)) return null;
+  try {
+    const result = Function(`"use strict"; return (${expression});`)();
+    return Number.isFinite(result) ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Splitst de argumenten van een functie op komma's op het buitenste niveau. */
+function splitArguments(input) {
+  const parts = [];
+  let depth = 0;
+  let current = '';
+
+  for (const char of input) {
+    if (char === '(') depth += 1;
+    if (char === ')') depth -= 1;
+    if (char === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current);
+  return parts;
+}
+
+/**
+ * Lost clamp() en calc() van binnen naar buiten op tot er een getal overblijft.
+ * clamp(min, preferred, max) wordt op REFERENCE_VIEWPORT uitgerekend.
+ */
+function resolveFunctions(expression) {
+  // calc() is puur rekenwerk, dus het keyword kan weg: de haakjes die
+  // overblijven zijn precies de groepering die de som nodig heeft. Dat maakt
+  // geneste calc's met eigen haakjesgroepen vanzelf oplosbaar.
+  let current = expression.replace(/\bcalc\b/g, '');
+
+  // Werk de binnenste functie-aanroep steeds als eerste weg.
+  for (let guard = 0; guard < 20; guard += 1) {
+    const match = current.match(/(clamp|min|max)\(([^()]*)\)/);
+    if (!match) break;
+
+    const [full, name, rawArgs] = match;
+    const args = splitArguments(rawArgs).map((part) =>
+      evaluateArithmetic(part.trim())
+    );
+    if (args.some((value) => value === null)) return null;
+
+    let resolved;
+    if (name === 'clamp') {
+      const [minimum, preferred, maximum] = args;
+      resolved = Math.min(Math.max(preferred, minimum), maximum);
+    } else if (name === 'min') {
+      resolved = Math.min(...args);
+    } else {
+      resolved = Math.max(...args);
+    }
+
+    current = current.replace(full, String(resolved));
+  }
+
+  return evaluateArithmetic(current);
+}
+
+/**
+ * Vervangt `var(--dsn-x-y)` door de al bekende pixelwaarde van dat token.
+ *
+ * Een handvol tokens verwijst rechtstreeks naar een CSS custom property in
+ * plaats van naar een tokenreferentie (`{dsn.x.y}`). Die waarden zijn niet via
+ * de tokengraaf te resolven, maar wel via de naam van de custom property.
+ */
+function substituteCssVars(expression, pixelsByCssName) {
+  if (!expression.includes('var(')) return expression;
+  if (!pixelsByCssName) return null;
+
+  let resolved = expression;
+  for (let guard = 0; guard < 5 && resolved.includes('var('); guard += 1) {
+    resolved = resolved.replace(
+      /var\(\s*--([a-z0-9-]+)\s*\)/gi,
+      (match, name) =>
+        pixelsByCssName.has(name) ? String(pixelsByCssName.get(name)) : match
+    );
+    if (!/var\(/.test(resolved)) break;
+    // Geen voortgang meer? Dan is de verwijzing onbekend.
+    if (resolved === expression) return null;
+    expression = resolved;
+  }
+
+  return resolved.includes('var(') ? null : resolved;
+}
+
+/**
+ * Zet een lengte-achtige tokenwaarde om naar een getal in pixels.
+ * Retourneert null als de waarde niet betrouwbaar te herleiden is.
+ */
+function toPixels(input, pixelsByCssName) {
+  const value = String(input).trim();
+
+  if (/^-?[\d.]+$/.test(value)) return Number(value);
+
+  const substituted = substituteCssVars(value, pixelsByCssName);
+  if (substituted === null) return null;
+
+  const withPixels = unitsToPixels(substituted);
+  if (withPixels === null) return null;
+
+  return resolveFunctions(withPixels);
+}
+
+// =============================================================================
+// TOKEN -> FIGMA VARIABLE
+// =============================================================================
+
+/** Tokengroepen die geen zinnige tegenhanger in Figma hebben. */
+const UNSUPPORTED_GROUPS = new Set([
+  'transition', // Figma kent geen duration/easing variables
+  'box-shadow', // hoort een Figma effect style te worden, geen variable
+  'breakpoint', // een designtijd-concept, niet iets om aan een laag te binden
+  'z-index', // Figma bepaalt stapelvolgorde via de laagvolgorde
+]);
+
+/** Tokennamen die per se een STRING moeten blijven. */
+const STRING_TYPES = new Set(['fontFamily', 'string', 'other']);
+
+/**
+ * Padsegmenten die een STRING aanduiden wanneer het token geen $type heeft.
+ * base.json laat $type vaak weg, waardoor font-family anders als getal
+ * geïnterpreteerd zou worden en zou afvallen.
+ */
+const STRING_PATH_SEGMENTS = new Set(['font-family']);
+
+/** Duur-eenheden bestaan niet als Figma variable. */
+const DURATION_PATTERN = /^-?[\d.]+m?s$/;
+
+/**
+ * Bepaalt type en waarde voor Figma.
+ * Retourneert `{ skip: reden }` als het token niet te mappen is.
+ *
+ * @param {object} token Style Dictionary token
+ * @param {Map<string, number>} [pixelsByCssName] Lookup om `var(--dsn-x)`
+ *   binnen een tokenwaarde alsnog te kunnen uitrekenen.
+ */
+export function mapTokenValue(token, pixelsByCssName) {
+  const type = token.$type ?? token.type;
+  const raw = token.$value ?? token.value;
+  // Op elk padsegment matchen, niet alleen op de groep: `dsn.backdrop.z-index`
+  // is net zo goed een z-index als `dsn.z-index.400`.
+  const unsupported = token.path.find((segment) =>
+    UNSUPPORTED_GROUPS.has(segment)
+  );
+  if (unsupported) {
+    return { skip: `"${unsupported}" heeft geen Figma-variable equivalent` };
+  }
+
+  if (type === 'color' || (typeof raw === 'string' && raw.startsWith('#'))) {
+    const color = parseColor(raw);
+    if (!color) {
+      return {
+        skip: `kleurwaarde "${raw}" is geen hex (color-mix of keyword)`,
+      };
+    }
+    return { figmaType: 'COLOR', value: color };
+  }
+
+  if (
+    STRING_TYPES.has(type) ||
+    token.path.some((segment) => STRING_PATH_SEGMENTS.has(segment))
+  ) {
+    return { figmaType: 'STRING', value: String(raw) };
+  }
+
+  if (DURATION_PATTERN.test(String(raw).trim())) {
+    return { skip: `duur "${raw}" heeft geen Figma-variable equivalent` };
+  }
+
+  // Percentages zijn alleen zinnig als ze een verhouding uitdrukken.
+  // Een layout-percentage (flex-basis, breedte) heeft in Figma geen
+  // variable-equivalent en hoort een constraint te zijn.
+  const percentage = String(raw)
+    .trim()
+    .match(/^([\d.]+)%$/);
+  if (percentage) {
+    if (type === 'opacity' || token.path.includes('opacity')) {
+      return { figmaType: 'FLOAT', value: Number(percentage[1]) / 100 };
+    }
+    return {
+      skip: `percentage "${raw}" is layout-gedrag, geen variable (gebruik een constraint)`,
+    };
+  }
+
+  // Alles wat overblijft proberen we als getal te lezen.
+  const pixels = toPixels(raw, pixelsByCssName);
+  if (pixels === null) {
+    return { skip: `waarde "${raw}" is niet naar een getal te herleiden` };
+  }
+
+  // Unitloze verhoudingen (line-height, opacity) niet afronden,
+  // pixelmaten wel op 3 decimalen om drijvende-kommaruis te vermijden.
+  const isRatio = type === 'lineHeight' || type === 'opacity';
+  return {
+    figmaType: 'FLOAT',
+    value: isRatio ? pixels : Math.round(pixels * 1000) / 1000,
+    // Bewaar de bron-expressie zodat een designer in Figma kan zien
+    // dat de waarde is vastgeprikt op een referentie-viewport.
+    fluidSource: /clamp|vw/.test(String(raw)) ? String(raw) : undefined,
+  };
+}
+
+/** `dsn.color.neutral.bg-default` -> `color/neutral/bg-default` */
+export function toVariableName(token) {
+  return token.path.slice(1).join('/');
+}
+
+/**
+ * Zet een tokenreferentie `{dsn.border.radius.md}` om naar een variable-naam.
+ * Retourneert null als de waarde geen enkele referentie is.
+ */
+export function referenceToVariableName(originalValue) {
+  if (typeof originalValue !== 'string') return null;
+  const match = originalValue.trim().match(/^\{([^}]+)\}$/);
+  if (!match) return null;
+  return match[1].split('.').slice(1).join('/');
+}
+
+// =============================================================================
+// COLLECTION-ASSEMBLAGE
+// =============================================================================
+
+/**
+ * Bepaalt in welke collection een token thuishoort op basis van het
+ * bronbestand. Het bronbestand is betrouwbaarder dan de tokennaam: `dsn.grid.*`
+ * staat zowel in components/grid.json als in een project-type override.
+ */
+function collectionForToken(token) {
+  const file = token.filePath.replace(/\\/g, '/');
+  if (file.includes('/tokens/project-types/')) return COLLECTIONS.density;
+  if (file.includes('/tokens/components/')) return COLLECTIONS.components;
+  return COLLECTIONS.primitives;
+}
+
+/**
+ * Bouwt een lookup van CSS custom property-naam naar pixelwaarde.
+ *
+ * Meerdere passes, omdat een token dat `var(--x)` gebruikt kan verwijzen naar
+ * een token dat zelf ook nog opgelost moet worden.
+ */
+function buildPixelLookup(tokens) {
+  const lookup = new Map();
+  const pending = [];
+
+  for (const token of tokens) {
+    const cssName = token.path.join('-');
+    const raw = String(token.$value ?? token.value);
+    if (raw.includes('var(')) {
+      pending.push({ cssName, raw });
+      continue;
+    }
+    const pixels = toPixels(raw);
+    if (pixels !== null) lookup.set(cssName, pixels);
+  }
+
+  // Elke ronde lost minstens één laag var()-verwijzingen op.
+  for (let round = 0; round < 5 && pending.length > 0; round += 1) {
+    let resolvedThisRound = 0;
+    for (let index = pending.length - 1; index >= 0; index -= 1) {
+      const pixels = toPixels(pending[index].raw, lookup);
+      if (pixels === null) continue;
+      lookup.set(pending[index].cssName, pixels);
+      pending.splice(index, 1);
+      resolvedThisRound += 1;
+    }
+    if (resolvedThisRound === 0) break;
+  }
+
+  return lookup;
+}
+
+/**
+ * Bouwt de volledige Figma-variables payload.
+ *
+ * @param {object} deps
+ * @param {Function} deps.loadTokens async (theme, mode, density) => allTokens[]
+ * @param {string[]} deps.themes
+ * @param {string[]} deps.modes
+ * @param {string[]} deps.densities
+ */
+export async function buildFigmaVariables({
+  loadTokens,
+  themes,
+  modes,
+  densities,
+}) {
+  const skipped = [];
+  const noteSkip = (token, reason) => {
+    skipped.push({ token: token.path.join('.'), reason });
+  };
+
+  // ---------------------------------------------------------------------------
+  // 1. Primitives: een mode per theme x light/dark combinatie.
+  // ---------------------------------------------------------------------------
+  const primitiveModes = [];
+  const primitives = new Map();
+
+  for (const theme of themes) {
+    for (const mode of modes) {
+      const modeName = `${theme}-${mode}`;
+      primitiveModes.push(modeName);
+
+      const tokens = await loadTokens(theme, mode, densities[0]);
+      const pixels = buildPixelLookup(tokens);
+      for (const token of tokens) {
+        if (collectionForToken(token) !== COLLECTIONS.primitives) continue;
+
+        const mapped = mapTokenValue(token, pixels);
+        const name = toVariableName(token);
+        if (mapped.skip) {
+          if (modeName === primitiveModes[0]) noteSkip(token, mapped.skip);
+          continue;
+        }
+
+        if (!primitives.has(name)) {
+          primitives.set(name, {
+            name,
+            type: mapped.figmaType,
+            description: token.$description ?? token.comment ?? '',
+            fluidSource: mapped.fluidSource,
+            valuesByMode: {},
+          });
+        }
+        primitives.get(name).valuesByMode[modeName] = mapped.value;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 2. Density: een mode per project-type (typografieschaal en overrides).
+  // ---------------------------------------------------------------------------
+  const density = new Map();
+
+  for (const densityName of densities) {
+    const tokens = await loadTokens(themes[0], modes[0], densityName);
+    const pixels = buildPixelLookup(tokens);
+    for (const token of tokens) {
+      if (collectionForToken(token) !== COLLECTIONS.density) continue;
+
+      const mapped = mapTokenValue(token, pixels);
+      const name = toVariableName(token);
+      if (mapped.skip) {
+        if (densityName === densities[0]) noteSkip(token, mapped.skip);
+        continue;
+      }
+
+      if (!density.has(name)) {
+        density.set(name, {
+          name,
+          type: mapped.figmaType,
+          description: token.$description ?? token.comment ?? '',
+          fluidSource: mapped.fluidSource,
+          valuesByMode: {},
+        });
+      }
+      density.get(name).valuesByMode[densityName] = mapped.value;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 3. Components: één mode. Verwijst waar mogelijk als alias naar 1 of 2,
+  //    zodat de theme- en density-schakelaars automatisch doorwerken.
+  // ---------------------------------------------------------------------------
+  const components = new Map();
+  const baseTokens = await loadTokens(themes[0], modes[0], densities[0]);
+  const basePixels = buildPixelLookup(baseTokens);
+
+  // Eerste pass: alle component-variables met hun letterlijke waarde, plus de
+  // referentie uit de bron. Een component-token mag naar een ander
+  // component-token verwijzen, dus de alias kan pas worden gelegd als de hele
+  // collection bestaat.
+  for (const token of baseTokens) {
+    if (collectionForToken(token) !== COLLECTIONS.components) continue;
+
+    const name = toVariableName(token);
+    // Een token dat al als density-variant bestaat hoort daar thuis, niet hier.
+    if (density.has(name)) continue;
+
+    const mapped = mapTokenValue(token, basePixels);
+    if (mapped.skip) {
+      noteSkip(token, mapped.skip);
+      continue;
+    }
+
+    components.set(name, {
+      name,
+      type: mapped.figmaType,
+      description: token.$description ?? token.comment ?? '',
+      valuesByMode: { default: mapped.value },
+      reference: referenceToVariableName(token.original.$value),
+    });
+  }
+
+  // Tweede pass: referenties omzetten naar aliassen. Een alias houdt de
+  // delegatieketen in Figma intact, precies zoals in de token-JSON.
+  const locate = (variableName) => {
+    if (primitives.has(variableName)) return COLLECTIONS.primitives;
+    if (density.has(variableName)) return COLLECTIONS.density;
+    if (components.has(variableName)) return COLLECTIONS.components;
+    return null;
+  };
+
+  const danglingReferences = [];
+  for (const variable of components.values()) {
+    const { reference } = variable;
+    delete variable.reference;
+    if (!reference) continue;
+
+    const collection = locate(reference);
+    if (!collection) {
+      // Het doel is zelf niet naar Figma te mappen (bijvoorbeeld een shadow).
+      // De letterlijke waarde blijft dan staan.
+      danglingReferences.push({ variable: variable.name, reference });
+      continue;
+    }
+
+    delete variable.valuesByMode;
+    variable.alias = { collection, name: reference };
+  }
+
+  return {
+    $schema: 'dsn-figma-variables/1',
+    generatedAt: new Date().toISOString(),
+    meta: {
+      rootFontSize: ROOT_FONT_SIZE,
+      referenceViewport: REFERENCE_VIEWPORT,
+    },
+    collections: [
+      {
+        name: COLLECTIONS.primitives,
+        modes: primitiveModes,
+        variables: [...primitives.values()],
+      },
+      {
+        name: COLLECTIONS.density,
+        modes: densities,
+        variables: [...density.values()],
+      },
+      {
+        name: COLLECTIONS.components,
+        modes: ['default'],
+        variables: [...components.values()],
+      },
+    ],
+    skipped,
+    danglingReferences,
+  };
+}

--- a/packages/design-tokens/src/config/figma.js
+++ b/packages/design-tokens/src/config/figma.js
@@ -609,6 +609,45 @@ export async function buildFigmaVariables({
     variable.alias = { collection, name: reference };
   }
 
+  // Een variable die niet in elke mode een waarde heeft is in Figma kapot:
+  // de ontbrekende modes vallen terug op een standaardwaarde. Dat gebeurt bij
+  // een token dat maar in één theme bestaat, of dat in de ene mode wel en in
+  // de andere niet te mappen is (bijvoorbeeld transparent tegenover
+  // color-mix). Zulke variables gaan er alsnog uit, met verantwoording.
+  const incomplete = [];
+  const dropIncomplete = (map, modeNames, collectionName) => {
+    for (const [name, variable] of [...map]) {
+      if (!variable.valuesByMode) continue;
+      const missing = modeNames.filter(
+        (mode) => variable.valuesByMode[mode] === undefined
+      );
+      if (!missing.length) continue;
+      map.delete(name);
+      incomplete.push({ variable: name, collection: collectionName, missing });
+    }
+  };
+
+  dropIncomplete(primitives, primitiveModes, COLLECTIONS.primitives);
+  dropIncomplete(density, densityModes, COLLECTIONS.density);
+
+  // Aliassen die naar een zojuist verwijderde variable wezen kunnen niet meer.
+  for (const [name, variable] of [...components]) {
+    if (!variable.alias) continue;
+    const target =
+      variable.alias.collection === COLLECTIONS.primitives
+        ? primitives
+        : variable.alias.collection === COLLECTIONS.density
+          ? density
+          : components;
+    if (target.has(variable.alias.name)) continue;
+    components.delete(name);
+    incomplete.push({
+      variable: name,
+      collection: COLLECTIONS.components,
+      missing: [`aliasdoel ${variable.alias.name} is vervallen`],
+    });
+  }
+
   return {
     $schema: 'dsn-figma-variables/1',
     generatedAt: new Date().toISOString(),
@@ -636,5 +675,6 @@ export async function buildFigmaVariables({
     skipped,
     danglingReferences,
     viewportPinned,
+    incomplete,
   };
 }

--- a/packages/design-tokens/src/config/figma.js
+++ b/packages/design-tokens/src/config/figma.js
@@ -23,11 +23,22 @@
 const ROOT_FONT_SIZE = 16;
 
 /**
- * Referentie-viewport voor het uitrekenen van fluid waarden (clamp met vw).
- * Figma-variables zijn statisch, dus een clamp() moet op één breedte worden
- * vastgeprikt. 1440px is een gangbare desktop-artboardbreedte.
+ * Viewports waarop fluid waarden (clamp met vw) worden uitgerekend.
+ *
+ * Een Figma-variable is statisch, dus een clamp() moet op een breedte worden
+ * vastgeprikt. In plaats van één willekeurige breedte te kiezen krijgt de
+ * typografieschaal een mode per viewport: de designer schakelt het artboard en
+ * de hele schaal volgt. 375px valt onder elke clamp-ondergrens, dus die mode
+ * bevat exact de ontworpen min-waarden.
  */
-const REFERENCE_VIEWPORT = 1440;
+export const VIEWPORTS = { mobile: 375, desktop: 1440 };
+
+/**
+ * Viewport voor waarden buiten de typografieschaal. Die zitten in collections
+ * met een andere mode-as (theme, light/dark) en kunnen er dus geen viewport-as
+ * bij hebben. Wat hierdoor wordt vastgeprikt komt in het report te staan.
+ */
+const DEFAULT_VIEWPORT = VIEWPORTS.desktop;
 
 export const COLLECTIONS = {
   primitives: 'dsn/Primitives',
@@ -68,18 +79,16 @@ function parseColor(input) {
 
 /**
  * Vervangt CSS-eenheden door pixelwaarden zodat de rest een kale som wordt.
- * vw wordt uitgerekend op REFERENCE_VIEWPORT, ch heeft geen betrouwbare
+ * vw wordt uitgerekend op de meegegeven viewport, ch heeft geen betrouwbare
  * conversie (hangt van het lettertype af) en levert daarom null op.
  */
-function unitsToPixels(expression) {
+function unitsToPixels(expression, viewport) {
   if (/[\d.]ch\b/.test(expression)) return null;
   if (/[\d.]e[m]\b/.test(expression)) return null;
 
   return expression
     .replace(/(-?[\d.]+)rem\b/g, (_, n) => String(Number(n) * ROOT_FONT_SIZE))
-    .replace(/(-?[\d.]+)vw\b/g, (_, n) =>
-      String((Number(n) / 100) * REFERENCE_VIEWPORT)
-    )
+    .replace(/(-?[\d.]+)vw\b/g, (_, n) => String((Number(n) / 100) * viewport))
     .replace(/(-?[\d.]+)px\b/g, (_, n) => String(Number(n)));
 }
 
@@ -120,7 +129,7 @@ function splitArguments(input) {
 
 /**
  * Lost clamp() en calc() van binnen naar buiten op tot er een getal overblijft.
- * clamp(min, preferred, max) wordt op REFERENCE_VIEWPORT uitgerekend.
+ * De vw-eenheden zijn op dat moment al door unitsToPixels vervangen.
  */
 function resolveFunctions(expression) {
   // calc() is puur rekenwerk, dus het keyword kan weg: de haakjes die
@@ -186,7 +195,7 @@ function substituteCssVars(expression, pixelsByCssName) {
  * Zet een lengte-achtige tokenwaarde om naar een getal in pixels.
  * Retourneert null als de waarde niet betrouwbaar te herleiden is.
  */
-function toPixels(input, pixelsByCssName) {
+function toPixels(input, pixelsByCssName, viewport = DEFAULT_VIEWPORT) {
   const value = String(input).trim();
 
   if (/^-?[\d.]+$/.test(value)) return Number(value);
@@ -194,7 +203,7 @@ function toPixels(input, pixelsByCssName) {
   const substituted = substituteCssVars(value, pixelsByCssName);
   if (substituted === null) return null;
 
-  const withPixels = unitsToPixels(substituted);
+  const withPixels = unitsToPixels(substituted, viewport);
   if (withPixels === null) return null;
 
   return resolveFunctions(withPixels);
@@ -233,7 +242,7 @@ const DURATION_PATTERN = /^-?[\d.]+m?s$/;
  * @param {Map<string, number>} [pixelsByCssName] Lookup om `var(--dsn-x)`
  *   binnen een tokenwaarde alsnog te kunnen uitrekenen.
  */
-export function mapTokenValue(token, pixelsByCssName) {
+export function mapTokenValue(token, pixelsByCssName, viewport) {
   const type = token.$type ?? token.type;
   const raw = token.$value ?? token.value;
   // Op elk padsegment matchen, niet alleen op de groep: `dsn.backdrop.z-index`
@@ -282,7 +291,7 @@ export function mapTokenValue(token, pixelsByCssName) {
   }
 
   // Alles wat overblijft proberen we als getal te lezen.
-  const pixels = toPixels(raw, pixelsByCssName);
+  const pixels = toPixels(raw, pixelsByCssName, viewport);
   if (pixels === null) {
     return { skip: `waarde "${raw}" is niet naar een getal te herleiden` };
   }
@@ -337,7 +346,7 @@ function collectionForToken(token) {
  * Meerdere passes, omdat een token dat `var(--x)` gebruikt kan verwijzen naar
  * een token dat zelf ook nog opgelost moet worden.
  */
-function buildPixelLookup(tokens) {
+function buildPixelLookup(tokens, viewport) {
   const lookup = new Map();
   const pending = [];
 
@@ -348,7 +357,7 @@ function buildPixelLookup(tokens) {
       pending.push({ cssName, raw });
       continue;
     }
-    const pixels = toPixels(raw);
+    const pixels = toPixels(raw, undefined, viewport);
     if (pixels !== null) lookup.set(cssName, pixels);
   }
 
@@ -356,7 +365,7 @@ function buildPixelLookup(tokens) {
   for (let round = 0; round < 5 && pending.length > 0; round += 1) {
     let resolvedThisRound = 0;
     for (let index = pending.length - 1; index >= 0; index -= 1) {
-      const pixels = toPixels(pending[index].raw, lookup);
+      const pixels = toPixels(pending[index].raw, lookup, viewport);
       if (pixels === null) continue;
       lookup.set(pending[index].cssName, pixels);
       pending.splice(index, 1);
@@ -388,6 +397,11 @@ export async function buildFigmaVariables({
     skipped.push({ token: token.path.join('.'), reason });
   };
 
+  // Fluid waarden buiten de typografieschaal. Die collections hebben een andere
+  // mode-as (theme, light/dark), dus daar kan geen viewport-as bij. Ze worden
+  // op DEFAULT_VIEWPORT vastgeprikt en hier verantwoord.
+  const viewportPinned = [];
+
   // ---------------------------------------------------------------------------
   // 1. Primitives: een mode per theme x light/dark combinatie.
   // ---------------------------------------------------------------------------
@@ -411,6 +425,14 @@ export async function buildFigmaVariables({
           continue;
         }
 
+        if (mapped.fluidSource && modeName === primitiveModes[0]) {
+          viewportPinned.push({
+            variable: name,
+            collection: COLLECTIONS.primitives,
+            source: mapped.fluidSource,
+          });
+        }
+
         if (!primitives.has(name)) {
           primitives.set(name, {
             name,
@@ -429,30 +451,88 @@ export async function buildFigmaVariables({
   // 2. Density: een mode per project-type (typografieschaal en overrides).
   // ---------------------------------------------------------------------------
   const density = new Map();
+  const densityModes = [];
+  const viewportNames = Object.keys(VIEWPORTS);
+
+  // Per project-type x viewport de hele tokenset uitrekenen. We houden alle
+  // waarden bij, niet alleen die van de Density-collection: een token als
+  // dsn.grid.gutter komt in het ene project-type uit een override en in het
+  // andere uit het component-bestand. Zonder de volledige set zou het in de
+  // default-modes geen waarde krijgen.
+  const measured = new Map();
+  const densityNames = new Set();
 
   for (const densityName of densities) {
-    const tokens = await loadTokens(themes[0], modes[0], densityName);
-    const pixels = buildPixelLookup(tokens);
-    for (const token of tokens) {
-      if (collectionForToken(token) !== COLLECTIONS.density) continue;
+    for (const viewportName of viewportNames) {
+      const tokens = await loadTokens(themes[0], modes[0], densityName);
+      const viewport = VIEWPORTS[viewportName];
+      const pixels = buildPixelLookup(tokens, viewport);
+      const values = new Map();
 
-      const mapped = mapTokenValue(token, pixels);
-      const name = toVariableName(token);
-      if (mapped.skip) {
-        if (densityName === densities[0]) noteSkip(token, mapped.skip);
-        continue;
+      for (const token of tokens) {
+        const isDensityToken =
+          collectionForToken(token) === COLLECTIONS.density;
+        const mapped = mapTokenValue(token, pixels, viewport);
+        const name = toVariableName(token);
+
+        if (mapped.skip) {
+          if (
+            isDensityToken &&
+            densityName === densities[0] &&
+            viewportName === viewportNames[0]
+          ) {
+            noteSkip(token, mapped.skip);
+          }
+          continue;
+        }
+
+        if (isDensityToken) densityNames.add(name);
+        values.set(name, { token, mapped });
       }
 
-      if (!density.has(name)) {
-        density.set(name, {
-          name,
-          type: mapped.figmaType,
-          description: token.$description ?? token.comment ?? '',
-          fluidSource: mapped.fluidSource,
-          valuesByMode: {},
-        });
+      measured.set(`${densityName}|${viewportName}`, values);
+    }
+  }
+
+  for (const densityName of densities) {
+    const valuesFor = (viewportName) =>
+      measured.get(`${densityName}|${viewportName}`);
+
+    // Levert elke viewport identieke waarden op? Dan is dit project-type niet
+    // fluid en zou een mode per viewport alleen maar ruis toevoegen.
+    const [first, ...rest] = viewportNames;
+    const isFluid = rest.some((viewportName) =>
+      [...densityNames].some(
+        (name) =>
+          valuesFor(viewportName).get(name)?.mapped.value !==
+          valuesFor(first).get(name)?.mapped.value
+      )
+    );
+
+    const modesForDensity = isFluid
+      ? viewportNames.map((viewportName) => ({
+          mode: `${densityName}-${viewportName}`,
+          viewportName,
+        }))
+      : [{ mode: densityName, viewportName: first }];
+
+    for (const { mode, viewportName } of modesForDensity) {
+      densityModes.push(mode);
+      for (const name of densityNames) {
+        const entry = valuesFor(viewportName).get(name);
+        if (!entry) continue;
+
+        if (!density.has(name)) {
+          density.set(name, {
+            name,
+            type: entry.mapped.figmaType,
+            description: entry.token.$description ?? entry.token.comment ?? '',
+            fluidSource: entry.mapped.fluidSource,
+            valuesByMode: {},
+          });
+        }
+        density.get(name).valuesByMode[mode] = entry.mapped.value;
       }
-      density.get(name).valuesByMode[densityName] = mapped.value;
     }
   }
 
@@ -487,6 +567,7 @@ export async function buildFigmaVariables({
       description: token.$description ?? token.comment ?? '',
       valuesByMode: { default: mapped.value },
       reference: referenceToVariableName(token.original.$value),
+      fluidSource: mapped.fluidSource,
     });
   }
 
@@ -501,11 +582,22 @@ export async function buildFigmaVariables({
 
   const danglingReferences = [];
   for (const variable of components.values()) {
-    const { reference } = variable;
+    const { reference, fluidSource } = variable;
     delete variable.reference;
+    delete variable.fluidSource;
+
+    // Een alias erft de mode van zijn doel en is dus niet vastgeprikt.
+    const collection = reference ? locate(reference) : null;
+    if (fluidSource && !collection) {
+      viewportPinned.push({
+        variable: variable.name,
+        collection: COLLECTIONS.components,
+        source: fluidSource,
+      });
+    }
+
     if (!reference) continue;
 
-    const collection = locate(reference);
     if (!collection) {
       // Het doel is zelf niet naar Figma te mappen (bijvoorbeeld een shadow).
       // De letterlijke waarde blijft dan staan.
@@ -522,7 +614,7 @@ export async function buildFigmaVariables({
     generatedAt: new Date().toISOString(),
     meta: {
       rootFontSize: ROOT_FONT_SIZE,
-      referenceViewport: REFERENCE_VIEWPORT,
+      viewports: VIEWPORTS,
     },
     collections: [
       {
@@ -532,7 +624,7 @@ export async function buildFigmaVariables({
       },
       {
         name: COLLECTIONS.density,
-        modes: densities,
+        modes: densityModes,
         variables: [...density.values()],
       },
       {
@@ -543,5 +635,6 @@ export async function buildFigmaVariables({
     ],
     skipped,
     danglingReferences,
+    viewportPinned,
   };
 }

--- a/packages/figma-plugin/README.md
+++ b/packages/figma-plugin/README.md
@@ -24,7 +24,7 @@ manifest**, en kies `packages/figma-plugin/manifest.json`.
 1. Genereer de bestanden:
 
 ```bash
-pnpm build:tokens && pnpm build:figma-components
+pnpm build:figma
 ```
 
 2. Start de plugin in een Figma-bestand en sleep er een JSON in:

--- a/packages/figma-plugin/README.md
+++ b/packages/figma-plugin/README.md
@@ -1,0 +1,81 @@
+# @dsn-starter-kit/figma-plugin
+
+Schrijft de JSON die `design-tokens` en `figma-sync` genereren weg naar Figma.
+
+Dit is het enige onderdeel van de keten dat Figma daadwerkelijk aanraakt.
+Bewust een plugin en geen REST-integratie: de Variables REST API vereist een
+Enterprise-plan, terwijl de Plugin API op elk plan werkt.
+
+**Er is geen token of API-key nodig.** De plugin draait in Figma Desktop en
+leest alleen bestanden die je zelf in de UI kiest. Het manifest declareert
+`networkAccess: none`, dus er gaat niets het netwerk op.
+
+## Installeren
+
+```bash
+pnpm build:figma-plugin
+```
+
+Daarna in Figma Desktop: **Plugins → Development → Import plugin from
+manifest**, en kies `packages/figma-plugin/manifest.json`.
+
+## Gebruiken
+
+1. Genereer de bestanden:
+
+```bash
+pnpm build:tokens && pnpm build:figma-components
+```
+
+2. Start de plugin in een Figma-bestand en sleep er een JSON in:
+
+| Bestand                                   | Wat er gebeurt                          |
+| ----------------------------------------- | --------------------------------------- |
+| `design-tokens/dist/figma/variables.json` | Variable collections, modes en aliassen |
+| `figma-sync/dist/{component}.json`        | Eén component set met al zijn varianten |
+
+Het `$schema`-veld bepaalt wat er geïmporteerd wordt, niet de bestandsnaam.
+
+**Draai `variables.json` als eerste.** Componenten verwijzen naar tokens, dus
+de variables moeten bestaan voordat je ze aan lagen kunt binden.
+
+## Idempotent
+
+Bestaande collections, modes en variables worden hergebruikt en bijgewerkt, niet
+gedupliceerd. Dat is een harde eis: dupliceren zou de bindingen verbreken die
+designers al gelegd hebben. De smoke test controleert dit expliciet door de
+import twee keer te draaien.
+
+Component sets worden wél elke keer opnieuw aangemaakt. Een bestaande set
+bijwerken zonder instanties te breken is een apart probleem, zie hieronder.
+
+## Smoke test
+
+```bash
+pnpm test:figma-plugin
+```
+
+Draait de import-logica tegen de echte gegenereerde JSON met een mock van de
+Plugin API (`scripts/figma-mock.js`). De mock dwingt de drie volgorde-eisen af
+die in Figma echt fouten geven:
+
+1. `characters` zetten voordat het font geladen is
+2. `layoutSizing*` op `FILL` terwijl de ouder geen auto layout heeft
+3. `layoutSizing*` op `HUG` terwijl de node zelf geen `layoutMode` heeft
+
+Die eerste ronde vond meteen drie bugs in de generator: `HUG` op nodes zonder
+auto layout, `FILL` binnen een niet-auto-layout ouder, en twee variables die
+niet in elke mode een waarde hadden. Draai deze test dus voordat je iets in
+Figma laadt.
+
+## Wat dit nog niet doet
+
+- **Component sets bijwerken.** Elke import maakt een nieuwe set aan. Bestaande
+  instanties in designbestanden koppelen daar niet vanzelf aan.
+- **Variables aan lagen binden.** De variables komen erin, maar de gegenereerde
+  componenten gebruiken vaste waarden in plaats van `boundVariables`. Daardoor
+  volgen ze de theme-schakelaar nog niet.
+- **Effect styles.** Box shadows staan in het skip-report en moeten nog
+  Figma-effectstijlen worden.
+- **Component properties.** Boolean-slots voor iconen, instance swap en text
+  properties blijven handwerk.

--- a/packages/figma-plugin/manifest.json
+++ b/packages/figma-plugin/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "DSN Sync",
+  "id": "dsn-starter-kit-sync",
+  "api": "1.0.0",
+  "main": "dist/code.js",
+  "ui": "src/ui.html",
+  "editorType": ["figma"],
+  "documentAccess": "dynamic-page",
+  "networkAccess": {
+    "allowedDomains": ["none"],
+    "reasoning": "De plugin leest alleen bestanden die de gebruiker zelf kiest; er gaat niets het netwerk op."
+  }
+}

--- a/packages/figma-plugin/package.json
+++ b/packages/figma-plugin/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@dsn-starter-kit/figma-plugin",
+  "version": "2.0.0",
+  "private": true,
+  "description": "Figma-plugin die de gegenereerde variables en component specs in Figma schrijft",
+  "type": "module",
+  "scripts": {
+    "build": "esbuild src/main.js --bundle --outfile=dist/code.js --format=iife --target=es2017 --log-level=warning",
+    "watch": "esbuild src/main.js --bundle --outfile=dist/code.js --format=iife --target=es2017 --watch",
+    "test": "node scripts/smoke-test.js",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.0"
+  },
+  "author": "Jeffrey Lauwers",
+  "license": "MIT"
+}

--- a/packages/figma-plugin/scripts/figma-mock.js
+++ b/packages/figma-plugin/scripts/figma-mock.js
@@ -8,6 +8,8 @@
  * 1. `characters` zetten voordat het font geladen is
  * 2. `layoutSizing*` op FILL terwijl de ouder geen auto layout heeft
  * 3. `layoutSizing*` op HUG terwijl de node zelf geen layoutMode heeft
+ * 4. `gridColumnAnchorIndex` en `gridRowAnchorIndex` zijn read-only; plaatsen
+ *    in een grid gaat via setGridChildPosition(rowIndex, columnIndex)
  */
 
 let nextId = 1;
@@ -40,6 +42,34 @@ class Node {
   resize(width, height) {
     this.width = width;
     this.height = height;
+  }
+
+  // Read-only in de echte API: eraan toewijzen geeft "no setter for property".
+  get gridColumnAnchorIndex() {
+    return this._gridColumnAnchorIndex;
+  }
+  set gridColumnAnchorIndex(_value) {
+    throw new Error('no setter for property gridColumnAnchorIndex');
+  }
+  get gridRowAnchorIndex() {
+    return this._gridRowAnchorIndex;
+  }
+  set gridRowAnchorIndex(_value) {
+    throw new Error('no setter for property gridRowAnchorIndex');
+  }
+
+  setGridChildPosition(rowIndex, columnIndex) {
+    if (!this.parent || this.parent.layoutMode !== 'GRID') {
+      throw new Error('setGridChildPosition vereist een GRID-ouder');
+    }
+    if (!Number.isInteger(rowIndex) || !Number.isInteger(columnIndex)) {
+      throw new Error('setGridChildPosition verwacht (rowIndex, columnIndex)');
+    }
+    if (columnIndex >= (this.parent.gridColumnCount ?? 1)) {
+      throw new Error(`kolomindex ${columnIndex} valt buiten het grid`);
+    }
+    this._gridRowAnchorIndex = rowIndex;
+    this._gridColumnAnchorIndex = columnIndex;
   }
 
   remove() {
@@ -200,6 +230,13 @@ export const figma = {
     const node = new Node('FRAME');
     node.isSvg = true;
     node.svg = svg;
+    // De echte API levert vector-kinderen op. Die zijn nodig om te kunnen
+    // controleren of de icoonkleur daadwerkelijk wordt doorgezet: in de
+    // browser erft een icoon `currentColor`, in Figma wordt het zwart.
+    const vector = new Node('VECTOR');
+    vector.fills = [];
+    vector.strokes = [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 } }];
+    node.appendChild(vector);
     return node;
   },
   combineAsVariants(components, parent) {

--- a/packages/figma-plugin/scripts/figma-mock.js
+++ b/packages/figma-plugin/scripts/figma-mock.js
@@ -1,0 +1,213 @@
+/**
+ * Minimale nabootsing van de Figma Plugin API, genoeg om de import-logica
+ * buiten Figma te kunnen draaien.
+ *
+ * De mock is bewust streng op de drie volgorde-eisen die in Figma echt fouten
+ * geven, want dat zijn precies de bugs die je anders pas in de app ontdekt:
+ *
+ * 1. `characters` zetten voordat het font geladen is
+ * 2. `layoutSizing*` op FILL terwijl de ouder geen auto layout heeft
+ * 3. `layoutSizing*` op HUG terwijl de node zelf geen layoutMode heeft
+ */
+
+let nextId = 1;
+const id = (prefix) => `${prefix}:${nextId++}`;
+
+const loadedFonts = new Set();
+
+class Node {
+  constructor(type) {
+    this.type = type;
+    this.id = id(type);
+    this.children = [];
+    this.parent = null;
+    this.width = 0;
+    this.height = 0;
+    this.x = 0;
+    this.y = 0;
+    this.layoutMode = 'NONE';
+    this.fills = [];
+  }
+
+  appendChild(child) {
+    if (child.parent) {
+      child.parent.children = child.parent.children.filter((c) => c !== child);
+    }
+    child.parent = this;
+    this.children.push(child);
+  }
+
+  resize(width, height) {
+    this.width = width;
+    this.height = height;
+  }
+
+  remove() {
+    if (this.parent) {
+      this.parent.children = this.parent.children.filter((c) => c !== this);
+    }
+  }
+
+  set layoutSizingHorizontal(value) {
+    this.#assertSizing('layoutSizingHorizontal', value);
+    this._layoutSizingHorizontal = value;
+  }
+  get layoutSizingHorizontal() {
+    return this._layoutSizingHorizontal;
+  }
+
+  set layoutSizingVertical(value) {
+    this.#assertSizing('layoutSizingVertical', value);
+    this._layoutSizingVertical = value;
+  }
+  get layoutSizingVertical() {
+    return this._layoutSizingVertical;
+  }
+
+  #assertSizing(axis, value) {
+    if (value === 'HUG' && this.layoutMode === 'NONE') {
+      throw new Error(`${axis}=HUG vereist een layoutMode op de node zelf`);
+    }
+    if (
+      value === 'FILL' &&
+      (!this.parent || this.parent.layoutMode === 'NONE')
+    ) {
+      throw new Error(`${axis}=FILL vereist een auto-layout ouder`);
+    }
+  }
+}
+
+class TextNode extends Node {
+  constructor() {
+    super('TEXT');
+    this._characters = '';
+  }
+
+  set characters(value) {
+    const font = this.fontName;
+    if (!font || !loadedFonts.has(`${font.family}|${font.style}`)) {
+      throw new Error(
+        `characters gezet zonder geladen font (${font ? `${font.family} ${font.style}` : 'geen fontName'})`
+      );
+    }
+    this._characters = value;
+  }
+  get characters() {
+    return this._characters;
+  }
+}
+
+class Variable {
+  constructor(name, collection, resolvedType) {
+    this.id = id('VAR');
+    this.name = name;
+    this.resolvedType = resolvedType;
+    this.variableCollectionId = collection.id;
+    this.valuesByMode = {};
+    this.description = '';
+  }
+
+  setValueForMode(modeId, value) {
+    if (!modeId) throw new Error(`onbekende modeId voor ${this.name}`);
+    this.valuesByMode[modeId] = value;
+  }
+
+  remove() {
+    state.variables = state.variables.filter((v) => v !== this);
+  }
+}
+
+class VariableCollection {
+  constructor(name) {
+    this.id = id('COL');
+    this.name = name;
+    this.modes = [{ modeId: id('MODE'), name: 'Mode 1' }];
+  }
+
+  addMode(name) {
+    // Figma begrenst het aantal modes per plan; Professional staat er 10 toe.
+    if (this.modes.length >= 10) {
+      throw new Error('Limiet van 10 modes per collection bereikt');
+    }
+    const mode = { modeId: id('MODE'), name };
+    this.modes.push(mode);
+    return mode.modeId;
+  }
+
+  renameMode(modeId, name) {
+    const mode = this.modes.find((m) => m.modeId === modeId);
+    if (!mode) throw new Error(`mode ${modeId} bestaat niet`);
+    mode.name = name;
+  }
+}
+
+const state = {
+  collections: [],
+  variables: [],
+  page: new Node('PAGE'),
+};
+
+export const figma = {
+  currentPage: state.page,
+  viewport: { scrollAndZoomIntoView() {} },
+  ui: { postMessage() {} },
+  showUI() {},
+  closePlugin() {},
+
+  variables: {
+    async getLocalVariableCollectionsAsync() {
+      return state.collections;
+    },
+    async getLocalVariablesAsync() {
+      return state.variables;
+    },
+    createVariableCollection(name) {
+      const collection = new VariableCollection(name);
+      state.collections.push(collection);
+      return collection;
+    },
+    createVariable(name, collection, resolvedType) {
+      const variable = new Variable(name, collection, resolvedType);
+      state.variables.push(variable);
+      return variable;
+    },
+    createVariableAlias(variable) {
+      return { type: 'VARIABLE_ALIAS', id: variable.id };
+    },
+  },
+
+  async loadFontAsync(font) {
+    // Alleen fonts die Figma standaard heeft plus het font van dit systeem.
+    const known = ['Inter', 'IBM Plex Sans', 'IBM Plex Mono', 'Roboto'];
+    if (!known.includes(font.family)) {
+      throw new Error(`font ${font.family} niet beschikbaar`);
+    }
+    loadedFonts.add(`${font.family}|${font.style}`);
+  },
+
+  createFrame() {
+    const frame = new Node('FRAME');
+    frame.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+    return frame;
+  },
+  createText() {
+    return new TextNode();
+  },
+  createComponent() {
+    return new Node('COMPONENT');
+  },
+  createNodeFromSvg(svg) {
+    const node = new Node('FRAME');
+    node.isSvg = true;
+    node.svg = svg;
+    return node;
+  },
+  combineAsVariants(components, parent) {
+    const set = new Node('COMPONENT_SET');
+    parent.appendChild(set);
+    for (const component of components) set.appendChild(component);
+    return set;
+  },
+};
+
+export { state };

--- a/packages/figma-plugin/scripts/figma-mock.js
+++ b/packages/figma-plugin/scripts/figma-mock.js
@@ -10,6 +10,8 @@
  * 3. `layoutSizing*` op HUG terwijl de node zelf geen layoutMode heeft
  * 4. `gridColumnAnchorIndex` en `gridRowAnchorIndex` zijn read-only; plaatsen
  *    in een grid gaat via setGridChildPosition(rowIndex, columnIndex)
+ * 5. `gridAutoTracks` gaat over automatisch rijen toevoegen; de maten van de
+ *    tracks horen in `gridColumnSizes` en `gridRowSizes`
  */
 
 let nextId = 1;
@@ -29,6 +31,10 @@ class Node {
     this.y = 0;
     this.layoutMode = 'NONE';
     this.fills = [];
+    // Zoals in Figma: een nieuw grid heeft FLEX-tracks, dus wie ze niet zet
+    // krijgt gelijke kolommen.
+    this.gridColumnSizes = [];
+    this.gridRowSizes = [];
   }
 
   appendChild(child) {
@@ -56,6 +62,18 @@ class Node {
   }
   set gridRowAnchorIndex(_value) {
     throw new Error('no setter for property gridRowAnchorIndex');
+  }
+
+  set gridAutoTracks(value) {
+    if (typeof value === 'object') {
+      throw new Error(
+        "gridAutoTracks verwacht 'NONE' of 'ROWS'; gebruik gridColumnSizes en gridRowSizes voor trackmaten"
+      );
+    }
+    this._gridAutoTracks = value;
+  }
+  get gridAutoTracks() {
+    return this._gridAutoTracks;
   }
 
   setGridChildPosition(rowIndex, columnIndex) {

--- a/packages/figma-plugin/scripts/smoke-test.js
+++ b/packages/figma-plugin/scripts/smoke-test.js
@@ -215,6 +215,35 @@ for (const file of componentFiles) {
     black.length === 0,
     black.length ? `${black.length} zwart gebleven` : ''
   );
+
+  // Zonder gridColumnSizes houdt Figma zijn eigen standaard aan (alle tracks
+  // FLEX) en worden alle kolommen even breed, ongeacht de CSS.
+  const gridMismatch = [];
+  const checkGrid = (node, spec) => {
+    if (spec?.layoutMode === 'GRID') {
+      const applied = node?.gridColumnSizes ?? [];
+      if (
+        applied.length !== spec.gridColumnSizes.length ||
+        applied.some((track, i) => track.type !== spec.gridColumnSizes[i].type)
+      ) {
+        gridMismatch.push(spec.name ?? 'grid');
+      }
+    }
+    (spec?.children ?? []).forEach((childSpec, index) =>
+      checkGrid(node?.children?.[index], childSpec)
+    );
+  };
+  for (const [index, component] of payload.componentSet.components.entries()) {
+    checkGrid(
+      state.page.children.at(-1)?.children[index]?.children[0],
+      component.node
+    );
+  }
+  check(
+    'grid-tracks toegepast',
+    gridMismatch.length === 0,
+    gridMismatch.length ? `${gridMismatch.length} niet overgenomen` : ''
+  );
 }
 
 console.log(

--- a/packages/figma-plugin/scripts/smoke-test.js
+++ b/packages/figma-plugin/scripts/smoke-test.js
@@ -1,0 +1,179 @@
+/**
+ * Draait de import-logica tegen de echte gegenereerde JSON, met een mock van
+ * de Figma Plugin API. Vangt volgorde- en aliasfouten voordat de plugin in
+ * Figma geladen wordt.
+ *
+ *   node scripts/smoke-test.js
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { figma, state } from './figma-mock.js';
+
+// De modules praten tegen een globale `figma`, net als in de sandbox.
+globalThis.figma = figma;
+
+const { importVariables } = await import('../src/variables.js');
+const { importComponentSet } = await import('../src/components.js');
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const monorepoRoot = path.resolve(__dirname, '..', '..', '..');
+
+const problems = [];
+const log = {
+  info: () => {},
+  warn: (message) => problems.push({ level: 'warn', message }),
+  error: (message) => problems.push({ level: 'error', message }),
+};
+
+function check(label, condition, detail) {
+  const mark = condition ? '  ✓' : '  ✗';
+  console.log(`${mark} ${label}${detail ? `  ${detail}` : ''}`);
+  if (!condition) process.exitCode = 1;
+}
+
+function read(relative) {
+  return JSON.parse(fs.readFileSync(path.join(monorepoRoot, relative), 'utf8'));
+}
+
+// =============================================================================
+// Variables
+// =============================================================================
+
+console.log('\n=== variables.json ===');
+const variablesPayload = read(
+  'packages/design-tokens/dist/figma/variables.json'
+);
+const result = await importVariables(variablesPayload, log);
+
+const expectedVariables = variablesPayload.collections.reduce(
+  (total, collection) => total + collection.variables.length,
+  0
+);
+
+check(
+  'collections aangemaakt',
+  state.collections.length === variablesPayload.collections.length,
+  `${state.collections.length}/${variablesPayload.collections.length}`
+);
+check(
+  'variables aangemaakt',
+  state.variables.length === expectedVariables,
+  `${state.variables.length}/${expectedVariables}`
+);
+
+const density = state.collections.find((c) => c.name === 'dsn/Density');
+check(
+  'Density heeft 3 modes',
+  density && density.modes.length === 3,
+  density ? density.modes.map((m) => m.name).join(', ') : 'ontbreekt'
+);
+
+// Elke variable moet voor elke mode van zijn collection een waarde hebben.
+let missingValues = 0;
+for (const collection of state.collections) {
+  const modeIds = collection.modes.map((m) => m.modeId);
+  for (const variable of state.variables.filter(
+    (v) => v.variableCollectionId === collection.id
+  )) {
+    for (const modeId of modeIds) {
+      if (variable.valuesByMode[modeId] === undefined) missingValues += 1;
+    }
+  }
+}
+check(
+  'elke variable heeft een waarde per mode',
+  missingValues === 0,
+  `${missingValues} gaten`
+);
+
+// Aliassen moeten naar een bestaande variable wijzen.
+const byId = new Map(state.variables.map((v) => [v.id, v]));
+let brokenAliases = 0;
+let aliasValues = 0;
+for (const variable of state.variables) {
+  for (const value of Object.values(variable.valuesByMode)) {
+    if (value && value.type === 'VARIABLE_ALIAS') {
+      aliasValues += 1;
+      if (!byId.has(value.id)) brokenAliases += 1;
+    }
+  }
+}
+check(
+  'aliassen wijzen naar bestaande variables',
+  brokenAliases === 0,
+  `${aliasValues} aliaswaarden`
+);
+check(
+  'aliassen gelegd',
+  result.aliasFailed === 0,
+  `${result.aliasCount} variables`
+);
+
+// Steekproef: een component-token moet doorverwijzen naar de typografieschaal.
+const paragraph = state.variables.find(
+  (v) => v.name === 'paragraph/default/font-size'
+);
+const paragraphTarget =
+  paragraph && byId.get(Object.values(paragraph.valuesByMode)[0]?.id);
+check(
+  'paragraph/default/font-size aliast naar text/font-size/md',
+  paragraphTarget && paragraphTarget.name === 'text/font-size/md',
+  paragraphTarget ? paragraphTarget.name : 'geen alias'
+);
+
+// Idempotent: nog een keer draaien mag niets dupliceren.
+const beforeRerun = state.variables.length;
+await importVariables(variablesPayload, log);
+check(
+  'tweede import dupliceert niets',
+  state.variables.length === beforeRerun,
+  `${state.variables.length} variables`
+);
+
+// =============================================================================
+// Componenten
+// =============================================================================
+
+const componentFiles = fs
+  .readdirSync(path.join(monorepoRoot, 'packages/figma-sync/dist'))
+  .filter((file) => file.endsWith('.json'));
+
+for (const file of componentFiles) {
+  console.log(`\n=== ${file} ===`);
+  const payload = read(`packages/figma-sync/dist/${file}`);
+  const before = problems.length;
+  const imported = await importComponentSet(payload, log);
+
+  check(
+    'alle varianten gebouwd',
+    imported.variants === payload.componentSet.components.length,
+    `${imported.variants}/${payload.componentSet.components.length}`
+  );
+  check('component set gecombineerd', imported.combined === true);
+
+  const fresh = problems
+    .slice(before)
+    .filter((p) => !payload.warnings.includes(p.message));
+  const errors = fresh.filter((p) => p.level === 'error');
+  check(
+    'geen importfouten',
+    errors.length === 0,
+    errors.map((e) => e.message).join(' | ')
+  );
+
+  const sizingWarnings = fresh.filter((p) =>
+    p.message.includes('layoutSizing')
+  );
+  check(
+    'geen ongeldige sizing',
+    sizingWarnings.length === 0,
+    sizingWarnings.length ? sizingWarnings[0].message : ''
+  );
+}
+
+console.log(
+  `\n${process.exitCode ? '✗ smoke test gefaald' : '✓ smoke test geslaagd'}\n`
+);

--- a/packages/figma-plugin/scripts/smoke-test.js
+++ b/packages/figma-plugin/scripts/smoke-test.js
@@ -172,6 +172,49 @@ for (const file of componentFiles) {
     sizingWarnings.length === 0,
     sizingWarnings.length ? sizingWarnings[0].message : ''
   );
+
+  const placementWarnings = fresh.filter((p) =>
+    p.message.includes('plaatsing')
+  );
+  check(
+    'geen mislukte plaatsingen',
+    placementWarnings.length === 0,
+    placementWarnings.length ? placementWarnings[0].message : ''
+  );
+
+  // Iconen erven in de browser currentColor; Figma maakt er zwart van als de
+  // kleur niet expliciet wordt doorgezet.
+  const black = [];
+  const visit = (node, spec) => {
+    if (spec?.type === 'VECTOR' && spec.fills?.length) {
+      const vector = node.children?.[0];
+      const paint = vector?.strokes?.[0] ?? vector?.fills?.[0];
+      const expected = spec.fills[0].color;
+      if (
+        !paint ||
+        paint.color.r !== expected.r ||
+        paint.color.g !== expected.g ||
+        paint.color.b !== expected.b
+      ) {
+        black.push(spec.name ?? 'icon');
+      }
+    }
+    (spec?.children ?? []).forEach((childSpec, index) =>
+      visit(node.children?.[index], childSpec)
+    );
+  };
+  for (const [index, component] of payload.componentSet.components.entries()) {
+    // Het component-wrapperframe zit één niveau boven de gebouwde boom.
+    visit(
+      state.page.children.at(-1)?.children[index]?.children[0],
+      component.node
+    );
+  }
+  check(
+    'iconen dragen de tekstkleur',
+    black.length === 0,
+    black.length ? `${black.length} zwart gebleven` : ''
+  );
 }
 
 console.log(

--- a/packages/figma-plugin/src/components.js
+++ b/packages/figma-plugin/src/components.js
@@ -67,6 +67,31 @@ async function loadFonts(fonts, log) {
   return available;
 }
 
+/**
+ * Kleurt een uit SVG opgebouwde node.
+ *
+ * In de browser erven iconen hun kleur van `currentColor`, maar Figma kent dat
+ * begrip niet: createNodeFromSvg maakt er zwart van. De gemeten tekstkleur
+ * wordt daarom over de vectoren heen gezet, en alleen daar waar de SVG
+ * daadwerkelijk een vulling of een lijn had. Zo blijft het verschil tussen een
+ * gevuld en een lijn-icoon intact.
+ */
+function recolorSvg(node, paints) {
+  if (!paints || !paints.length) return;
+
+  const visit = (current) => {
+    if (Array.isArray(current.fills) && current.fills.length) {
+      current.fills = paints;
+    }
+    if (Array.isArray(current.strokes) && current.strokes.length) {
+      current.strokes = paints;
+    }
+    for (const child of current.children ?? []) visit(child);
+  };
+
+  for (const child of node.children ?? []) visit(child);
+}
+
 function applyPaints(target, spec) {
   if (spec.fills) target.fills = spec.fills;
   if (spec.strokes) {
@@ -136,8 +161,12 @@ function applyPlacement(node, spec, log) {
       return;
     }
     if (spec.gridColumnAnchorIndex !== undefined) {
-      node.gridColumnAnchorIndex = spec.gridColumnAnchorIndex;
-      node.gridRowAnchorIndex = spec.gridRowAnchorIndex;
+      // gridColumnAnchorIndex en gridRowAnchorIndex zijn read-only; plaatsing
+      // gaat via deze methode, en die neemt de rij als eerste argument.
+      node.setGridChildPosition(
+        spec.gridRowAnchorIndex,
+        spec.gridColumnAnchorIndex
+      );
       if (spec.gridColumnSpan) node.gridColumnSpan = spec.gridColumnSpan;
       if (spec.gridRowSpan) node.gridRowSpan = spec.gridRowSpan;
     }
@@ -199,6 +228,7 @@ function buildNode(spec, parent, fonts, log) {
     parent.appendChild(node);
     node.name = spec.name ?? 'icon';
     if (spec.width && spec.height) node.resize(spec.width, spec.height);
+    recolorSvg(node, spec.fills);
     applyPlacement(node, spec, log);
     return node;
   }

--- a/packages/figma-plugin/src/components.js
+++ b/packages/figma-plugin/src/components.js
@@ -1,0 +1,301 @@
+/**
+ * Bouwt een Figma component set uit een node spec van de generator.
+ *
+ * De volgorde waarin Figma-eigenschappen gezet worden is niet vrij:
+ * - `layoutSizing*` op HUG kan pas als de node zelf een layoutMode heeft
+ * - `layoutSizing*` op FILL kan pas als de node in een auto-layout ouder hangt
+ * - een tekstnode accepteert pas karakters als het font geladen is
+ *
+ * Vandaar: node maken, aan de ouder hangen, stijl zetten, layoutMode zetten,
+ * kinderen bouwen, en pas als laatste de eigen sizing.
+ */
+
+/** Figma verwacht een style-naam, geen numeriek gewicht. */
+const WEIGHT_TO_STYLE = {
+  100: 'Thin',
+  200: 'ExtraLight',
+  300: 'Light',
+  400: 'Regular',
+  500: 'Medium',
+  600: 'SemiBold',
+  700: 'Bold',
+  800: 'ExtraBold',
+  900: 'Black',
+};
+
+const FALLBACK_FONT = { family: 'Inter', style: 'Regular' };
+
+function fontFor(node) {
+  const style = WEIGHT_TO_STYLE[node.fontWeight] ?? 'Regular';
+  return {
+    family: node.fontFamily,
+    style: node.italic
+      ? `${style} Italic`.replace('Regular Italic', 'Italic')
+      : style,
+  };
+}
+
+/** Loopt de spec af en verzamelt elk font dat geladen moet worden. */
+function collectFonts(node, into = new Map()) {
+  if (node.type === 'TEXT') {
+    const font = fontFor(node);
+    into.set(`${font.family}|${font.style}`, font);
+  }
+  for (const child of node.children ?? []) collectFonts(child, into);
+  return into;
+}
+
+/**
+ * Laadt alle benodigde fonts. Ontbrekende fonts worden op de fallback gezet
+ * zodat de import doorloopt in plaats van halverwege te stoppen.
+ */
+async function loadFonts(fonts, log) {
+  const available = new Map();
+  await figma.loadFontAsync(FALLBACK_FONT);
+
+  for (const [key, font] of fonts) {
+    try {
+      await figma.loadFontAsync(font);
+      available.set(key, font);
+    } catch {
+      log.warn(
+        `Font "${font.family} ${font.style}" is niet beschikbaar in dit bestand; Inter Regular gebruikt`
+      );
+      available.set(key, FALLBACK_FONT);
+    }
+  }
+  return available;
+}
+
+function applyPaints(target, spec) {
+  if (spec.fills) target.fills = spec.fills;
+  if (spec.strokes) {
+    target.strokes = spec.strokes;
+    if (spec.strokeWeight !== undefined)
+      target.strokeWeight = spec.strokeWeight;
+    if (spec.dashPattern) target.dashPattern = spec.dashPattern;
+  }
+}
+
+function applyCorners(target, spec) {
+  if (spec.cornerRadius !== undefined) {
+    target.cornerRadius = spec.cornerRadius;
+    return;
+  }
+  for (const corner of [
+    'topLeftRadius',
+    'topRightRadius',
+    'bottomRightRadius',
+    'bottomLeftRadius',
+  ]) {
+    if (spec[corner] !== undefined) target[corner] = spec[corner];
+  }
+}
+
+function applyAutoLayout(frame, spec) {
+  if (!spec.layoutMode || spec.layoutMode === 'NONE') return;
+  frame.layoutMode = spec.layoutMode;
+
+  if (spec.layoutMode === 'GRID') {
+    if (spec.gridColumnCount) frame.gridColumnCount = spec.gridColumnCount;
+    if (spec.gridRowCount) frame.gridRowCount = spec.gridRowCount;
+    if (spec.gridColumnGap !== undefined)
+      frame.gridColumnGap = spec.gridColumnGap;
+    if (spec.gridRowGap !== undefined) frame.gridRowGap = spec.gridRowGap;
+    if (spec.gridItemsPositioning) {
+      frame.gridItemsPositioning = spec.gridItemsPositioning;
+    }
+  } else {
+    if (spec.itemSpacing !== undefined) frame.itemSpacing = spec.itemSpacing;
+    if (spec.layoutWrap) frame.layoutWrap = spec.layoutWrap;
+    if (spec.primaryAxisAlignItems) {
+      frame.primaryAxisAlignItems = spec.primaryAxisAlignItems;
+    }
+    if (spec.counterAxisAlignItems) {
+      frame.counterAxisAlignItems = spec.counterAxisAlignItems;
+    }
+  }
+
+  for (const side of [
+    'paddingTop',
+    'paddingRight',
+    'paddingBottom',
+    'paddingLeft',
+  ]) {
+    if (spec[side] !== undefined) frame[side] = spec[side];
+  }
+}
+
+/** Plaatsing van een kind binnen zijn ouder: absoluut of in een gridcel. */
+function applyPlacement(node, spec, log) {
+  try {
+    if (spec.layoutPositioning === 'ABSOLUTE') {
+      node.layoutPositioning = 'ABSOLUTE';
+      if (spec.x !== undefined) node.x = spec.x;
+      if (spec.y !== undefined) node.y = spec.y;
+      return;
+    }
+    if (spec.gridColumnAnchorIndex !== undefined) {
+      node.gridColumnAnchorIndex = spec.gridColumnAnchorIndex;
+      node.gridRowAnchorIndex = spec.gridRowAnchorIndex;
+      if (spec.gridColumnSpan) node.gridColumnSpan = spec.gridColumnSpan;
+      if (spec.gridRowSpan) node.gridRowSpan = spec.gridRowSpan;
+    }
+    if (spec.layoutAlign) node.layoutAlign = spec.layoutAlign;
+  } catch (error) {
+    log.warn(`${spec.name ?? spec.type}: plaatsing mislukt: ${error.message}`);
+  }
+}
+
+/** Sizing als laatste: HUG vereist een eigen layoutMode, FILL een auto-layout ouder. */
+function applySizing(node, spec, log) {
+  for (const axis of ['layoutSizingHorizontal', 'layoutSizingVertical']) {
+    const value = spec[axis];
+    if (!value) continue;
+    try {
+      node[axis] = value;
+    } catch {
+      // Niet elke combinatie is geldig (FILL zonder auto-layout ouder,
+      // HUG zonder layoutMode). De gemeten afmeting blijft dan staan.
+      log.warn(`${spec.name ?? spec.type}: ${axis}=${value} niet toegestaan`);
+    }
+  }
+}
+
+/**
+ * Bouwt één node uit de spec en hangt hem aan `parent`.
+ * @returns {SceneNode}
+ */
+function buildNode(spec, parent, fonts, log) {
+  if (spec.type === 'TEXT') {
+    const text = figma.createText();
+    parent.appendChild(text);
+
+    const key = `${spec.fontFamily}|${fontFor(spec).style}`;
+    text.fontName = fonts.get(key) ?? FALLBACK_FONT;
+    text.characters = spec.characters ?? '';
+    if (spec.fontSize) text.fontSize = spec.fontSize;
+    if (spec.letterSpacing !== undefined) {
+      text.letterSpacing = { unit: 'PIXELS', value: spec.letterSpacing };
+    }
+    if (spec.lineHeight) text.lineHeight = spec.lineHeight;
+    if (spec.textAlignHorizontal) {
+      text.textAlignHorizontal = spec.textAlignHorizontal;
+    }
+    if (spec.textDecoration) text.textDecoration = spec.textDecoration;
+    if (spec.textCase) text.textCase = spec.textCase;
+    if (spec.fills) text.fills = spec.fills;
+    text.name = spec.name ?? spec.characters ?? 'Text';
+
+    applyPlacement(text, spec, log);
+    applySizing(text, spec, log);
+    return text;
+  }
+
+  if (spec.type === 'VECTOR') {
+    // createNodeFromSvg levert een frame met de vectoren erin. Dat is precies
+    // wat we willen: één node die het icoon voorstelt.
+    const node = figma.createNodeFromSvg(spec.svg);
+    parent.appendChild(node);
+    node.name = spec.name ?? 'icon';
+    if (spec.width && spec.height) node.resize(spec.width, spec.height);
+    applyPlacement(node, spec, log);
+    return node;
+  }
+
+  const frame = figma.createFrame();
+  parent.appendChild(frame);
+  frame.name = spec.name ?? 'Frame';
+
+  // Een nieuw frame heeft een witte vulling; die overschrijven we altijd,
+  // ook met een lege lijst, anders krijgt elk transparant element wit.
+  frame.fills = spec.fills ?? [];
+  applyPaints(frame, spec);
+  applyCorners(frame, spec);
+  if (spec.opacity !== undefined) frame.opacity = spec.opacity;
+  if (spec.clipsContent !== undefined) frame.clipsContent = spec.clipsContent;
+  if (spec.width && spec.height) frame.resize(spec.width, spec.height);
+
+  applyAutoLayout(frame, spec);
+  for (const child of spec.children ?? []) buildNode(child, frame, fonts, log);
+
+  applyPlacement(frame, spec, log);
+  applySizing(frame, spec, log);
+  return frame;
+}
+
+/**
+ * Importeert een volledige component set.
+ *
+ * @param {object} payload de inhoud van een {component}.json
+ * @param {object} log verzamelaar met .info/.warn/.error
+ */
+export async function importComponentSet(payload, log) {
+  if (payload.$schema !== 'dsn-figma-components/1') {
+    throw new Error(
+      `Onbekend formaat: ${payload.$schema ?? 'geen $schema'}. Verwacht dsn-figma-components/1.`
+    );
+  }
+
+  const spec = payload.componentSet;
+
+  // Alle fonts van alle varianten in één keer laden.
+  const fonts = new Map();
+  for (const component of spec.components) collectFonts(component.node, fonts);
+  const loaded = await loadFonts(fonts, log);
+
+  const page = figma.currentPage;
+  const components = [];
+  let cursorX = 0;
+  let rowHeight = 0;
+
+  for (const [index, component] of spec.components.entries()) {
+    const wrapper = figma.createComponent();
+    page.appendChild(wrapper);
+    // De naam bepaalt de variant properties zodra combineAsVariants draait.
+    wrapper.name = component.name;
+    wrapper.layoutMode = 'HORIZONTAL';
+    wrapper.primaryAxisSizingMode = 'AUTO';
+    wrapper.counterAxisSizingMode = 'AUTO';
+    wrapper.fills = [];
+
+    buildNode(component.node, wrapper, loaded, log);
+
+    // Varianten naast elkaar leggen; combineAsVariants ordent daarna zelf.
+    wrapper.x = cursorX;
+    wrapper.y = 0;
+    cursorX += wrapper.width + 40;
+    rowHeight = Math.max(rowHeight, wrapper.height);
+    components.push(wrapper);
+
+    if ((index + 1) % 6 === 0) {
+      cursorX = 0;
+    }
+  }
+
+  let set;
+  try {
+    set = figma.combineAsVariants(components, page);
+    set.name = spec.name;
+    set.layoutMode = 'VERTICAL';
+    set.itemSpacing = 24;
+    set.counterAxisSizingMode = 'AUTO';
+    set.primaryAxisSizingMode = 'AUTO';
+  } catch (error) {
+    log.error(
+      `Component set "${spec.name}" kon niet gecombineerd worden: ${error.message}. De losse varianten staan wel op de pagina.`
+    );
+    return { name: spec.name, variants: components.length, combined: false };
+  }
+
+  log.info(`${spec.name}: ${components.length} varianten gecombineerd`);
+
+  if (payload.warnings && payload.warnings.length) {
+    for (const warning of payload.warnings) log.warn(warning);
+  }
+
+  figma.currentPage.selection = [set];
+  figma.viewport.scrollAndZoomIntoView([set]);
+
+  return { name: spec.name, variants: components.length, combined: true };
+}

--- a/packages/figma-plugin/src/components.js
+++ b/packages/figma-plugin/src/components.js
@@ -130,6 +130,10 @@ function applyAutoLayout(frame, spec) {
     if (spec.gridItemsPositioning) {
       frame.gridItemsPositioning = spec.gridItemsPositioning;
     }
+    // Zonder deze twee blijft Figma bij zijn eigen standaard (alle tracks
+    // FLEX) en worden alle kolommen even breed, ongeacht de CSS.
+    if (spec.gridColumnSizes) frame.gridColumnSizes = spec.gridColumnSizes;
+    if (spec.gridRowSizes) frame.gridRowSizes = spec.gridRowSizes;
   } else {
     if (spec.itemSpacing !== undefined) frame.itemSpacing = spec.itemSpacing;
     if (spec.layoutWrap) frame.layoutWrap = spec.layoutWrap;

--- a/packages/figma-plugin/src/main.js
+++ b/packages/figma-plugin/src/main.js
@@ -1,0 +1,64 @@
+/**
+ * Entry point van de plugin (draait in de Figma-sandbox).
+ *
+ * De plugin leest niets zelf van schijf: de UI laat de gebruiker de door de
+ * generator geschreven JSON-bestanden kiezen en stuurt de inhoud hierheen.
+ * Daarmee heeft de plugin geen netwerktoegang en geen token nodig.
+ */
+
+import { importVariables } from './variables.js';
+import { importComponentSet } from './components.js';
+
+figma.showUI(__html__, { width: 420, height: 520 });
+
+/** Verzamelt meldingen en stuurt ze naar de UI. */
+function createLog() {
+  const entries = [];
+  const push = (level) => (message) => {
+    entries.push({ level, message });
+    figma.ui.postMessage({ type: 'log', level, message });
+  };
+  return {
+    entries,
+    info: push('info'),
+    warn: push('warn'),
+    error: push('error'),
+  };
+}
+
+async function handleImport(message) {
+  const log = createLog();
+  const started = Date.now();
+
+  try {
+    let summary;
+
+    if (message.kind === 'variables') {
+      const result = await importVariables(message.payload, log);
+      summary = `${result.aliasCount} aliassen gelegd`;
+    } else {
+      const result = await importComponentSet(message.payload, log);
+      summary = `${result.variants} varianten`;
+    }
+
+    const seconds = ((Date.now() - started) / 1000).toFixed(1);
+    const errors = log.entries.filter(
+      (entry) => entry.level === 'error'
+    ).length;
+
+    figma.ui.postMessage({
+      type: 'done',
+      ok: errors === 0,
+      summary: `${summary} in ${seconds}s${errors ? `, ${errors} fouten` : ''}`,
+    });
+  } catch (error) {
+    log.error(error.message);
+    figma.ui.postMessage({ type: 'done', ok: false, summary: error.message });
+  }
+}
+
+figma.ui.onmessage = (message) => {
+  if (message.type === 'import') return handleImport(message);
+  if (message.type === 'close') return figma.closePlugin();
+  return undefined;
+};

--- a/packages/figma-plugin/src/ui.html
+++ b/packages/figma-plugin/src/ui.html
@@ -1,0 +1,155 @@
+<style>
+  :root {
+    color-scheme: light dark;
+    font-family:
+      Inter,
+      -apple-system,
+      system-ui,
+      sans-serif;
+    font-size: 12px;
+  }
+  body {
+    margin: 0;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    height: 100vh;
+    box-sizing: border-box;
+  }
+  h1 {
+    font-size: 13px;
+    margin: 0;
+  }
+  p {
+    margin: 0;
+    opacity: 0.7;
+    line-height: 1.5;
+  }
+  .drop {
+    border: 1px dashed currentColor;
+    border-radius: 6px;
+    padding: 20px 16px;
+    text-align: center;
+    opacity: 0.85;
+    cursor: pointer;
+  }
+  .drop:hover,
+  .drop.over {
+    opacity: 1;
+    background: rgba(128, 128, 128, 0.12);
+  }
+  input[type='file'] {
+    display: none;
+  }
+  #log {
+    flex: 1;
+    overflow-y: auto;
+    border-radius: 6px;
+    background: rgba(128, 128, 128, 0.1);
+    padding: 8px;
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .warn {
+    color: #b26a00;
+  }
+  .error {
+    color: #c5372c;
+  }
+  .status {
+    font-weight: 600;
+  }
+</style>
+
+<h1>DSN Sync</h1>
+<p>
+  Kies <code>variables.json</code> uit <code>design-tokens/dist/figma/</code>, of
+  een componentbestand uit <code>figma-sync/dist/</code>. Het formaat wordt
+  automatisch herkend.
+</p>
+
+<label class="drop" id="drop">
+  Sleep een JSON-bestand hierheen of klik om te kiezen
+  <input type="file" id="file" accept="application/json,.json" multiple />
+</label>
+
+<div id="log">Nog niets geïmporteerd.</div>
+
+<script>
+  const logElement = document.getElementById('log');
+  const drop = document.getElementById('drop');
+  const fileInput = document.getElementById('file');
+  let cleared = false;
+
+  function write(message, level) {
+    if (!cleared) {
+      logElement.textContent = '';
+      cleared = true;
+    }
+    const line = document.createElement('div');
+    if (level && level !== 'info') line.className = level;
+    line.textContent = message;
+    logElement.append(line);
+    logElement.scrollTop = logElement.scrollHeight;
+  }
+
+  async function handleFiles(files) {
+    for (const file of files) {
+      let payload;
+      try {
+        payload = JSON.parse(await file.text());
+      } catch (error) {
+        write(`${file.name}: geen geldige JSON (${error.message})`, 'error');
+        continue;
+      }
+
+      // Het schema bepaalt wat er geïmporteerd wordt, niet de bestandsnaam.
+      const kind =
+        payload.$schema === 'dsn-figma-variables/1'
+          ? 'variables'
+          : payload.$schema === 'dsn-figma-components/1'
+            ? 'components'
+            : null;
+
+      if (!kind) {
+        write(
+          `${file.name}: onbekend $schema "${payload.$schema ?? 'ontbreekt'}"`,
+          'error'
+        );
+        continue;
+      }
+
+      write(`> ${file.name}`);
+      parent.postMessage({ pluginMessage: { type: 'import', kind, payload } }, '*');
+    }
+  }
+
+  drop.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    drop.classList.add('over');
+  });
+  drop.addEventListener('dragleave', () => drop.classList.remove('over'));
+  drop.addEventListener('drop', (event) => {
+    event.preventDefault();
+    drop.classList.remove('over');
+    handleFiles(event.dataTransfer.files);
+  });
+  fileInput.addEventListener('change', () => handleFiles(fileInput.files));
+
+  onmessage = (event) => {
+    const message = event.data.pluginMessage;
+    if (!message) return;
+    if (message.type === 'log') write(`  ${message.message}`, message.level);
+    if (message.type === 'done') {
+      const line = document.createElement('div');
+      line.className = 'status' + (message.ok ? '' : ' error');
+      line.textContent = (message.ok ? '✓ ' : '✗ ') + message.summary;
+      logElement.append(line);
+      logElement.scrollTop = logElement.scrollHeight;
+    }
+  };
+</script>

--- a/packages/figma-plugin/src/variables.js
+++ b/packages/figma-plugin/src/variables.js
@@ -1,0 +1,180 @@
+/**
+ * Schrijft dist/figma/variables.json weg als Figma variable collections.
+ *
+ * Twee passes, om dezelfde reden als in de generator: een alias kan pas gelegd
+ * worden als het doel bestaat, en een component-token mag naar een ander
+ * component-token verwijzen.
+ *
+ * De import is idempotent: bestaande collections, modes en variables worden
+ * hergebruikt en bijgewerkt in plaats van gedupliceerd. Dat is een harde eis,
+ * want anders raken bindingen die designers al gelegd hebben los.
+ */
+
+/** Zoekt een bestaande collection op naam, of maakt hem aan. */
+async function ensureCollection(name) {
+  const existing = await figma.variables.getLocalVariableCollectionsAsync();
+  const found = existing.find((collection) => collection.name === name);
+  return found ?? figma.variables.createVariableCollection(name);
+}
+
+/**
+ * Zorgt dat de collection precies de gevraagde modes heeft.
+ * De eerste mode bestaat altijd al (Figma maakt hem aan met de collection),
+ * dus die wordt hernoemd in plaats van toegevoegd.
+ */
+function ensureModes(collection, modeNames, log) {
+  const modeIds = {};
+
+  modeNames.forEach((modeName, index) => {
+    const existing = collection.modes.find((mode) => mode.name === modeName);
+    if (existing) {
+      modeIds[modeName] = existing.modeId;
+      return;
+    }
+
+    if (index === 0) {
+      collection.renameMode(collection.modes[0].modeId, modeName);
+      modeIds[modeName] = collection.modes[0].modeId;
+      return;
+    }
+
+    try {
+      modeIds[modeName] = collection.addMode(modeName);
+    } catch (error) {
+      // Het mode-maximum hangt af van het Figma-plan.
+      log.error(
+        `Mode "${modeName}" kon niet worden toegevoegd aan ${collection.name}: ${error.message}`
+      );
+    }
+  });
+
+  return modeIds;
+}
+
+/** Zoekt een bestaande variable in de collection, of maakt hem aan. */
+function ensureVariable(name, collection, resolvedType, index, log) {
+  const existing = index.get(name);
+  if (existing) {
+    if (existing.resolvedType === resolvedType) return existing;
+    // Van type wisselen kan niet; de oude variable moet dan weg.
+    log.warn(
+      `${name}: type wijzigt van ${existing.resolvedType} naar ${resolvedType}, variable opnieuw aangemaakt`
+    );
+    existing.remove();
+    index.delete(name);
+  }
+
+  const created = figma.variables.createVariable(
+    name,
+    collection,
+    resolvedType
+  );
+  index.set(name, created);
+  return created;
+}
+
+/**
+ * @param {object} payload de inhoud van variables.json
+ * @param {object} log verzamelaar met .info/.warn/.error
+ */
+export async function importVariables(payload, log) {
+  if (payload.$schema !== 'dsn-figma-variables/1') {
+    throw new Error(
+      `Onbekend formaat: ${payload.$schema ?? 'geen $schema'}. Verwacht dsn-figma-variables/1.`
+    );
+  }
+
+  const state = new Map();
+
+  // ---------------------------------------------------------------------------
+  // Pass 1: collections, modes en alle variables met hun letterlijke waarde.
+  // ---------------------------------------------------------------------------
+  for (const spec of payload.collections) {
+    const collection = await ensureCollection(spec.name);
+    const modeIds = ensureModes(collection, spec.modes, log);
+
+    const allVariables = await figma.variables.getLocalVariablesAsync();
+    const index = new Map(
+      allVariables
+        .filter((v) => v.variableCollectionId === collection.id)
+        .map((v) => [v.name, v])
+    );
+
+    const variables = new Map();
+
+    for (const spec2 of spec.variables) {
+      const variable = ensureVariable(
+        spec2.name,
+        collection,
+        spec2.type,
+        index,
+        log
+      );
+      variables.set(spec2.name, variable);
+
+      if (spec2.description) variable.description = spec2.description;
+
+      // Aliassen komen in pass 2; hier alleen de vaste waarden.
+      if (!spec2.valuesByMode) continue;
+
+      for (const [modeName, value] of Object.entries(spec2.valuesByMode)) {
+        const modeId = modeIds[modeName];
+        if (!modeId) continue;
+        try {
+          variable.setValueForMode(modeId, value);
+        } catch (error) {
+          log.error(`${spec2.name} (${modeName}): ${error.message}`);
+        }
+      }
+    }
+
+    state.set(spec.name, { collection, modeIds, variables });
+    log.info(
+      `${spec.name}: ${spec.variables.length} variables, ${spec.modes.length} modes`
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pass 2: aliassen. Nu bestaan alle doelen.
+  // ---------------------------------------------------------------------------
+  let aliasCount = 0;
+  let aliasFailed = 0;
+
+  for (const spec of payload.collections) {
+    const entry = state.get(spec.name);
+
+    for (const spec2 of spec.variables) {
+      if (!spec2.alias) continue;
+
+      const target = state.get(spec2.alias.collection);
+      const targetVariable = target && target.variables.get(spec2.alias.name);
+      if (!targetVariable) {
+        log.error(
+          `${spec2.name}: aliasdoel ${spec2.alias.collection} / ${spec2.alias.name} niet gevonden`
+        );
+        aliasFailed += 1;
+        continue;
+      }
+
+      const alias = figma.variables.createVariableAlias(targetVariable);
+      const variable = entry.variables.get(spec2.name);
+
+      // Een alias geldt voor elke mode van de eigen collection; het doel lost
+      // zelf per mode op. Zo blijft de delegatieketen in Figma intact.
+      for (const modeId of Object.values(entry.modeIds)) {
+        try {
+          variable.setValueForMode(modeId, alias);
+        } catch (error) {
+          log.error(`${spec2.name}: alias mislukt: ${error.message}`);
+          aliasFailed += 1;
+        }
+      }
+      aliasCount += 1;
+    }
+  }
+
+  log.info(
+    `${aliasCount} aliassen gelegd${aliasFailed ? `, ${aliasFailed} mislukt` : ''}`
+  );
+  return { aliasCount, aliasFailed };
+}

--- a/packages/figma-sync/README.md
+++ b/packages/figma-sync/README.md
@@ -71,11 +71,34 @@ Figma auto layout past:
 | `padding-*`                        | `padding*`                          |
 | `justify-content` / `align-items`  | `primary` / `counterAxisAlignItems` |
 | `display: inline-flex`             | `layoutSizingHorizontal: HUG`       |
+| `display: grid` + `grid-column`    | `layoutMode: GRID` + grid anchors   |
+| `position: absolute`               | `layoutPositioning: ABSOLUTE`       |
+| kind vult de binnenbreedte         | `layoutSizingHorizontal: FILL`      |
 
 Een element dat alleen tekst bevat en zelf niets tekent, wordt één TEXT-node in
 plaats van een frame met een tekstnode erin. Zonder die stap krijgt elke `<span>`
 een eigen frame en ontstaat de diepe nesting die een Figma-library onwerkbaar
 maakt.
+
+### Wat er wordt overgeslagen
+
+Elementen met de klasse `dsn-visually-hidden` en elementen met `opacity: 0`
+(zoals de native input onder een custom checkbox-control) leveren in Figma
+alleen een onzichtbare node op en worden daarom niet meegenomen.
+
+### Drie valkuilen bij het meten
+
+Deze drie leverden allemaal stilzwijgend verkeerde waarden op en zijn de reden
+dat de extractor eruitziet zoals hij eruitziet:
+
+1. **Transitions.** `getComputedStyle` leest tijdens een transition de
+   tussenwaarde, niet de eindwaarde. Een hover-kleur werd zo halverwege
+   gemeten. De pagina zet daarom `transition` en `animation` op `none`.
+2. **De cursor blijft staan.** Na een hover-variant staat de muis er nog, dus
+   elke volgende variant meet óók als hover. De cursor gaat nu voor elke
+   variant terug naar (0, 0).
+3. **Webfonts.** Zonder `document.fonts.ready` meet de eerste variant met een
+   systeemfont en wijken de breedtes af van de rest.
 
 ## Een component toevoegen
 

--- a/packages/figma-sync/README.md
+++ b/packages/figma-sync/README.md
@@ -51,10 +51,23 @@ staan als `viewportPinned` in het report.
 ## Gebruik
 
 ```bash
-pnpm build:tokens                      # variables.json + report
+pnpm build:figma                       # de hele keten in één keer
+```
+
+Of per stap:
+
+```bash
+pnpm build:tokens                      # de gewone token-build
+pnpm build:figma-variables             # variables.json + report
 pnpm build:figma-components            # alle matrices
 pnpm build:figma-components button     # één component
+pnpm build:figma-plugin                # de plugin-bundle
 ```
+
+De Figma-stappen staan bewust los van `build:tokens`. De token-CSS is het
+hoofdproduct waar Storybook, de componenten en npm-consumenten van afhangen;
+die hoort niet om te vallen door een fout in een generator die er alleen maar
+naast draait. Faalt de Figma-keten, dan faalt alleen de Figma-keten.
 
 ## Hoe de componentgeneratie werkt
 

--- a/packages/figma-sync/README.md
+++ b/packages/figma-sync/README.md
@@ -86,6 +86,31 @@ Elementen met de klasse `dsn-visually-hidden` en elementen met `opacity: 0`
 (zoals de native input onder een custom checkbox-control) leveren in Figma
 alleen een onzichtbare node op en worden daarom niet meegenomen.
 
+### Mobile-first meten
+
+De meetviewport is **375px**, en blok-componenten krijgen een wrapper van
+**343px** (375 min 2 x 16px padding). Dat is bewust: het design system wordt
+mobile-first ontworpen, en op 375px lossen alle fluid clamps op hun ondergrens
+op. De gemeten typografie komt daarmee exact overeen met de `default-mobile`
+mode van de `dsn/Density`-collection, dus component en variable zeggen
+hetzelfde. Per matrix te overschrijven met `viewport`.
+
+### CSS Grid
+
+`grid-template-columns: <maat> 1fr` wordt in Figma `FIXED` + `FLEX`, waarbij
+`FLEX` overeenkomt met de `fr`-eenheid. De browser lost `fr` op naar pixels
+voordat wij kunnen meten, dus welke track flexibel was is uit één meting niet
+af te lezen. De extractor rendert een component met een grid daarom een tweede
+keer in een bredere wrapper: een track die meegroeit was flexibel.
+
+Rijen worden `HUG`. CSS-gridrijen zijn standaard `auto`, en een vaste
+rijhoogte zou betekenen dat het component niet meegroeit als tekst afbreekt.
+
+De plaatsing per cel gaat via `setGridChildPosition(rowIndex, columnIndex)`;
+`gridColumnAnchorIndex` is read-only. De trackmaten horen in `gridColumnSizes`
+en `gridRowSizes`, niet in `gridAutoTracks` (dat gaat over automatisch rijen
+toevoegen).
+
 ### Drie valkuilen bij het meten
 
 Deze drie leverden allemaal stilzwijgend verkeerde waarden op en zijn de reden
@@ -99,6 +124,11 @@ dat de extractor eruitziet zoals hij eruitziet:
    variant terug naar (0, 0).
 3. **Webfonts.** Zonder `document.fonts.ready` meet de eerste variant met een
    systeemfont en wijken de breedtes af van de rest.
+
+Plus een vierde die geen meetfout is maar wel dezelfde vorm heeft: `body.css`
+hangt aan de klasse `.dsn-body`, niet aan het element. Zonder die klasse op de
+meetpagina erft alles zonder eigen font-family-token het browserstandaard­
+lettertype, en meet je Times.
 
 ## Een component toevoegen
 

--- a/packages/figma-sync/README.md
+++ b/packages/figma-sync/README.md
@@ -20,6 +20,34 @@ Naast `variables.json` komt `variables-report.json` te staan met alles wat
 níet naar een variable te vertalen was, inclusief reden. Lees dat bestand bij
 elke review: het is de plek waar drift zichtbaar wordt.
 
+## Fluid typografie
+
+Een Figma-variable is statisch, dus een `clamp()` moet op een viewport worden
+vastgeprikt. In plaats van één willekeurige breedte te kiezen krijgt de
+`dsn/Density`-collection een mode per viewport:
+
+| mode                | viewport | `text/font-size/md` |
+| ------------------- | -------- | ------------------- |
+| `default-mobile`    | 375px    | 16px                |
+| `default-desktop`   | 1440px   | 19,4px              |
+| `information-dense` | n.v.t.   | 16px                |
+
+375px valt onder elke clamp-ondergrens, dus die mode bevat exact de ontworpen
+min-waarden. De bovengrens is bewust géén mode: die wordt pas bereikt vanaf
+ongeveer 1733px en komt op geen realistisch artboard voor.
+
+Een project-type dat niet fluid is krijgt automatisch één mode in plaats van
+een mode per viewport, zoals `information-dense` hierboven.
+
+35 component-variables aliassen naar deze collection, dus het schakelen van het
+artboard laat de hele typografie meebewegen zonder dat er iets opnieuw gebonden
+hoeft te worden.
+
+Twaalf fluid waarden staan buiten deze collection (de icon-sizes en vier
+`padding-*-with-icon`-tokens). Die hangen van theme én viewport af en zitten in
+een collection met een andere mode-as, dus ze zijn op 1440px vastgeprikt. Ze
+staan als `viewportPinned` in het report.
+
 ## Gebruik
 
 ```bash

--- a/packages/figma-sync/README.md
+++ b/packages/figma-sync/README.md
@@ -1,0 +1,94 @@
+# @dsn-starter-kit/figma-sync
+
+Genereert Figma-input uit de bestaande bron: de tokens en de HTML/CSS-laag.
+Dit package schrijft **geen** data naar Figma. Het levert twee JSON-bestanden
+die een Figma-plugin inleest.
+
+Waarom die splitsing: op een Figma Professional-plan is de Variables REST API
+niet beschikbaar, dus de Plugin API is het enige schrijfpad. Door de generatie
+in de repo te houden en het schrijven in de plugin, blijft alles wat naar Figma
+gaat reviewbaar in een PR.
+
+## De twee outputs
+
+| Bestand                                   | Wordt gegenereerd door        | Bevat                                    |
+| ----------------------------------------- | ----------------------------- | ---------------------------------------- |
+| `design-tokens/dist/figma/variables.json` | `pnpm build:tokens`           | Variable collections, modes en aliassen  |
+| `figma-sync/dist/{component}.json`        | `pnpm build:figma-components` | Node specs per variant van een component |
+
+Naast `variables.json` komt `variables-report.json` te staan met alles wat
+níet naar een variable te vertalen was, inclusief reden. Lees dat bestand bij
+elke review: het is de plek waar drift zichtbaar wordt.
+
+## Gebruik
+
+```bash
+pnpm build:tokens                      # variables.json + report
+pnpm build:figma-components            # alle matrices
+pnpm build:figma-components button     # één component
+```
+
+## Hoe de componentgeneratie werkt
+
+De CSS parsen om Figma-nodes te bouwen werkt niet: cascade, custom properties,
+`clamp()` en media queries bepalen samen pas de eindwaarde. In plaats daarvan
+rendert `extract.js` elke variant in een echte browser en leest de _computed_
+styles uit. Dat levert meteen de flexbox-informatie op die vrijwel 1-op-1 op
+Figma auto layout past:
+
+| CSS                                | Figma                               |
+| ---------------------------------- | ----------------------------------- |
+| `display: flex` + `flex-direction` | `layoutMode` HORIZONTAL / VERTICAL  |
+| `gap`                              | `itemSpacing`                       |
+| `padding-*`                        | `padding*`                          |
+| `justify-content` / `align-items`  | `primary` / `counterAxisAlignItems` |
+| `display: inline-flex`             | `layoutSizingHorizontal: HUG`       |
+
+Een element dat alleen tekst bevat en zelf niets tekent, wordt één TEXT-node in
+plaats van een frame met een tekstnode erin. Zonder die stap krijgt elke `<span>`
+een eigen frame en ontstaat de diepe nesting die een Figma-library onwerkbaar
+maakt.
+
+## Een component toevoegen
+
+Zet een matrix in `src/matrices/{component}.js`. De assen daarin worden de
+variant properties van de Figma component set. Definieer ze expliciet: stories
+zijn losse voorbeelden, een component set heeft een volledige matrix nodig.
+
+```js
+export default {
+  component: 'Badge',
+  fonts: [
+    'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;700',
+  ],
+  css: [
+    '@dsn-starter-kit/design-tokens/dist/css/start-light-default.css',
+    '@dsn-starter-kit/components-html/src/badge/badge.css',
+  ],
+  axes: { variant: ['info', 'warning'], size: ['small', 'default'] },
+  pseudoStates: { hover: 'hover' },
+  render: ({ variant, size }) =>
+    `<span class="dsn-badge dsn-badge--${variant} dsn-badge--size-${size}" data-figma-root>Label</span>`,
+};
+```
+
+De `fonts`-lijst is niet optioneel als het component tekst bevat: zonder
+geladen webfont meet de browser met een systeemfont en kloppen de breedtes niet.
+De fontnaam moet ook in Figma beschikbaar zijn.
+
+## Wat hier bewust niet in hoort
+
+- **Layoutcomponenten** (`Grid`, `Container`, `PageBody`, `BreakoutSection`).
+  Dat is layoutgedrag zonder eigen visuele identiteit. Een designer gebruikt
+  daar Figma auto layout voor, een gegenereerd "Stack-component" is een
+  anti-patroon.
+- **Patronen en templates.** Die componeer je in Figma uit de gegenereerde
+  componenten.
+- **Box shadows.** Die horen Figma effect styles te worden, geen variables.
+  Ze staan daarom in het skip-report.
+
+## Wat de generator niet levert
+
+Component properties (boolean voor icon-slots, instance swap, text properties)
+en thumbnails. Die blijven handwerk in Figma. Reken op genereren tot ongeveer
+85% en een polijstslag daarna.

--- a/packages/figma-sync/package.json
+++ b/packages/figma-sync/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@dsn-starter-kit/figma-sync",
+  "version": "2.0.0",
+  "private": true,
+  "description": "Genereert Figma node specs uit de HTML/CSS-laag van het design system",
+  "type": "module",
+  "scripts": {
+    "build": "node src/build-components.js",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@dsn-starter-kit/components-html": "workspace:*",
+    "@dsn-starter-kit/design-tokens": "workspace:*"
+  },
+  "devDependencies": {
+    "playwright": "^1.58.2"
+  },
+  "author": "Jeffrey Lauwers",
+  "license": "MIT"
+}

--- a/packages/figma-sync/src/build-components.js
+++ b/packages/figma-sync/src/build-components.js
@@ -1,0 +1,73 @@
+/**
+ * Runner: rendert de matrices en schrijft de Figma node specs weg.
+ *
+ *   node src/build-components.js            # alle matrices
+ *   node src/build-components.js button     # één matrix
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { extractMatrix } from './extract.js';
+import { toComponentSet } from './to-figma.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const outputDir = path.join(__dirname, '..', 'dist');
+
+async function loadMatrices(requested) {
+  const dir = path.join(__dirname, 'matrices');
+  const files = fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith('.js'))
+    .filter(
+      (file) => !requested.length || requested.includes(path.parse(file).name)
+    );
+
+  return Promise.all(
+    files.map(async (file) => ({
+      key: path.parse(file).name,
+      matrix: (await import(path.join(dir, file))).default,
+    }))
+  );
+}
+
+async function main() {
+  const requested = process.argv.slice(2);
+  const matrices = await loadMatrices(requested);
+
+  if (!matrices.length) {
+    console.error(`❌ Geen matrix gevonden voor: ${requested.join(', ')}`);
+    process.exit(1);
+  }
+
+  fs.mkdirSync(outputDir, { recursive: true });
+  console.log('🧩 Building Figma component specs...\n');
+
+  for (const { key, matrix } of matrices) {
+    const started = Date.now();
+    const extracted = await extractMatrix(matrix);
+    const spec = toComponentSet(matrix, extracted);
+
+    const destination = path.join(outputDir, `${key}.json`);
+    fs.writeFileSync(destination, `${JSON.stringify(spec, null, 2)}\n`);
+
+    const seconds = ((Date.now() - started) / 1000).toFixed(1);
+    console.log(
+      `   ${matrix.component.padEnd(12)} ${String(extracted.length).padStart(3)} varianten  ${seconds}s  -> dist/${key}.json`
+    );
+
+    if (spec.warnings.length) {
+      console.log(`\n   ⚠️  ${spec.warnings.length} aandachtspunten:`);
+      for (const warning of spec.warnings) console.log(`      ${warning}`);
+      console.log();
+    }
+  }
+
+  console.log('\n✅ Klaar\n');
+}
+
+main().catch((error) => {
+  console.error('❌ Component build failed:', error);
+  process.exit(1);
+});

--- a/packages/figma-sync/src/extract.js
+++ b/packages/figma-sync/src/extract.js
@@ -150,8 +150,24 @@ function domWalker([properties, hiddenClass]) {
  * @param {object} matrix Een matrixdefinitie uit src/matrices/
  * @returns {Promise<Array<{variant: object, tree: object}>>}
  */
+/**
+ * Documentstijlen die altijd meegeladen worden.
+ *
+ * body.css zet de basis-font-family. Zonder dit erft elk element dat zelf geen
+ * font-family declareert (een <div>, een <p> zonder eigen token) het
+ * browser-standaardlettertype, en meet de generator Times in plaats van het
+ * lettertype van het design system.
+ */
+const BASE_CSS = ['@dsn-starter-kit/components-html/src/body/body.css'];
+
+/**
+ * body.css hangt aan de klasse `.dsn-body`, niet aan het element. Een consument
+ * zet die klasse zelf op zijn body, dus de meetpagina doet dat ook.
+ */
+const BODY_CLASS = 'dsn-body';
+
 export async function extractMatrix(matrix) {
-  const stylesheets = matrix.css
+  const stylesheets = [...BASE_CSS, ...matrix.css]
     .map(resolveCssPath)
     .map((file) => fs.readFileSync(file, 'utf8'))
     .join('\n');
@@ -186,7 +202,7 @@ export async function extractMatrix(matrix) {
            }
            body { margin: 0; padding: 40px; background: #fff; }
          </style>${fontLinks}<style>${stylesheets}</style></head>
-         <body><div style="${matrix.wrapperStyle ?? ''}">${matrix.render(combination)}</div></body></html>`,
+         <body class="${BODY_CLASS}"><div style="${matrix.wrapperStyle ?? ''}">${matrix.render(combination)}</div></body></html>`,
         { waitUntil: 'load' }
       );
 

--- a/packages/figma-sync/src/extract.js
+++ b/packages/figma-sync/src/extract.js
@@ -166,6 +166,21 @@ const BASE_CSS = ['@dsn-starter-kit/components-html/src/body/body.css'];
  */
 const BODY_CLASS = 'dsn-body';
 
+/**
+ * Meetviewport. Mobile-first: een small-viewport ontwerp is 375px breed, en
+ * daar lossen de fluid clamps op hun ondergrens op. De gemeten typografie komt
+ * daarmee overeen met de `default-mobile` mode van de Density-collection.
+ */
+const DEFAULT_VIEWPORT = { width: 375, height: 900 };
+
+/**
+ * Extra breedte voor de tweede meting waarmee flexibele grid-tracks worden
+ * herkend. De browser lost `1fr` op naar pixels voordat wij kunnen meten, dus
+ * de enige manier om `fr` van een vaste maat te onderscheiden is kijken welke
+ * track meegroeit als de container breder wordt.
+ */
+const GRID_PROBE_DELTA = 240;
+
 export async function extractMatrix(matrix) {
   const stylesheets = [...BASE_CSS, ...matrix.css]
     .map(resolveCssPath)
@@ -176,64 +191,91 @@ export async function extractMatrix(matrix) {
     .map((href) => `<link rel="stylesheet" href="${href}">`)
     .join('');
 
+  const viewport = matrix.viewport ?? DEFAULT_VIEWPORT;
+
   const browser = await chromium.launch();
-  const page = await browser.newPage({
-    viewport: { width: 1440, height: 900 },
-  });
+  const page = await browser.newPage({ viewport });
 
   const combinations = cartesian(matrix.axes);
   const results = [];
 
+  const documentFor = (combination, wrapperStyle) =>
+    `<!doctype html><html><head><meta charset="utf-8"><style>
+       /* Neutrale ondergrond zodat de component zelf de enige bron van
+          layout is en er geen body-marges meelekken. */
+       *, *::before, *::after { box-sizing: border-box; }
+
+       /* Transitions en animaties uitzetten. getComputedStyle leest tijdens
+          een transition de tussenwaarde, niet de eindwaarde, en dan meten we
+          halverwege een hover-kleur of een icoon dat nog aan het infaden is. */
+       *, *::before, *::after {
+         transition: none !important;
+         animation: none !important;
+       }
+
+       /* Bij de brede tweede meting steekt de wrapper buiten de viewport;
+          zonder dit verschuift een scrollbalk de layout. */
+       body { margin: 0; padding: 40px; background: #fff; overflow: hidden; }
+     </style>${fontLinks}<style>${stylesheets}</style></head>
+     <body class="${BODY_CLASS}"><div style="${wrapperStyle}">${matrix.render(combination)}</div></body></html>`;
+
+  /**
+   * Zet één variant in de pagina en meet hem.
+   * `extraWidth` verbreedt alleen de wrapper, niet de viewport, zodat de
+   * fluid typografie op de meetviewport vastgeprikt blijft.
+   */
+  const render = async (combination, extraWidth) => {
+    const wrapperStyle = extraWidth
+      ? `${matrix.wrapperStyle ?? ''};width:${viewport.width + extraWidth}px`
+      : (matrix.wrapperStyle ?? '');
+
+    await page.setContent(documentFor(combination, wrapperStyle), {
+      waitUntil: 'load',
+    });
+
+    // Toestanden die niet in markup uit te drukken zijn (zoals de
+    // indeterminate-property van een checkbox) worden hier gezet.
+    if (matrix.domSetup) {
+      await page.evaluate(`(() => { ${matrix.domSetup} })()`);
+    }
+
+    // Zonder document.fonts.ready meet de eerste variant nog met een
+    // fallback-font en wijken de breedtes af van de rest.
+    await page.evaluate(() => document.fonts.ready);
+
+    // De cursor blijft tussen varianten staan waar hij stond. Zonder hem eerst
+    // weg te zetten meet elke variant na een hover-variant óók als hover,
+    // want het element staat op dezelfde plek.
+    await page.mouse.move(0, 0);
+
+    // De pseudo-toestand kan op elke as staan, niet per se op een as die
+    // toevallig 'state' heet.
+    const pseudo = Object.values(combination)
+      .map((value) => matrix.pseudoStates?.[value])
+      .find(Boolean);
+    if (pseudo === 'hover') await page.hover('[data-figma-root]');
+
+    return page.evaluate(domWalker, [
+      CAPTURED_PROPERTIES,
+      VISUALLY_HIDDEN_CLASS,
+    ]);
+  };
+
+  const hasGrid = (node) =>
+    Boolean(node.styles?.display?.endsWith('grid')) ||
+    (node.children ?? []).some(hasGrid);
+
   try {
     for (const combination of combinations) {
-      await page.setContent(
-        `<!doctype html><html><head><meta charset="utf-8"><style>
-           /* Neutrale ondergrond zodat de component zelf de enige bron van
-              layout is en er geen body-marges meelekken. */
-           *, *::before, *::after { box-sizing: border-box; }
+      const tree = await render(combination);
 
-           /* Transitions en animaties uitzetten. getComputedStyle leest
-              tijdens een transition de tussenwaarde, niet de eindwaarde, en
-              dan meten we halverwege een hover-kleur of een icoon dat nog
-              aan het infaden is. */
-           *, *::before, *::after {
-             transition: none !important;
-             animation: none !important;
-           }
-           body { margin: 0; padding: 40px; background: #fff; }
-         </style>${fontLinks}<style>${stylesheets}</style></head>
-         <body class="${BODY_CLASS}"><div style="${matrix.wrapperStyle ?? ''}">${matrix.render(combination)}</div></body></html>`,
-        { waitUntil: 'load' }
-      );
+      // De tweede meting kost een extra render, dus alleen doen als er
+      // daadwerkelijk een grid in zit waarvan de tracks te duiden zijn.
+      const wideTree = hasGrid(tree)
+        ? await render(combination, GRID_PROBE_DELTA)
+        : undefined;
 
-      // Toestanden die niet in markup uit te drukken zijn (zoals de
-      // indeterminate-property van een checkbox) worden hier gezet.
-      if (matrix.domSetup)
-        await page.evaluate(`(() => { ${matrix.domSetup} })()`);
-
-      // Zonder document.fonts.ready meet de eerste variant nog met een
-      // fallback-font en wijken de breedtes af van de rest.
-      await page.evaluate(() => document.fonts.ready);
-
-      // De cursor blijft tussen varianten staan waar hij stond. Zonder hem
-      // eerst weg te zetten meet elke variant na een hover-variant óók als
-      // hover, want het element staat op dezelfde plek.
-      await page.mouse.move(0, 0);
-
-      // De pseudo-toestand kan op elke as staan, niet per se op een as die
-      // toevallig 'state' heet.
-      const pseudo = Object.values(combination)
-        .map((value) => matrix.pseudoStates?.[value])
-        .find(Boolean);
-      if (pseudo === 'hover') {
-        await page.hover('[data-figma-root]');
-      }
-
-      const tree = await page.evaluate(domWalker, [
-        CAPTURED_PROPERTIES,
-        VISUALLY_HIDDEN_CLASS,
-      ]);
-      results.push({ variant: combination, tree });
+      results.push({ variant: combination, tree, wideTree });
     }
   } finally {
     await browser.close();

--- a/packages/figma-sync/src/extract.js
+++ b/packages/figma-sync/src/extract.js
@@ -1,0 +1,190 @@
+/**
+ * Leest de *computed* layout van een component uit een echte browser.
+ *
+ * De CSS parsen zou onbetrouwbaar zijn: cascade, custom properties, clamp() en
+ * media queries bepalen samen pas de eindwaarde. Door de component te renderen
+ * en getComputedStyle te lezen krijgen we exact wat de gebruiker ziet, en
+ * bovendien flexbox-informatie die vrijwel 1-op-1 op Figma auto layout past.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { chromium } from 'playwright';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const monorepoRoot = path.resolve(__dirname, '..', '..', '..');
+
+/** `@dsn-starter-kit/x/y/z.css` -> absoluut pad binnen de monorepo. */
+function resolveCssPath(specifier) {
+  const match = specifier.match(/^@dsn-starter-kit\/([^/]+)\/(.+)$/);
+  if (!match) return path.resolve(monorepoRoot, specifier);
+  return path.join(monorepoRoot, 'packages', match[1], match[2]);
+}
+
+/**
+ * Eigenschappen die we uitlezen. Alles wat hier niet in staat bestaat voor de
+ * generator niet, dus deze lijst is de feitelijke scope van de conversie.
+ */
+const CAPTURED_PROPERTIES = [
+  'display',
+  'flexDirection',
+  'flexWrap',
+  'gap',
+  'rowGap',
+  'columnGap',
+  'alignItems',
+  'justifyContent',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'backgroundColor',
+  'borderTopWidth',
+  'borderRightWidth',
+  'borderBottomWidth',
+  'borderLeftWidth',
+  'borderTopColor',
+  'borderStyle',
+  'borderTopLeftRadius',
+  'borderTopRightRadius',
+  'borderBottomLeftRadius',
+  'borderBottomRightRadius',
+  'color',
+  'fontFamily',
+  'fontSize',
+  'fontWeight',
+  'fontStyle',
+  'lineHeight',
+  'letterSpacing',
+  'textAlign',
+  'textDecorationLine',
+  'textTransform',
+  'opacity',
+  'boxShadow',
+  'position',
+  'overflow',
+];
+
+/**
+ * Loopt de DOM af binnen de browser en geeft een boom terug met per element
+ * de computed styles en de positie ten opzichte van de root.
+ */
+/* c8 ignore start - draait in de browsercontext, niet in Node */
+function domWalker(properties) {
+  const root = document.querySelector('[data-figma-root]');
+  if (!root) throw new Error('geen [data-figma-root] gevonden');
+  const origin = root.getBoundingClientRect();
+
+  const readStyles = (element) => {
+    const computed = getComputedStyle(element);
+    const result = {};
+    for (const property of properties) result[property] = computed[property];
+    return result;
+  };
+
+  const visit = (element) => {
+    const rect = element.getBoundingClientRect();
+    const node = {
+      tag: element.tagName.toLowerCase(),
+      classes: Array.from(element.classList),
+      rect: {
+        x: Math.round((rect.x - origin.x) * 100) / 100,
+        y: Math.round((rect.y - origin.y) * 100) / 100,
+        width: Math.round(rect.width * 100) / 100,
+        height: Math.round(rect.height * 100) / 100,
+      },
+      styles: readStyles(element),
+      children: [],
+    };
+
+    // SVG wordt niet uitgelopen: dat wordt in Figma één vector-node.
+    if (node.tag === 'svg') {
+      node.kind = 'vector';
+      node.svg = element.outerHTML;
+      return node;
+    }
+
+    for (const child of element.childNodes) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        const text = child.textContent.trim();
+        if (text) node.children.push({ kind: 'text', text });
+        continue;
+      }
+      if (child.nodeType === Node.ELEMENT_NODE)
+        node.children.push(visit(child));
+    }
+
+    return node;
+  };
+
+  return visit(root);
+}
+/* c8 ignore stop */
+
+/**
+ * Rendert elke cel van de matrix en levert de computed boom per variant.
+ *
+ * @param {object} matrix Een matrixdefinitie uit src/matrices/
+ * @returns {Promise<Array<{variant: object, tree: object}>>}
+ */
+export async function extractMatrix(matrix) {
+  const stylesheets = matrix.css
+    .map(resolveCssPath)
+    .map((file) => fs.readFileSync(file, 'utf8'))
+    .join('\n');
+
+  const fontLinks = (matrix.fonts ?? [])
+    .map((href) => `<link rel="stylesheet" href="${href}">`)
+    .join('');
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage({
+    viewport: { width: 1440, height: 900 },
+  });
+
+  const combinations = cartesian(matrix.axes);
+  const results = [];
+
+  try {
+    for (const combination of combinations) {
+      await page.setContent(
+        `<!doctype html><html><head><meta charset="utf-8"><style>
+           /* Neutrale ondergrond zodat de component zelf de enige bron van
+              layout is en er geen body-marges meelekken. */
+           *, *::before, *::after { box-sizing: border-box; }
+           body { margin: 0; padding: 40px; background: #fff; }
+         </style>${fontLinks}<style>${stylesheets}</style></head>
+         <body>${matrix.render(combination)}</body></html>`,
+        { waitUntil: 'load' }
+      );
+
+      // Zonder document.fonts.ready meet de eerste variant nog met een
+      // fallback-font en wijken de breedtes af van de rest.
+      await page.evaluate(() => document.fonts.ready);
+
+      const pseudo = matrix.pseudoStates?.[combination.state];
+      if (pseudo === 'hover') {
+        await page.hover('[data-figma-root]');
+      }
+
+      const tree = await page.evaluate(domWalker, CAPTURED_PROPERTIES);
+      results.push({ variant: combination, tree });
+    }
+  } finally {
+    await browser.close();
+  }
+
+  return results;
+}
+
+/** Alle combinaties van de assen, in stabiele volgorde. */
+export function cartesian(axes) {
+  return Object.entries(axes).reduce(
+    (accumulator, [name, values]) =>
+      accumulator.flatMap((base) =>
+        values.map((value) => ({ ...base, [name]: value }))
+      ),
+    [{}]
+  );
+}

--- a/packages/figma-sync/src/extract.js
+++ b/packages/figma-sync/src/extract.js
@@ -35,6 +35,17 @@ const CAPTURED_PROPERTIES = [
   'columnGap',
   'alignItems',
   'justifyContent',
+  'alignSelf',
+  'gridTemplateColumns',
+  'gridTemplateRows',
+  'gridColumnStart',
+  'gridColumnEnd',
+  'gridRowStart',
+  'gridRowEnd',
+  'top',
+  'right',
+  'bottom',
+  'left',
   'paddingTop',
   'paddingRight',
   'paddingBottom',
@@ -67,11 +78,18 @@ const CAPTURED_PROPERTIES = [
 ];
 
 /**
+ * Klasse die een element alleen voor screenreaders bedoeld maakt. Zulke
+ * elementen staan buiten beeld geklemd op 1x1px en hebben in Figma geen
+ * tegenhanger; ze zouden alleen maar een onzichtbare 1px-node opleveren.
+ */
+const VISUALLY_HIDDEN_CLASS = 'dsn-visually-hidden';
+
+/**
  * Loopt de DOM af binnen de browser en geeft een boom terug met per element
  * de computed styles en de positie ten opzichte van de root.
  */
 /* c8 ignore start - draait in de browsercontext, niet in Node */
-function domWalker(properties) {
+function domWalker([properties, hiddenClass]) {
   const root = document.querySelector('[data-figma-root]');
   if (!root) throw new Error('geen [data-figma-root] gevonden');
   const origin = root.getBoundingClientRect();
@@ -111,8 +129,12 @@ function domWalker(properties) {
         if (text) node.children.push({ kind: 'text', text });
         continue;
       }
-      if (child.nodeType === Node.ELEMENT_NODE)
-        node.children.push(visit(child));
+      if (child.nodeType !== Node.ELEMENT_NODE) continue;
+      if (child.classList.contains(hiddenClass)) continue;
+      // Volledig doorzichtige elementen (zoals de native input onder een
+      // custom control) leveren in Figma alleen een onzichtbare node op.
+      if (getComputedStyle(child).opacity === '0') continue;
+      node.children.push(visit(child));
     }
 
     return node;
@@ -153,22 +175,48 @@ export async function extractMatrix(matrix) {
            /* Neutrale ondergrond zodat de component zelf de enige bron van
               layout is en er geen body-marges meelekken. */
            *, *::before, *::after { box-sizing: border-box; }
+
+           /* Transitions en animaties uitzetten. getComputedStyle leest
+              tijdens een transition de tussenwaarde, niet de eindwaarde, en
+              dan meten we halverwege een hover-kleur of een icoon dat nog
+              aan het infaden is. */
+           *, *::before, *::after {
+             transition: none !important;
+             animation: none !important;
+           }
            body { margin: 0; padding: 40px; background: #fff; }
          </style>${fontLinks}<style>${stylesheets}</style></head>
-         <body>${matrix.render(combination)}</body></html>`,
+         <body><div style="${matrix.wrapperStyle ?? ''}">${matrix.render(combination)}</div></body></html>`,
         { waitUntil: 'load' }
       );
+
+      // Toestanden die niet in markup uit te drukken zijn (zoals de
+      // indeterminate-property van een checkbox) worden hier gezet.
+      if (matrix.domSetup)
+        await page.evaluate(`(() => { ${matrix.domSetup} })()`);
 
       // Zonder document.fonts.ready meet de eerste variant nog met een
       // fallback-font en wijken de breedtes af van de rest.
       await page.evaluate(() => document.fonts.ready);
 
-      const pseudo = matrix.pseudoStates?.[combination.state];
+      // De cursor blijft tussen varianten staan waar hij stond. Zonder hem
+      // eerst weg te zetten meet elke variant na een hover-variant óók als
+      // hover, want het element staat op dezelfde plek.
+      await page.mouse.move(0, 0);
+
+      // De pseudo-toestand kan op elke as staan, niet per se op een as die
+      // toevallig 'state' heet.
+      const pseudo = Object.values(combination)
+        .map((value) => matrix.pseudoStates?.[value])
+        .find(Boolean);
       if (pseudo === 'hover') {
         await page.hover('[data-figma-root]');
       }
 
-      const tree = await page.evaluate(domWalker, CAPTURED_PROPERTIES);
+      const tree = await page.evaluate(domWalker, [
+        CAPTURED_PROPERTIES,
+        VISUALLY_HIDDEN_CLASS,
+      ]);
       results.push({ variant: combination, tree });
     }
   } finally {

--- a/packages/figma-sync/src/matrices/alert.js
+++ b/packages/figma-sync/src/matrices/alert.js
@@ -9,7 +9,7 @@
  * extractor overgeslagen: die hebben in Figma geen tegenhanger.
  */
 
-import { TEKST } from '../text.js';
+import { HEADING, TEKST } from '../text.js';
 
 const ICONS = {
   info: `<path d="M12 9h.01M11 12h1v4h1"/><circle cx="12" cy="12" r="9"/>`,
@@ -46,10 +46,10 @@ export default {
   },
 
   /**
-   * Alert heeft een vaste breedte nodig: hij is een blok-element dat de
-   * beschikbare ruimte vult, dus zonder container meet hij de viewportbreedte.
+   * Mobile-first: een small-viewport ontwerp is 375px breed met 16px padding
+   * links en rechts, dus een blok-component is in de basis 343px.
    */
-  wrapperStyle: 'width: 560px;',
+  wrapperStyle: 'width: 343px;',
 
   render({ variant, icon }) {
     const classes = [
@@ -69,7 +69,7 @@ export default {
 
     return `<div class="${classes}" role="alert" data-figma-root>
       ${iconMarkup}
-      <h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading"><span class="dsn-visually-hidden">${LABELS[variant]}</span>${TEKST}</h2>
+      <h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading"><span class="dsn-visually-hidden">${LABELS[variant]}</span>${HEADING}</h2>
       <div class="dsn-alert__content">
         <p class="dsn-paragraph">${TEKST}</p>
       </div>

--- a/packages/figma-sync/src/matrices/alert.js
+++ b/packages/figma-sync/src/matrices/alert.js
@@ -1,0 +1,76 @@
+/**
+ * Variant-matrix voor Alert.
+ *
+ * Alert is de test voor CSS Grid: de component gebruikt
+ * `grid-template-columns: <icon> 1fr` met expliciete `grid-column` en
+ * `grid-row` per kind. Dat mapt op Figma's GRID-layoutmodus met anchors.
+ *
+ * De `dsn-visually-hidden` variant-labels in de heading worden door de
+ * extractor overgeslagen: die hebben in Figma geen tegenhanger.
+ */
+
+const ICONS = {
+  info: `<path d="M12 9h.01M11 12h1v4h1"/><circle cx="12" cy="12" r="9"/>`,
+  positive: `<circle cx="12" cy="12" r="9"/><path d="M9 12l2 2 4-4"/>`,
+  negative: `<circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/>`,
+  warning: `<path d="M12 4l9 16H3z"/><path d="M12 10v4M12 17h.01"/>`,
+};
+
+const LABELS = {
+  info: 'Informatie: ',
+  positive: 'Succes: ',
+  negative: 'Foutmelding: ',
+  warning: 'Let op: ',
+};
+
+export default {
+  component: 'Alert',
+
+  fonts: [
+    'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;700&display=swap',
+  ],
+
+  css: [
+    '@dsn-starter-kit/design-tokens/dist/css/start-light-default.css',
+    '@dsn-starter-kit/components-html/src/icon/icon.css',
+    '@dsn-starter-kit/components-html/src/heading/heading.css',
+    '@dsn-starter-kit/components-html/src/paragraph/paragraph.css',
+    '@dsn-starter-kit/components-html/src/alert/alert.css',
+  ],
+
+  axes: {
+    variant: ['info', 'positive', 'negative', 'warning'],
+    icon: ['with-icon', 'no-icon'],
+  },
+
+  /**
+   * Alert heeft een vaste breedte nodig: hij is een blok-element dat de
+   * beschikbare ruimte vult, dus zonder container meet hij de viewportbreedte.
+   */
+  wrapperStyle: 'width: 560px;',
+
+  render({ variant, icon }) {
+    const classes = [
+      'dsn-alert',
+      variant !== 'info' && `dsn-alert--${variant}`,
+      icon === 'no-icon' && 'dsn-alert--no-icon',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const iconMarkup =
+      icon === 'with-icon'
+        ? `<span class="dsn-alert__icon" aria-hidden="true">
+             <svg class="dsn-icon dsn-icon--xl" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">${ICONS[variant]}</svg>
+           </span>`
+        : '';
+
+    return `<div class="${classes}" role="alert" data-figma-root>
+      ${iconMarkup}
+      <h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading"><span class="dsn-visually-hidden">${LABELS[variant]}</span>Heading</h2>
+      <div class="dsn-alert__content">
+        <p class="dsn-paragraph">Body text of andere inhoud.</p>
+      </div>
+    </div>`;
+  },
+};

--- a/packages/figma-sync/src/matrices/alert.js
+++ b/packages/figma-sync/src/matrices/alert.js
@@ -9,6 +9,8 @@
  * extractor overgeslagen: die hebben in Figma geen tegenhanger.
  */
 
+import { TEKST } from '../text.js';
+
 const ICONS = {
   info: `<path d="M12 9h.01M11 12h1v4h1"/><circle cx="12" cy="12" r="9"/>`,
   positive: `<circle cx="12" cy="12" r="9"/><path d="M9 12l2 2 4-4"/>`,
@@ -67,9 +69,9 @@ export default {
 
     return `<div class="${classes}" role="alert" data-figma-root>
       ${iconMarkup}
-      <h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading"><span class="dsn-visually-hidden">${LABELS[variant]}</span>Heading</h2>
+      <h2 class="dsn-heading dsn-heading--heading-3 dsn-alert__heading"><span class="dsn-visually-hidden">${LABELS[variant]}</span>${TEKST}</h2>
       <div class="dsn-alert__content">
-        <p class="dsn-paragraph">Body text of andere inhoud.</p>
+        <p class="dsn-paragraph">${TEKST}</p>
       </div>
     </div>`;
   },

--- a/packages/figma-sync/src/matrices/button.js
+++ b/packages/figma-sync/src/matrices/button.js
@@ -1,0 +1,62 @@
+/**
+ * Variant-matrix voor Button.
+ *
+ * Bewust expliciet en niet afgeleid uit de stories: stories zijn losse
+ * voorbeelden, terwijl een Figma component set een volledige matrix nodig heeft
+ * met assen die een designer herkent. Deze matrix is de bron voor de
+ * variant properties in Figma.
+ */
+
+/** Een klein inline-icoon, zodat er geen iconenregistratie nodig is. */
+const CHEVRON = `<svg class="dsn-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 6l6 6-6 6"/></svg>`;
+
+export default {
+  component: 'Button',
+
+  /**
+   * Webfonts die geladen moeten zijn voordat er gemeten wordt. Zonder dit valt
+   * de browser terug op een systeemfont en kloppen de tekstbreedtes niet.
+   * De naam moet overeenkomen met een font dat ook in Figma beschikbaar is.
+   */
+  fonts: [
+    'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;700&display=swap',
+  ],
+
+  /** CSS die geladen moet zijn voordat de computed styles kloppen. */
+  css: [
+    '@dsn-starter-kit/design-tokens/dist/css/start-light-default.css',
+    '@dsn-starter-kit/components-html/src/icon/icon.css',
+    '@dsn-starter-kit/components-html/src/button/button.css',
+  ],
+
+  /**
+   * De assen van de component set. Elke combinatie wordt één variant.
+   * `state` bevat alleen toestanden die Figma als aparte variant kan tonen.
+   */
+  axes: {
+    variant: ['strong', 'default', 'subtle'],
+    size: ['small', 'default', 'large'],
+    state: ['default', 'hover', 'disabled'],
+  },
+
+  /**
+   * Toestanden die in de browser via een pseudo-klasse ontstaan en dus door
+   * Playwright nagebootst moeten worden in plaats van via een class.
+   */
+  pseudoStates: { hover: 'hover' },
+
+  /** Bouwt de markup voor één cel van de matrix. */
+  render({ variant, size, state }) {
+    const classes = [
+      'dsn-button',
+      `dsn-button--${variant}`,
+      `dsn-button--size-${size}`,
+    ].join(' ');
+    const disabled = state === 'disabled' ? ' disabled' : '';
+
+    return `<button type="button" class="${classes}"${disabled} data-figma-root>
+      <span class="dsn-button__label">Knoptekst</span>
+      ${CHEVRON}
+    </button>`;
+  },
+};

--- a/packages/figma-sync/src/matrices/button.js
+++ b/packages/figma-sync/src/matrices/button.js
@@ -7,6 +7,8 @@
  * variant properties in Figma.
  */
 
+import { TEKST } from '../text.js';
+
 /** Een klein inline-icoon, zodat er geen iconenregistratie nodig is. */
 const CHEVRON = `<svg class="dsn-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 6l6 6-6 6"/></svg>`;
 
@@ -55,7 +57,7 @@ export default {
     const disabled = state === 'disabled' ? ' disabled' : '';
 
     return `<button type="button" class="${classes}"${disabled} data-figma-root>
-      <span class="dsn-button__label">Knoptekst</span>
+      <span class="dsn-button__label">${TEKST}</span>
       ${CHEVRON}
     </button>`;
   },

--- a/packages/figma-sync/src/matrices/card.js
+++ b/packages/figma-sync/src/matrices/card.js
@@ -10,7 +10,7 @@
  * terechtkomen.
  */
 
-import { TEKST } from '../text.js';
+import { HEADING, TEKST } from '../text.js';
 
 export default {
   component: 'Card',
@@ -27,8 +27,8 @@ export default {
     '@dsn-starter-kit/components-html/src/card/card.css',
   ],
 
-  // Card vult zijn container, dus zonder vaste breedte meet hij de viewport.
-  wrapperStyle: 'width: 320px;',
+  // Mobile-first: 375px viewport met 16px padding aan weerszijden.
+  wrapperStyle: 'width: 343px;',
 
   axes: {
     header: ['with-header', 'no-header'],
@@ -53,7 +53,7 @@ export default {
     return `<div class="dsn-card" data-figma-root>
       ${headerMarkup}
       <div class="dsn-card__body">
-        <h3 class="dsn-card-heading">${TEKST}</h3>
+        <h3 class="dsn-card-heading">${HEADING}</h3>
         <p class="dsn-paragraph">${TEKST}</p>
       </div>
       ${footerMarkup}

--- a/packages/figma-sync/src/matrices/card.js
+++ b/packages/figma-sync/src/matrices/card.js
@@ -10,6 +10,8 @@
  * terechtkomen.
  */
 
+import { TEKST } from '../text.js';
+
 export default {
   component: 'Card',
 
@@ -44,15 +46,15 @@ export default {
     const footerMarkup =
       footer === 'with-footer'
         ? `<div class="dsn-card__footer">
-             <span class="dsn-link">Lees meer</span>
+             <span class="dsn-link">${TEKST}</span>
            </div>`
         : '';
 
     return `<div class="dsn-card" data-figma-root>
       ${headerMarkup}
       <div class="dsn-card__body">
-        <h3 class="dsn-card-heading">Kaarttitel</h3>
-        <p class="dsn-paragraph">Een korte omschrijving van de inhoud van deze kaart.</p>
+        <h3 class="dsn-card-heading">${TEKST}</h3>
+        <p class="dsn-paragraph">${TEKST}</p>
       </div>
       ${footerMarkup}
     </div>`;

--- a/packages/figma-sync/src/matrices/card.js
+++ b/packages/figma-sync/src/matrices/card.js
@@ -1,0 +1,60 @@
+/**
+ * Variant-matrix voor Card.
+ *
+ * Card is de test voor nesting: een flex-kolom met header, body en footer,
+ * waarbij de body zelf ook weer een flex-kolom is. Als de generator hier een
+ * bruikbare boom oplevert, houdt de aanpak ook voor samengestelde componenten.
+ *
+ * Card gebruikt daarnaast box-shadow en overflow:hidden, dus dit is meteen de
+ * test of die twee correct als waarschuwing respectievelijk clipsContent
+ * terechtkomen.
+ */
+
+export default {
+  component: 'Card',
+
+  fonts: [
+    'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;700&display=swap',
+  ],
+
+  css: [
+    '@dsn-starter-kit/design-tokens/dist/css/start-light-default.css',
+    '@dsn-starter-kit/components-html/src/heading/heading.css',
+    '@dsn-starter-kit/components-html/src/paragraph/paragraph.css',
+    '@dsn-starter-kit/components-html/src/link/link.css',
+    '@dsn-starter-kit/components-html/src/card/card.css',
+  ],
+
+  // Card vult zijn container, dus zonder vaste breedte meet hij de viewport.
+  wrapperStyle: 'width: 320px;',
+
+  axes: {
+    header: ['with-header', 'no-header'],
+    footer: ['with-footer', 'no-footer'],
+  },
+
+  render({ header, footer }) {
+    const headerMarkup =
+      header === 'with-header'
+        ? `<div class="dsn-card__header">
+             <div class="dsn-card__image-placeholder"></div>
+           </div>`
+        : '';
+
+    const footerMarkup =
+      footer === 'with-footer'
+        ? `<div class="dsn-card__footer">
+             <span class="dsn-link">Lees meer</span>
+           </div>`
+        : '';
+
+    return `<div class="dsn-card" data-figma-root>
+      ${headerMarkup}
+      <div class="dsn-card__body">
+        <h3 class="dsn-card-heading">Kaarttitel</h3>
+        <p class="dsn-paragraph">Een korte omschrijving van de inhoud van deze kaart.</p>
+      </div>
+      ${footerMarkup}
+    </div>`;
+  },
+};

--- a/packages/figma-sync/src/matrices/checkbox.js
+++ b/packages/figma-sync/src/matrices/checkbox.js
@@ -1,0 +1,62 @@
+/**
+ * Variant-matrix voor Checkbox.
+ *
+ * Checkbox is de test voor niet-stromende layout: de native input en de
+ * custom control liggen allebei absoluut over elkaar heen. De input is
+ * bovendien volledig doorzichtig en wordt door de extractor overgeslagen.
+ *
+ * Let op: de CSS van dit component staat in components-react en niet in
+ * components-html, anders dan het twee-lagen-patroon voorschrijft. De css-lijst
+ * hieronder wijst daarom naar een ander package dan bij de overige matrices.
+ */
+
+const ICONS = {
+  check: `<path d="M5 12l5 5L20 7"/>`,
+  minus: `<path d="M5 12h14"/>`,
+};
+
+export default {
+  component: 'Checkbox',
+
+  fonts: [
+    'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;700&display=swap',
+  ],
+
+  css: [
+    '@dsn-starter-kit/design-tokens/dist/css/start-light-default.css',
+    '@dsn-starter-kit/components-html/src/icon/icon.css',
+    '@dsn-starter-kit/components-react/src/Checkbox/Checkbox.css',
+  ],
+
+  axes: {
+    state: ['unchecked', 'checked', 'indeterminate'],
+    interaction: ['default', 'hover', 'disabled'],
+  },
+
+  pseudoStates: { hover: 'hover' },
+
+  /**
+   * `:indeterminate` is geen attribuut maar een DOM-property, dus die is niet
+   * in markup te zetten. Dit draait in de pagina voordat er gemeten wordt.
+   */
+  domSetup: `
+    for (const input of document.querySelectorAll('input[data-indeterminate]')) {
+      input.indeterminate = true;
+    }
+  `,
+
+  render({ state, interaction }) {
+    const checked = state === 'checked' ? ' checked' : '';
+    const disabled = interaction === 'disabled' ? ' disabled' : '';
+    const icon = state === 'indeterminate' ? ICONS.minus : ICONS.check;
+    const indeterminate =
+      state === 'indeterminate' ? ' data-indeterminate' : '';
+
+    return `<div class="dsn-checkbox" data-figma-root>
+      <input type="checkbox" class="dsn-checkbox__input"${checked}${disabled}${indeterminate}>
+      <span class="dsn-checkbox__control" aria-hidden="true">
+        <svg class="dsn-icon dsn-checkbox__icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">${icon}</svg>
+      </span>
+    </div>`;
+  },
+};

--- a/packages/figma-sync/src/matrices/radio.js
+++ b/packages/figma-sync/src/matrices/radio.js
@@ -1,0 +1,46 @@
+/**
+ * Variant-matrix voor Radio.
+ *
+ * Zelfde opbouw als Checkbox: een doorzichtige native input met daarover een
+ * absoluut gepositioneerde control. Het verschil is dat de gevulde staat hier
+ * een geneste `<span>` is (`__inner-circle`) in plaats van een icoon, dus dit
+ * toetst of een element dat alleen via border-radius rond is correct
+ * doorkomt.
+ *
+ * Radio kent geen indeterminate-toestand.
+ *
+ * Let op: de CSS staat in components-react in plaats van components-html.
+ * Zie het issue over de ontbrekende HTML/CSS-laag voor formuliercontrols.
+ */
+
+export default {
+  component: 'Radio',
+
+  fonts: [
+    'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;700&display=swap',
+  ],
+
+  css: [
+    '@dsn-starter-kit/design-tokens/dist/css/start-light-default.css',
+    '@dsn-starter-kit/components-react/src/Radio/Radio.css',
+  ],
+
+  axes: {
+    state: ['unchecked', 'checked'],
+    interaction: ['default', 'hover', 'disabled'],
+  },
+
+  pseudoStates: { hover: 'hover' },
+
+  render({ state, interaction }) {
+    const checked = state === 'checked' ? ' checked' : '';
+    const disabled = interaction === 'disabled' ? ' disabled' : '';
+
+    return `<div class="dsn-radio" data-figma-root>
+      <input type="radio" name="demo" class="dsn-radio__input"${checked}${disabled}>
+      <span class="dsn-radio__control" aria-hidden="true">
+        <span class="dsn-radio__inner-circle"></span>
+      </span>
+    </div>`;
+  },
+};

--- a/packages/figma-sync/src/text.js
+++ b/packages/figma-sync/src/text.js
@@ -9,3 +9,6 @@
 
 export const TEKST = 'Tekst';
 export const WEINIG_TEKST = 'A';
+
+/** Voor koppen (h1 t/m h6). Storybook gebruikt hier ook 'Heading'. */
+export const HEADING = 'Heading';

--- a/packages/figma-sync/src/text.js
+++ b/packages/figma-sync/src/text.js
@@ -1,0 +1,11 @@
+/**
+ * Canonieke voorbeeldteksten.
+ *
+ * Dezelfde waarden als `packages/storybook/src/story-helpers.tsx`, dat het
+ * origineel is. Ze staan hier apart omdat dat bestand TSX is en tot het
+ * storybook-package hoort; deze generator draait als kaal Node-script.
+ * Wijzigt story-helpers, pas dit dan mee aan.
+ */
+
+export const TEKST = 'Tekst';
+export const WEINIG_TEKST = 'A';

--- a/packages/figma-sync/src/to-figma.js
+++ b/packages/figma-sync/src/to-figma.js
@@ -198,12 +198,32 @@ function rgbOf({ r, g, b }) {
   return { r, g, b };
 }
 
-function cornerRadiusFrom(styles) {
+/**
+ * Hoekafronding, met percentages omgerekend naar pixels.
+ *
+ * `border-radius: 50%` komt als "50%" uit getComputedStyle. Zou je dat als 50
+ * doorgeven, dan klopt de waarde alleen zolang Figma hem toevallig klemt op de
+ * helft van de kortste zijde; bij een breder element wordt het een afgeronde
+ * rechthoek in plaats van een pil.
+ */
+function cornerRadiusFrom(styles, rect) {
+  // Figma kent één radius per hoek, CSS twee (horizontaal en verticaal).
+  // Voor een percentage nemen we de kortste zijde, wat voor de ronde controls
+  // in dit systeem (vierkant) exact klopt.
+  const shortestSide = Math.min(rect.width, rect.height);
+  const toPixels = (value) => {
+    const percentage = String(value)
+      .trim()
+      .match(/^([\d.]+)%$/);
+    if (!percentage) return px(value);
+    return (Number(percentage[1]) / 100) * shortestSide;
+  };
+
   const corners = [
-    px(styles.borderTopLeftRadius),
-    px(styles.borderTopRightRadius),
-    px(styles.borderBottomRightRadius),
-    px(styles.borderBottomLeftRadius),
+    toPixels(styles.borderTopLeftRadius),
+    toPixels(styles.borderTopRightRadius),
+    toPixels(styles.borderBottomRightRadius),
+    toPixels(styles.borderBottomLeftRadius),
   ];
   const uniform = corners.every((corner) => corner === corners[0]);
   return uniform
@@ -381,7 +401,7 @@ function convertNode(node, warnings, pathLabel) {
     x: node.rect.x,
     y: node.rect.y,
     ...autoLayout,
-    ...cornerRadiusFrom(styles),
+    ...cornerRadiusFrom(styles, node.rect),
     fills: paintFrom(styles.backgroundColor),
     ...(strokes ?? {}),
     opacity: Number(styles.opacity) === 1 ? undefined : Number(styles.opacity),

--- a/packages/figma-sync/src/to-figma.js
+++ b/packages/figma-sync/src/to-figma.js
@@ -287,8 +287,11 @@ function applyChildPlacement(
 
   // Een kind dat precies de binnenbreedte van zijn ouder vult is een
   // blok-element. In Figma hoort dat FILL te zijn: met een vaste breedte
-  // schaalt het niet mee als de ouder groeit.
+  // schaalt het niet mee als de ouder groeit. FILL kan alleen binnen een
+  // auto-layout ouder; anders weigert de API het.
   if (
+    parentLayout.layoutMode &&
+    parentLayout.layoutMode !== 'NONE' &&
     parentContentWidth !== undefined &&
     Math.abs(child.rect.width - parentContentWidth) < 1
   ) {
@@ -428,10 +431,13 @@ function convertNode(node, warnings, pathLabel) {
     }),
   };
 
-  // Een inline-flex element hugt zijn inhoud; block-elementen vullen de breedte.
+  // HUG kan Figma alleen op een node met een eigen layoutMode; zonder
+  // auto layout is er niets om naar te huggen en weigert de API het.
+  const hasAutoLayout =
+    autoLayout.layoutMode && autoLayout.layoutMode !== 'NONE';
   figmaNode.layoutSizingHorizontal =
-    styles.display === 'inline-flex' ? 'HUG' : 'FIXED';
-  figmaNode.layoutSizingVertical = 'HUG';
+    hasAutoLayout && styles.display === 'inline-flex' ? 'HUG' : 'FIXED';
+  figmaNode.layoutSizingVertical = hasAutoLayout ? 'HUG' : 'FIXED';
 
   return figmaNode;
 }

--- a/packages/figma-sync/src/to-figma.js
+++ b/packages/figma-sync/src/to-figma.js
@@ -323,11 +323,29 @@ function applyChildPlacement(
 
   const columnEnd = Number.parseInt(styles.gridColumnEnd, 10);
   const rowEnd = Number.parseInt(styles.gridRowEnd, 10);
-  if (Number.isFinite(columnEnd) && columnEnd - columnStart > 1) {
-    converted.gridColumnSpan = columnEnd - columnStart;
-  }
+  const columnSpan =
+    Number.isFinite(columnEnd) && columnEnd - columnStart > 1
+      ? columnEnd - columnStart
+      : 1;
+  if (columnSpan > 1) converted.gridColumnSpan = columnSpan;
   if (Number.isFinite(rowEnd) && rowEnd - rowStart > 1) {
     converted.gridRowSpan = rowEnd - rowStart;
+  }
+
+  // Een kind in een grid vult zijn *cel*, niet de hele ouder. De vergelijking
+  // met de ouderbreedte hierboven slaat daar dus altijd op mis; hier wordt hij
+  // alsnog tegen de juiste tracks gedaan.
+  const tracks = parentLayout.gridAutoTracks?.columns ?? [];
+  const cellWidth = tracks
+    .slice(columnStart - 1, columnStart - 1 + columnSpan)
+    .reduce(
+      (total, track, index) =>
+        total + track.value + (index > 0 ? parentLayout.gridColumnGap : 0),
+      0
+    );
+
+  if (cellWidth > 0 && Math.abs(child.rect.width - cellWidth) < 1) {
+    converted.layoutSizingHorizontal = 'FILL';
   }
 }
 

--- a/packages/figma-sync/src/to-figma.js
+++ b/packages/figma-sync/src/to-figma.js
@@ -63,15 +63,67 @@ const COUNTER_AXIS_ALIGN = {
 // NODE-CONVERSIE
 // =============================================================================
 
+/**
+ * Telt de tracks in een computed grid-template.
+ * De browser lost `1fr` op naar pixels, dus de tracks komen er als
+ * pixelwaarden uit: `"32px 500px"`.
+ */
+function trackSizes(template) {
+  if (!template || template === 'none') return [];
+  return template
+    .split(/\s+/)
+    .map((track) => Number.parseFloat(track))
+    .filter((track) => Number.isFinite(track));
+}
+
+/**
+ * CSS Grid naar Figma's GRID auto layout.
+ *
+ * Figma kent sinds 2025 een grid-layoutmodus met expliciete plaatsing per kind
+ * (gridColumnAnchorIndex / gridRowAnchorIndex). Dat past op een grid met
+ * expliciete `grid-column` / `grid-row`, zoals Alert.
+ */
+function gridLayoutFrom(styles, warnings, pathLabel) {
+  const columns = trackSizes(styles.gridTemplateColumns);
+  const rows = trackSizes(styles.gridTemplateRows);
+
+  // De browser lost fr-tracks op naar pixels, dus hier is niet meer te zien
+  // welke track flexibel was. De designer moet dat in Figma nazetten.
+  if (columns.length > 1) {
+    warnings.push(
+      `${pathLabel}: grid-tracks komen als vaste pixelmaten binnen; controleer in Figma welke track flexibel moet zijn`
+    );
+  }
+
+  return {
+    layoutMode: 'GRID',
+    gridColumnCount: Math.max(columns.length, 1),
+    gridRowCount: Math.max(rows.length, 1),
+    gridColumnGap: px(styles.columnGap ?? styles.gap),
+    gridRowGap: px(styles.rowGap ?? styles.gap),
+    gridAutoTracks: {
+      columns: columns.map((value) => ({ type: 'FIXED', value })),
+      rows: rows.map((value) => ({ type: 'FIXED', value })),
+    },
+    // De kinderen dragen hun eigen cel, dus Figma moet niet zelf plaatsen.
+    gridItemsPositioning: 'MANUAL',
+    paddingTop: px(styles.paddingTop),
+    paddingRight: px(styles.paddingRight),
+    paddingBottom: px(styles.paddingBottom),
+    paddingLeft: px(styles.paddingLeft),
+    stretchChildren: false,
+    reversed: false,
+  };
+}
+
 /** Bouwt de auto layout-eigenschappen uit de flexbox computed styles. */
 function autoLayoutFrom(styles, warnings, pathLabel) {
+  if (styles.display === 'grid' || styles.display === 'inline-grid') {
+    return gridLayoutFrom(styles, warnings, pathLabel);
+  }
+
   const isFlex = styles.display === 'flex' || styles.display === 'inline-flex';
   if (!isFlex) {
-    if (styles.display === 'grid' || styles.display === 'inline-grid') {
-      warnings.push(
-        `${pathLabel}: display:grid heeft geen auto layout-equivalent, wordt een vaste frame-layout`
-      );
-    }
     return { layoutMode: 'NONE' };
   }
 
@@ -196,6 +248,67 @@ function paintFrom(cssColor) {
 }
 
 /**
+ * Zet de plaatsing van een kind binnen zijn ouder.
+ *
+ * Twee gevallen die niet in de gewone auto layout-stroom passen:
+ * een absoluut gepositioneerd kind (Figma: layoutPositioning ABSOLUTE) en een
+ * kind met een expliciete cel in een grid (Figma: grid anchors).
+ */
+function applyChildPlacement(
+  converted,
+  child,
+  parentLayout,
+  warnings,
+  label,
+  parentContentWidth
+) {
+  const styles = child.styles;
+  if (!styles) return;
+
+  // Een kind dat precies de binnenbreedte van zijn ouder vult is een
+  // blok-element. In Figma hoort dat FILL te zijn: met een vaste breedte
+  // schaalt het niet mee als de ouder groeit.
+  if (
+    parentContentWidth !== undefined &&
+    Math.abs(child.rect.width - parentContentWidth) < 1
+  ) {
+    converted.layoutSizingHorizontal = 'FILL';
+  }
+
+  if (styles.position === 'absolute' || styles.position === 'fixed') {
+    // Een absoluut kind valt buiten de stroom; Figma houdt het op zijn plek
+    // ten opzichte van de ouder in plaats van het mee te laten stromen.
+    converted.layoutPositioning = 'ABSOLUTE';
+    return;
+  }
+
+  if (parentLayout.layoutMode !== 'GRID') return;
+
+  const columnStart = Number.parseInt(styles.gridColumnStart, 10);
+  const rowStart = Number.parseInt(styles.gridRowStart, 10);
+
+  if (!Number.isFinite(columnStart) || !Number.isFinite(rowStart)) {
+    warnings.push(
+      `${label}: geen expliciete grid-cel, Figma plaatst dit kind zelf in leesvolgorde`
+    );
+    return;
+  }
+
+  // CSS-gridlijnen tellen vanaf 1, Figma's anchors vanaf 0.
+  converted.gridColumnAnchorIndex = columnStart - 1;
+  converted.gridRowAnchorIndex = rowStart - 1;
+
+  const columnEnd = Number.parseInt(styles.gridColumnEnd, 10);
+  const rowEnd = Number.parseInt(styles.gridRowEnd, 10);
+  if (Number.isFinite(columnEnd) && columnEnd - columnStart > 1) {
+    converted.gridColumnSpan = columnEnd - columnStart;
+  }
+  if (Number.isFinite(rowEnd) && rowEnd - rowStart > 1) {
+    converted.gridRowSpan = rowEnd - rowStart;
+  }
+}
+
+/**
  * Zet één DOM-node om naar een Figma-node.
  *
  * @param {object} node computed DOM-node
@@ -250,6 +363,14 @@ function convertNode(node, warnings, pathLabel) {
   }
 
   const { stretchChildren, reversed, ...autoLayout } = layout;
+
+  // Binnenbreedte van dit element: de rect min padding en randen.
+  const contentWidth =
+    node.rect.width -
+    px(styles.paddingLeft) -
+    px(styles.paddingRight) -
+    px(styles.borderLeftWidth) -
+    px(styles.borderRightWidth);
   const children = reversed ? [...node.children].reverse() : node.children;
 
   const figmaNode = {
@@ -275,6 +396,14 @@ function convertNode(node, warnings, pathLabel) {
         });
       }
       if (stretchChildren) converted.layoutAlign = 'STRETCH';
+      applyChildPlacement(
+        converted,
+        child,
+        autoLayout,
+        warnings,
+        childLabel,
+        contentWidth
+      );
       return converted;
     }),
   };

--- a/packages/figma-sync/src/to-figma.js
+++ b/packages/figma-sync/src/to-figma.js
@@ -77,21 +77,49 @@ function trackSizes(template) {
 }
 
 /**
+ * Bepaalt per track of hij vast of flexibel is.
+ *
+ * De browser lost `1fr` op naar pixels voordat wij kunnen meten, dus uit één
+ * meting is `fr` niet van een vaste maat te onderscheiden. Door hetzelfde
+ * component ook in een bredere container te meten wordt het wel zichtbaar:
+ * een track die meegroeit was flexibel, een track die gelijk blijft was vast.
+ */
+function trackSizesFrom(template, wideTemplate, fallbackType = 'FIXED') {
+  const sizes = trackSizes(template);
+  const wide = trackSizes(wideTemplate ?? '');
+
+  return sizes.map((value, index) => {
+    const grew = wide.length === sizes.length && wide[index] - value > 0.5;
+    // Figma's FLEX-waarde komt overeen met de fr-eenheid in CSS.
+    if (grew) return { type: 'FLEX', value: 1 };
+    return fallbackType === 'HUG' ? { type: 'HUG' } : { type: 'FIXED', value };
+  });
+}
+
+/**
  * CSS Grid naar Figma's GRID auto layout.
  *
- * Figma kent sinds 2025 een grid-layoutmodus met expliciete plaatsing per kind
- * (gridColumnAnchorIndex / gridRowAnchorIndex). Dat past op een grid met
- * expliciete `grid-column` / `grid-row`, zoals Alert.
+ * Figma kent sinds 2025 een grid-layoutmodus met expliciete plaatsing per kind.
+ * Dat past op een grid met expliciete `grid-column` / `grid-row`, zoals Alert.
  */
-function gridLayoutFrom(styles, warnings, pathLabel) {
-  const columns = trackSizes(styles.gridTemplateColumns);
-  const rows = trackSizes(styles.gridTemplateRows);
+function gridLayoutFrom(styles, wideStyles, warnings, pathLabel) {
+  const columns = trackSizesFrom(
+    styles.gridTemplateColumns,
+    wideStyles?.gridTemplateColumns
+  );
+  // Rijen in CSS Grid zijn standaard `auto`, dus inhoudsgestuurd. Uit de
+  // computed waarde is dat niet te zien (die is altijd een pixelmaat), maar
+  // een vaste rijhoogte zou betekenen dat het component niet meegroeit als
+  // tekst afbreekt. HUG is daarom de juiste standaard.
+  const rows = trackSizesFrom(
+    styles.gridTemplateRows,
+    wideStyles?.gridTemplateRows,
+    'HUG'
+  );
 
-  // De browser lost fr-tracks op naar pixels, dus hier is niet meer te zien
-  // welke track flexibel was. De designer moet dat in Figma nazetten.
-  if (columns.length > 1) {
+  if (columns.length > 1 && !wideStyles) {
     warnings.push(
-      `${pathLabel}: grid-tracks komen als vaste pixelmaten binnen; controleer in Figma welke track flexibel moet zijn`
+      `${pathLabel}: geen tweede meting beschikbaar, alle grid-tracks zijn vast; controleer in Figma welke flexibel moet zijn`
     );
   }
 
@@ -101,10 +129,10 @@ function gridLayoutFrom(styles, warnings, pathLabel) {
     gridRowCount: Math.max(rows.length, 1),
     gridColumnGap: px(styles.columnGap ?? styles.gap),
     gridRowGap: px(styles.rowGap ?? styles.gap),
-    gridAutoTracks: {
-      columns: columns.map((value) => ({ type: 'FIXED', value })),
-      rows: rows.map((value) => ({ type: 'FIXED', value })),
-    },
+    // Let op de namen: gridAutoTracks is iets anders (automatisch rijen
+    // toevoegen). De maten van de tracks zelf horen hier.
+    gridColumnSizes: columns,
+    gridRowSizes: rows,
     // De kinderen dragen hun eigen cel, dus Figma moet niet zelf plaatsen.
     gridItemsPositioning: 'MANUAL',
     paddingTop: px(styles.paddingTop),
@@ -117,9 +145,9 @@ function gridLayoutFrom(styles, warnings, pathLabel) {
 }
 
 /** Bouwt de auto layout-eigenschappen uit de flexbox computed styles. */
-function autoLayoutFrom(styles, warnings, pathLabel) {
+function autoLayoutFrom(styles, wideStyles, warnings, pathLabel) {
   if (styles.display === 'grid' || styles.display === 'inline-grid') {
-    return gridLayoutFrom(styles, warnings, pathLabel);
+    return gridLayoutFrom(styles, wideStyles, warnings, pathLabel);
   }
 
   const isFlex = styles.display === 'flex' || styles.display === 'inline-flex';
@@ -335,14 +363,23 @@ function applyChildPlacement(
   // Een kind in een grid vult zijn *cel*, niet de hele ouder. De vergelijking
   // met de ouderbreedte hierboven slaat daar dus altijd op mis; hier wordt hij
   // alsnog tegen de juiste tracks gedaan.
-  const tracks = parentLayout.gridAutoTracks?.columns ?? [];
-  const cellWidth = tracks
-    .slice(columnStart - 1, columnStart - 1 + columnSpan)
-    .reduce(
-      (total, track, index) =>
-        total + track.value + (index > 0 ? parentLayout.gridColumnGap : 0),
-      0
-    );
+  const tracks = (parentLayout.gridColumnSizes ?? []).slice(
+    columnStart - 1,
+    columnStart - 1 + columnSpan
+  );
+
+  // Een flexibele track heeft geen pixelmaat om tegen af te zetten: wie daarin
+  // staat groeit per definitie mee.
+  if (tracks.some((track) => track.type === 'FLEX')) {
+    converted.layoutSizingHorizontal = 'FILL';
+    return;
+  }
+
+  const cellWidth = tracks.reduce(
+    (total, track, index) =>
+      total + track.value + (index > 0 ? parentLayout.gridColumnGap : 0),
+    0
+  );
 
   if (cellWidth > 0 && Math.abs(child.rect.width - cellWidth) < 1) {
     converted.layoutSizingHorizontal = 'FILL';
@@ -356,7 +393,7 @@ function applyChildPlacement(
  * @param {string[]} warnings verzamelt alles wat niet exact vertaald kon worden
  * @param {string} pathLabel leesbaar pad voor in de waarschuwing
  */
-function convertNode(node, warnings, pathLabel) {
+function convertNode(node, wideNode, warnings, pathLabel) {
   if (node.kind === 'text') {
     // Een kale tekstnode erft zijn stijl van de ouder; die wordt daar gezet.
     return { type: 'TEXT', characters: node.text };
@@ -375,7 +412,7 @@ function convertNode(node, warnings, pathLabel) {
   }
 
   const { styles } = node;
-  const layout = autoLayoutFrom(styles, warnings, pathLabel);
+  const layout = autoLayoutFrom(styles, wideNode?.styles, warnings, pathLabel);
   const strokes = strokesFrom(styles, warnings, pathLabel);
 
   // Een element dat alleen tekst bevat en zelf niets tekent, wordt in Figma
@@ -405,6 +442,13 @@ function convertNode(node, warnings, pathLabel) {
 
   const { stretchChildren, reversed, ...autoLayout } = layout;
 
+  // Kinderen aan hun tegenhanger in de brede meting koppelen op index; beide
+  // bomen komen uit dezelfde DOM en hebben dus dezelfde volgorde.
+  const paired = (node.children ?? []).map((child, index) => ({
+    child,
+    wide: wideNode?.children?.[index],
+  }));
+
   // Binnenbreedte van dit element: de rect min padding en randen.
   const contentWidth =
     node.rect.width -
@@ -412,7 +456,7 @@ function convertNode(node, warnings, pathLabel) {
     px(styles.paddingRight) -
     px(styles.borderLeftWidth) -
     px(styles.borderRightWidth);
-  const children = reversed ? [...node.children].reverse() : node.children;
+  const children = reversed ? [...paired].reverse() : paired;
 
   const figmaNode = {
     type: 'FRAME',
@@ -427,9 +471,9 @@ function convertNode(node, warnings, pathLabel) {
     ...(strokes ?? {}),
     opacity: Number(styles.opacity) === 1 ? undefined : Number(styles.opacity),
     clipsContent: styles.overflow === 'hidden',
-    children: children.map((child, index) => {
+    children: children.map(({ child, wide }, index) => {
       const childLabel = `${pathLabel} > ${child.classes?.[0] ?? child.kind ?? child.tag ?? index}`;
-      const converted = convertNode(child, warnings, childLabel);
+      const converted = convertNode(child, wide, warnings, childLabel);
       if (converted.type === 'TEXT') {
         // Tekst erft de typografie van het element waarin hij staat.
         Object.assign(converted, textStyleFrom(styles), {
@@ -469,11 +513,16 @@ function convertNode(node, warnings, pathLabel) {
 export function toComponentSet(matrix, extracted) {
   const warnings = [];
 
-  const components = extracted.map(({ variant, tree }) => {
+  const components = extracted.map(({ variant, tree, wideTree }) => {
     const label = Object.entries(variant)
       .map(([axis, value]) => `${axis}=${value}`)
       .join(', ');
-    const node = convertNode(tree, warnings, `${matrix.component}[${label}]`);
+    const node = convertNode(
+      tree,
+      wideTree,
+      warnings,
+      `${matrix.component}[${label}]`
+    );
     return { name: label, variantProperties: variant, node };
   });
 

--- a/packages/figma-sync/src/to-figma.js
+++ b/packages/figma-sync/src/to-figma.js
@@ -1,0 +1,318 @@
+/**
+ * Zet een computed DOM-boom om naar een Figma node spec.
+ *
+ * De kern van de vertaling is flexbox -> auto layout. Dat is de reden dat deze
+ * route werkt waar CSS-parsing faalt: `display:flex` met gap, padding en
+ * alignment bevat exact de informatie die Figma nodig heeft om een frame te
+ * laten meeschalen in plaats van een dood, absoluut gepositioneerd blok.
+ */
+
+// =============================================================================
+// WAARDE-CONVERSIE
+// =============================================================================
+
+/** `rgb(27, 89, 164)` of `rgba(0, 0, 0, 0)` -> Figma RGBA (kanalen 0..1). */
+export function parseCssColor(input) {
+  const match = String(input).match(
+    /rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)(?:[,\s/]+([\d.%]+))?\s*\)/i
+  );
+  if (!match) return null;
+
+  const [, r, g, b, a] = match;
+  let alpha = 1;
+  if (a !== undefined) {
+    alpha = a.endsWith('%') ? Number(a.slice(0, -1)) / 100 : Number(a);
+  }
+
+  return {
+    r: Number(r) / 255,
+    g: Number(g) / 255,
+    b: Number(b) / 255,
+    a: alpha,
+  };
+}
+
+/** `12px` -> 12. `normal` en lege waarden -> fallback. */
+function px(value, fallback = 0) {
+  const number = Number.parseFloat(value);
+  return Number.isFinite(number) ? Math.round(number * 100) / 100 : fallback;
+}
+
+const PRIMARY_AXIS_ALIGN = {
+  'flex-start': 'MIN',
+  start: 'MIN',
+  center: 'CENTER',
+  'flex-end': 'MAX',
+  end: 'MAX',
+  'space-between': 'SPACE_BETWEEN',
+};
+
+const COUNTER_AXIS_ALIGN = {
+  'flex-start': 'MIN',
+  start: 'MIN',
+  center: 'CENTER',
+  'flex-end': 'MAX',
+  end: 'MAX',
+  baseline: 'BASELINE',
+  // Figma kent geen STRETCH op de counter axis van de parent; dat wordt op het
+  // kind gezet via layoutAlign. Zie stretchChildren verderop.
+  stretch: 'MIN',
+};
+
+// =============================================================================
+// NODE-CONVERSIE
+// =============================================================================
+
+/** Bouwt de auto layout-eigenschappen uit de flexbox computed styles. */
+function autoLayoutFrom(styles, warnings, pathLabel) {
+  const isFlex = styles.display === 'flex' || styles.display === 'inline-flex';
+  if (!isFlex) {
+    if (styles.display === 'grid' || styles.display === 'inline-grid') {
+      warnings.push(
+        `${pathLabel}: display:grid heeft geen auto layout-equivalent, wordt een vaste frame-layout`
+      );
+    }
+    return { layoutMode: 'NONE' };
+  }
+
+  const vertical = styles.flexDirection.startsWith('column');
+  const reversed = styles.flexDirection.endsWith('-reverse');
+  if (reversed) {
+    warnings.push(
+      `${pathLabel}: ${styles.flexDirection} kent Figma niet, kinderen zijn in omgekeerde volgorde gezet`
+    );
+  }
+  if (styles.flexWrap === 'wrap') {
+    warnings.push(`${pathLabel}: flex-wrap:wrap wordt layoutWrap WRAP`);
+  }
+
+  const gap = px(
+    vertical ? (styles.rowGap ?? styles.gap) : (styles.columnGap ?? styles.gap),
+    0
+  );
+
+  return {
+    layoutMode: vertical ? 'VERTICAL' : 'HORIZONTAL',
+    layoutWrap: styles.flexWrap === 'wrap' ? 'WRAP' : 'NO_WRAP',
+    itemSpacing: gap,
+    itemReverseZIndex: false,
+    paddingTop: px(styles.paddingTop),
+    paddingRight: px(styles.paddingRight),
+    paddingBottom: px(styles.paddingBottom),
+    paddingLeft: px(styles.paddingLeft),
+    primaryAxisAlignItems: PRIMARY_AXIS_ALIGN[styles.justifyContent] ?? 'MIN',
+    counterAxisAlignItems: COUNTER_AXIS_ALIGN[styles.alignItems] ?? 'MIN',
+    // Kinderen krijgen layoutAlign STRETCH als de parent ze uitrekt.
+    stretchChildren: styles.alignItems === 'stretch',
+    reversed,
+  };
+}
+
+/** Randen: alleen uniforme randen worden een Figma stroke. */
+function strokesFrom(styles, warnings, pathLabel) {
+  const widths = [
+    px(styles.borderTopWidth),
+    px(styles.borderRightWidth),
+    px(styles.borderBottomWidth),
+    px(styles.borderLeftWidth),
+  ];
+  const maximum = Math.max(...widths);
+  if (maximum === 0 || styles.borderStyle === 'none') return null;
+
+  const uniform = widths.every((width) => width === widths[0]);
+  if (!uniform) {
+    warnings.push(
+      `${pathLabel}: ongelijke randbreedtes (${widths.join('/')}), Figma krijgt de dikste`
+    );
+  }
+  if (styles.borderStyle !== 'solid') {
+    warnings.push(
+      `${pathLabel}: border-style ${styles.borderStyle} wordt in Figma een dashPattern`
+    );
+  }
+
+  const color = parseCssColor(styles.borderTopColor);
+  if (!color) return null;
+
+  return {
+    strokeWeight: maximum,
+    strokes: [{ type: 'SOLID', color: rgbOf(color), opacity: color.a }],
+    dashPattern: styles.borderStyle === 'dashed' ? [4, 4] : [],
+  };
+}
+
+/** Figma scheidt kleur en alpha: opacity zit op de paint, niet in de kleur. */
+function rgbOf({ r, g, b }) {
+  return { r, g, b };
+}
+
+function cornerRadiusFrom(styles) {
+  const corners = [
+    px(styles.borderTopLeftRadius),
+    px(styles.borderTopRightRadius),
+    px(styles.borderBottomRightRadius),
+    px(styles.borderBottomLeftRadius),
+  ];
+  const uniform = corners.every((corner) => corner === corners[0]);
+  return uniform
+    ? { cornerRadius: corners[0] }
+    : {
+        topLeftRadius: corners[0],
+        topRightRadius: corners[1],
+        bottomRightRadius: corners[2],
+        bottomLeftRadius: corners[3],
+      };
+}
+
+/** Tekststijl uit de computed styles van het *ouder*-element. */
+function textStyleFrom(styles) {
+  const lineHeight = styles.lineHeight;
+  return {
+    fontFamily: styles.fontFamily.split(',')[0].replace(/['"]/g, '').trim(),
+    fontSize: px(styles.fontSize, 16),
+    fontWeight: Number.parseInt(styles.fontWeight, 10) || 400,
+    italic: styles.fontStyle === 'italic',
+    lineHeight:
+      lineHeight === 'normal'
+        ? { unit: 'AUTO' }
+        : { unit: 'PIXELS', value: px(lineHeight) },
+    letterSpacing:
+      styles.letterSpacing === 'normal' ? 0 : px(styles.letterSpacing),
+    textAlignHorizontal: (styles.textAlign === 'start'
+      ? 'left'
+      : styles.textAlign
+    ).toUpperCase(),
+    textDecoration:
+      styles.textDecorationLine === 'underline' ? 'UNDERLINE' : 'NONE',
+    textCase: styles.textTransform === 'uppercase' ? 'UPPER' : 'ORIGINAL',
+    fills: paintFrom(styles.color),
+  };
+}
+
+function paintFrom(cssColor) {
+  const color = parseCssColor(cssColor);
+  if (!color || color.a === 0) return [];
+  return [{ type: 'SOLID', color: rgbOf(color), opacity: color.a }];
+}
+
+/**
+ * Zet één DOM-node om naar een Figma-node.
+ *
+ * @param {object} node computed DOM-node
+ * @param {string[]} warnings verzamelt alles wat niet exact vertaald kon worden
+ * @param {string} pathLabel leesbaar pad voor in de waarschuwing
+ */
+function convertNode(node, warnings, pathLabel) {
+  if (node.kind === 'text') {
+    // Een kale tekstnode erft zijn stijl van de ouder; die wordt daar gezet.
+    return { type: 'TEXT', characters: node.text };
+  }
+
+  if (node.kind === 'vector') {
+    return {
+      type: 'VECTOR',
+      name: 'icon',
+      width: node.rect.width,
+      height: node.rect.height,
+      // De plugin importeert dit met figma.createNodeFromSvg().
+      svg: node.svg,
+      fills: paintFrom(node.styles.color),
+    };
+  }
+
+  const { styles } = node;
+  const layout = autoLayoutFrom(styles, warnings, pathLabel);
+  const strokes = strokesFrom(styles, warnings, pathLabel);
+
+  // Een element dat alleen tekst bevat en zelf niets tekent, wordt in Figma
+  // één TEXT-node. Zonder deze stap krijgt elke <span> een eigen frame en
+  // ontstaat precies de diepe nesting die een Figma-library onwerkbaar maakt.
+  const onlyChildIsText =
+    node.children.length === 1 && node.children[0].kind === 'text';
+  const drawsNothing =
+    paintFrom(styles.backgroundColor).length === 0 &&
+    !strokes &&
+    px(styles.borderTopLeftRadius) === 0;
+
+  if (onlyChildIsText && drawsNothing) {
+    return {
+      type: 'TEXT',
+      name: node.classes[0] ?? node.children[0].text.slice(0, 24),
+      characters: node.children[0].text,
+      ...textStyleFrom(styles),
+    };
+  }
+
+  if (styles.boxShadow && styles.boxShadow !== 'none') {
+    warnings.push(
+      `${pathLabel}: box-shadow moet een Figma effect style worden, niet meegenomen`
+    );
+  }
+
+  const { stretchChildren, reversed, ...autoLayout } = layout;
+  const children = reversed ? [...node.children].reverse() : node.children;
+
+  const figmaNode = {
+    type: 'FRAME',
+    name: node.classes[0] ?? node.tag,
+    width: node.rect.width,
+    height: node.rect.height,
+    x: node.rect.x,
+    y: node.rect.y,
+    ...autoLayout,
+    ...cornerRadiusFrom(styles),
+    fills: paintFrom(styles.backgroundColor),
+    ...(strokes ?? {}),
+    opacity: Number(styles.opacity) === 1 ? undefined : Number(styles.opacity),
+    clipsContent: styles.overflow === 'hidden',
+    children: children.map((child, index) => {
+      const childLabel = `${pathLabel} > ${child.classes?.[0] ?? child.kind ?? child.tag ?? index}`;
+      const converted = convertNode(child, warnings, childLabel);
+      if (converted.type === 'TEXT') {
+        // Tekst erft de typografie van het element waarin hij staat.
+        Object.assign(converted, textStyleFrom(styles), {
+          name: converted.characters.slice(0, 24),
+        });
+      }
+      if (stretchChildren) converted.layoutAlign = 'STRETCH';
+      return converted;
+    }),
+  };
+
+  // Een inline-flex element hugt zijn inhoud; block-elementen vullen de breedte.
+  figmaNode.layoutSizingHorizontal =
+    styles.display === 'inline-flex' ? 'HUG' : 'FIXED';
+  figmaNode.layoutSizingVertical = 'HUG';
+
+  return figmaNode;
+}
+
+/**
+ * Bouwt een complete Figma component set uit de geëxtraheerde varianten.
+ *
+ * @param {object} matrix de matrixdefinitie
+ * @param {Array<{variant: object, tree: object}>} extracted
+ */
+export function toComponentSet(matrix, extracted) {
+  const warnings = [];
+
+  const components = extracted.map(({ variant, tree }) => {
+    const label = Object.entries(variant)
+      .map(([axis, value]) => `${axis}=${value}`)
+      .join(', ');
+    const node = convertNode(tree, warnings, `${matrix.component}[${label}]`);
+    return { name: label, variantProperties: variant, node };
+  });
+
+  return {
+    $schema: 'dsn-figma-components/1',
+    generatedAt: new Date().toISOString(),
+    componentSet: {
+      name: matrix.component,
+      variantAxes: matrix.axes,
+      components,
+    },
+    // Ontdubbeld: dezelfde waarschuwing komt per variant terug.
+    warnings: [...new Set(warnings)],
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,12 @@ importers:
         specifier: ^4.0.0
         version: 4.4.0(tslib@2.8.1)
 
+  packages/figma-plugin:
+    devDependencies:
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+
   packages/figma-sync:
     dependencies:
       '@dsn-starter-kit/components-html':
@@ -9206,7 +9212,7 @@ snapshots:
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
-      esbuild: 0.27.2
+      esbuild: 0.25.12
       open: 10.2.0
       recast: 0.23.11
       semver: 7.7.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,19 @@ importers:
         specifier: ^4.0.0
         version: 4.4.0(tslib@2.8.1)
 
+  packages/figma-sync:
+    dependencies:
+      '@dsn-starter-kit/components-html':
+        specifier: workspace:*
+        version: link:../components-html
+      '@dsn-starter-kit/design-tokens':
+        specifier: workspace:*
+        version: link:../design-tokens
+    devDependencies:
+      playwright:
+        specifier: ^1.58.2
+        version: 1.58.2
+
   packages/storybook:
     dependencies:
       '@dsn-starter-kit/components-react':
@@ -1707,6 +1720,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}


### PR DESCRIPTION
Spike om te bepalen of de Figma-library vanuit code gegenereerd kan worden, in plaats van hem met de hand te bouwen.

**Uitkomst: ja.** Vijf componenten met vier verschillende layoutmodellen komen er schoon doorheen.

## Waarom deze opzet

Op ons Professional-plan is de Variables REST API niet beschikbaar (Enterprise-only) en Code Connect ook niet (Organization/Enterprise). De Plugin API kent die beperkingen niet en is dus het enige schrijfpad. Daarom: **genereren in de repo, schrijven in een plugin.** Alles wat naar Figma gaat is daarmee reviewbaar in een PR, en de plugin heeft geen token nodig.

```
tokens + HTML/CSS  ──►  JSON in de repo  ──►  Figma-plugin  ──►  Figma
     (bron)              (reviewbaar)          (geen token)
```

## Drie packages

| Package | Wat het doet |
| --- | --- |
| `design-tokens` (uitgebreid) | Nieuw `figma`-platform: `dist/figma/variables.json` |
| `figma-sync` (nieuw) | Rendert componenten headless, schrijft node specs |
| `figma-plugin` (nieuw) | Leest die JSON en schrijft naar Figma |

## Tokens

**1308 variables** over drie collections, waarvan **783 als alias**. Die aliassen zijn het punt: doordat component-tokens naar de primitives verwijzen werkt de theme-schakelaar in Figma automatisch door, net als de delegatieketen in de token-JSON.

| Collection | Modes |
| --- | --- |
| `dsn/Primitives` | 4 (`start-light`, `start-dark`, `wireframe-light`, `wireframe-dark`) |
| `dsn/Density` | 3 (`default-mobile`, `default-desktop`, `information-dense`) |
| `dsn/Components` | 1 |

### Fluid typografie

Een Figma-variable is statisch, dus `clamp()` moet op een viewport worden vastgeprikt. In plaats van één willekeurige breedte krijgt de typografieschaal een mode per viewport. 375px valt onder elke clamp-ondergrens, dus die mode bevat exact de ontworpen min-waarden. De bovengrens is bewust géén mode: die wordt pas bereikt vanaf ~1733px en komt op geen realistisch artboard voor.

Modes in plaats van aparte `min`/`max`-tokennamen, omdat 37 component-tokens in 26 bestanden naar `dsn.text.font-size.*` verwijzen. Bij een naamsplitsing zouden die allemaal mee moeten splitsen.

## Componenten

De CSS parsen werkt niet: cascade, custom properties, `clamp()` en media queries bepalen samen pas de eindwaarde. In plaats daarvan wordt elke variant headless gerenderd en worden de *computed* styles uitgelezen. Flexbox mapt dan vrijwel 1-op-1 op auto layout.

| Component | Varianten | Stresst |
| --- | --- | --- |
| Button | 27 | flex, drie assen, hover |
| Alert | 8 | CSS Grid met expliciete plaatsing |
| Card | 4 | geneste flex-kolommen |
| Checkbox | 9 | absolute overlays, `:indeterminate` |
| Radio | 6 | idem, met `border-radius: 50%` |

De variant-matrix staat expliciet per component: stories zijn losse voorbeelden, een Figma component set heeft een volledige matrix nodig.

## Gevonden meetfouten

Vijf bugs die stilzwijgend verkeerde waarden gaven, zonder waarschuwing:

1. **De cursor bleef tussen varianten staan.** Elke variant na een hover-variant werd óók als hover gemeten. Hierdoor stond de Button strong-achtergrond op de hover-kleur.
2. **Transitions.** `getComputedStyle` leest tijdens een transition de tussenwaarde. De pagina zet `transition` en `animation` nu op `none`.
3. **`pseudoStates` werd opgezocht op een as die `state` moest heten.** Checkbox noemt die as `interaction`, dus daar werkte hover niet.
4. **`border-radius: 50%`** kwam binnen als `cornerRadius: 50` in plaats van de helft van de kortste zijde.
5. **Webfonts.** Zonder `document.fonts.ready` meet de eerste variant met een systeemfont.

Alle kleuren zijn nu geverifieerd tegen de gebouwde CSS: `button-strong-background-color` → #1b59a4, hover → #04499a. Exact.

## Plugin met smoke test

De plugin heeft een smoke test die de import-logica draait tegen de echte gegenereerde JSON, met een mock van de Plugin API die de drie volgorde-eisen afdwingt die in Figma echt fouten geven (`characters` zonder geladen font, `FILL` zonder auto-layout ouder, `HUG` zonder eigen `layoutMode`).

Die eerste ronde vond drie generator-bugs die anders pas in Figma waren opgevallen, waaronder twee variables die niet in elke mode een waarde hadden. In Figma vallen zulke variables terug op een standaardwaarde; ze worden nu weggelaten en verantwoord in het report.

De variables-import is idempotent: bestaande collections, modes en variables worden hergebruikt. Dupliceren zou de bindingen verbreken die designers al gelegd hebben.

## Wat dit nog niet doet

- Component sets bijwerken zonder bestaande instanties te breken
- Variables aan lagen binden (`boundVariables`), dus de gegenereerde componenten volgen de theme-schakelaar nog niet
- Box shadows als effect styles
- Component properties (icon-slots, instance swap, text) en thumbnails: blijft handwerk
- Alert's `1fr`-track komt als vaste pixelmaat binnen; de browser lost `fr` op voordat we kunnen meten

## Documentatie

- [DR-2026-05](docs/decisions/DR-2026-05-figma-genereren-uit-code-via-plugin.md): waarom het zo gebouwd is, inclusief de overwogen alternatieven
- README's in `figma-sync` en `figma-plugin` voor de operationele kant
- Repository-structuur, scripts en changelog bijgewerkt; twee rijen in de navigatietabel van CLAUDE.md

## Bouwt los van de tokenbuild

`buildFigma()` hing eerst in `build.js` van design-tokens, waardoor een fout in de generator de hele tokenbuild kon meeslepen en daarmee ook Storybook. De Figma-keten heeft nu eigen scripts (`build:figma`), en `build.js` is weer regel voor regel gelijk aan `main`.

Geverifieerd door de generator opzettelijk te laten gooien: `build:tokens` geeft nog steeds exit 0, `build:figma-variables` faalt luid met exit 1.

## Onderweg gevonden

Zie #320: 19 formuliercontrols zijn react-only, terwijl CLAUDE.md "altijd twee lagen, geen uitzonderingen" voorschrijft en Storybook er wel een HTML/CSS-tab voor toont.

## Controles

- `pnpm test`: 1607 tests groen
- `pnpm test:figma-plugin`: smoke test groen
- `pnpm --filter storybook exec tsc --noEmit`: 0 fouten
- `pnpm lint`: 0 errors, 96 warnings (identiek aan `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
