### PR TITLE
feat(IconList): lijst met iconen als markers in plaats van bullets of nummers

### DIFF
--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -822,6 +822,33 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 
 **Tests:** React (8 tests), Web Component (11 tests)
 
+### IconList Component
+
+**Status:** Complete (HTML/CSS, React)
+
+**Location:** `packages/components-{html|react}/src/{icon-list|IconList}/`
+
+**Component Tokens:** `tokens/components/icon-list.json`
+
+**Features:**
+
+- An icon per item replaces the bullet or number; `IconList` + `IconListItem`
+- `as` prop: renders as `<ul>` (default) or `<ol>` when the order carries meaning
+- `iconColor` prop sets `--dsn-icon-list-icon-color` inline, so a whole list can take a semantic color (positive, negative, warning)
+- `role="list"` is always set: `list-style-type: none` makes Safari/VoiceOver drop the list announcement
+- Icons are decorative (`aria-hidden`); the item text carries the full meaning
+- Icon size equals one line height, so it scales with the fluid type scale and stays aligned with the first text line
+
+**Tokens:**
+
+- `font-family`, `font-weight`, `color`, `font-size`, `line-height`
+- `max-inline-size`, `margin-block-end`, `gap`
+- `icon-color`: accent color for the icons, overridable per list
+- `icon-size`: delegates to `{dsn.icon.size.md}` (font-size x line-height)
+- `icon-gap`: space between icon and text
+
+**Tests:** React (20 tests)
+
 ### LinkButton Component
 
 **Status:** Complete (HTML/CSS, React)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,18 @@ All notable changes to this project are documented in this file.
 
 Nog niet gepubliceerde wijzigingen. Schrijf nieuwe changelog-entries hieronder; bij de volgende release wordt deze kop gepromoveerd naar het definitieve versienummer.
 
+### IconList
+
+#### Added
+
+- **IconList: lijst met iconen als marker** (issue [#106](https://github.com/jeffreylauwers/design-system-starter-kit/issues/106)): nieuw lijstcomponent waarbij een icoon de bullet of het cijfer vervangt. `IconList` rendert als `<ul>` of, met `as="ol"`, als geordende lijst; `IconListItem` neemt een verplichte `icon`-prop uit de iconenset.
+  - De icoonkleur staat standaard op de accentkleur (gelijk aan de marker-kleur van UnorderedList) en is per lijst te overschrijven via de `iconColor`-prop of, in HTML/CSS, via `--dsn-icon-list-icon-color` als inline custom property
+  - `role="list"` staat altijd op het lijstelement: `list-style-type: none` laat Safari/VoiceOver de lijstaankondiging weglaten, en de expliciete rol herstelt dat zonder iets te veranderen in andere browsers
+  - Iconen zijn decoratief (`aria-hidden="true"`); de tekst van het item draagt de volledige betekenis
+  - `icon-size` delegeert naar `{dsn.icon.size.md}` in plaats van de calc-formule te herhalen, zodat het icoon precies één regelhoogte groot blijft en meeschaalt met de fluid type scale
+  - `icon-gap` gebruikt `{dsn.space.text.md}` (8px), de bestaande conventie voor ruimte tussen icoon en tekst, in plaats van de in het issue voorgestelde `{dsn.space.inline.sm}` (4px)
+  - `max-inline-size` toegevoegd voor leesbaarheid, consistent met UnorderedList en OrderedList
+
 ### Figma-integratie
 
 #### Added

--- a/packages/components-html/manifest.json
+++ b/packages/components-html/manifest.json
@@ -255,6 +255,16 @@
       "primaryProps": []
     },
     {
+      "name": "IconList",
+      "cssBlock": "dsn-icon-list",
+      "category": "content",
+      "purpose": "List where an icon replaces the bullet or number as the item marker; renders as ul or ol and takes a per-list icon color.",
+      "platforms": ["html-css", "react"],
+      "primaryProps": [
+        { "name": "as", "values": ["ul", "ol"], "default": "ul" }
+      ]
+    },
+    {
       "name": "Alert",
       "cssBlock": "dsn-alert",
       "category": "display-feedback",

--- a/packages/components-html/package.json
+++ b/packages/components-html/package.json
@@ -33,6 +33,7 @@
     "./pre-heading": "./src/pre-heading/pre-heading.css",
     "./hero": "./src/hero/hero.css",
     "./icon": "./src/icon/icon.css",
+    "./icon-list": "./src/icon-list/icon-list.css",
     "./image": "./src/image/image.css",
     "./link": "./src/link/link.css",
     "./link-button": "./src/link-button/link-button.css",

--- a/packages/components-html/src/icon-list/icon-list.css
+++ b/packages/components-html/src/icon-list/icon-list.css
@@ -1,0 +1,86 @@
+/**
+ * Icon List Component
+ * List where every item carries an icon instead of a bullet or number.
+ *
+ * The list renders as <ul> by default and as <ol> when the order matters.
+ * Both use the same class: the icon replaces the marker in either case.
+ *
+ * `role="list"` is required, not optional: `list-style-type: none` makes
+ * Safari/VoiceOver drop the list announcement, and the explicit role
+ * restores it without changing anything in other browsers.
+ *
+ * Icons are decorative (aria-hidden); the item text is the full accessible
+ * name. The icon color comes from --dsn-icon-list-icon-color, which is
+ * inherited by every item and can be overridden per list with an inline
+ * custom property.
+ *
+ * Usage:
+ * <!-- Unordered, an icon per item -->
+ * <ul class="dsn-icon-list" role="list">
+ *   <li class="dsn-icon-list__item">
+ *     <svg class="dsn-icon dsn-icon-list__icon" aria-hidden="true"><!-- calendar-event --></svg>
+ *     Afspraak op maandag 24 maart
+ *   </li>
+ *   <li class="dsn-icon-list__item">
+ *     <svg class="dsn-icon dsn-icon-list__icon" aria-hidden="true"><!-- clock --></svg>
+ *     Duurt 30 minuten
+ *   </li>
+ * </ul>
+ *
+ * <!-- Ordered: the icon replaces the number, the order stays semantic -->
+ * <ol class="dsn-icon-list" role="list">
+ *   <li class="dsn-icon-list__item">
+ *     <svg class="dsn-icon dsn-icon-list__icon" aria-hidden="true"><!-- calendar-event --></svg>
+ *     Maak een afspraak
+ *   </li>
+ * </ol>
+ *
+ * <!-- Custom icon color for the whole list -->
+ * <ul class="dsn-icon-list" role="list" style="--dsn-icon-list-icon-color: var(--dsn-color-positive-color-default)">
+ *   <li class="dsn-icon-list__item">
+ *     <svg class="dsn-icon dsn-icon-list__icon" aria-hidden="true"><!-- check --></svg>
+ *     Aanvraag goedgekeurd
+ *   </li>
+ * </ul>
+ */
+
+.dsn-icon-list {
+  font-family: var(--dsn-icon-list-font-family);
+  font-weight: var(--dsn-icon-list-font-weight);
+  color: var(--dsn-icon-list-color);
+  font-size: var(--dsn-icon-list-font-size);
+  line-height: var(--dsn-icon-list-line-height);
+  max-inline-size: var(--dsn-icon-list-max-inline-size);
+  padding-inline-start: 0;
+  margin-block-start: 0;
+  margin-block-end: var(--dsn-icon-list-margin-block-end);
+  list-style-type: none;
+}
+
+/* Icon and text side by side; the icon stays on the first text line */
+.dsn-icon-list__item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--dsn-icon-list-icon-gap);
+}
+
+/* Spacing between list items */
+.dsn-icon-list > .dsn-icon-list__item {
+  margin-block-end: var(--dsn-icon-list-gap);
+}
+
+.dsn-icon-list > .dsn-icon-list__item:last-child {
+  margin-block-end: 0;
+}
+
+/**
+ * Icon sizing and color.
+ * The icon box is exactly one line height tall, so flex-start aligns it
+ * optically with the first line of text without an extra offset.
+ */
+.dsn-icon-list__item > .dsn-icon-list__icon {
+  flex-shrink: 0;
+  width: var(--dsn-icon-list-icon-size);
+  height: var(--dsn-icon-list-icon-size);
+  color: var(--dsn-icon-list-icon-color);
+}

--- a/packages/components-react/src/IconList/IconList.css
+++ b/packages/components-react/src/IconList/IconList.css
@@ -1,0 +1,6 @@
+/**
+ * IconList Component Styles for React
+ * Re-exports the base IconList styles from components-html
+ */
+
+@import '../../../components-html/src/icon-list/icon-list.css';

--- a/packages/components-react/src/IconList/IconList.test.tsx
+++ b/packages/components-react/src/IconList/IconList.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IconList, IconListItem } from './IconList';
+
+// =============================================================================
+// IconList
+// =============================================================================
+
+describe('IconList', () => {
+  it('renders as a <ul> element by default', () => {
+    const { container } = render(<IconList />);
+    expect(container.firstChild?.nodeName).toBe('UL');
+  });
+
+  it('renders as an <ol> element when as is "ol"', () => {
+    const { container } = render(<IconList as="ol" />);
+    expect(container.firstChild?.nodeName).toBe('OL');
+  });
+
+  it('always has base dsn-icon-list class', () => {
+    const { container } = render(<IconList />);
+    expect(container.firstChild).toHaveClass('dsn-icon-list');
+  });
+
+  it('sets role="list" so Safari/VoiceOver keeps announcing the list', () => {
+    render(<IconList />);
+    expect(screen.getByRole('list')).toBeInTheDocument();
+  });
+
+  it('sets role="list" on the ordered variant as well', () => {
+    render(<IconList as="ol" />);
+    expect(screen.getByRole('list')).toBeInTheDocument();
+  });
+
+  it('does not set an inline icon color by default', () => {
+    const { container } = render(<IconList />);
+    expect(container.firstElementChild?.getAttribute('style')).toBeNull();
+  });
+
+  it('sets --dsn-icon-list-icon-color when iconColor is given', () => {
+    const { container } = render(
+      <IconList iconColor="var(--dsn-color-positive-color-default)" />
+    );
+    expect(container.firstElementChild?.getAttribute('style')).toContain(
+      '--dsn-icon-list-icon-color: var(--dsn-color-positive-color-default)'
+    );
+  });
+
+  it('keeps other inline styles when iconColor is given', () => {
+    const { container } = render(
+      <IconList
+        iconColor="var(--dsn-color-negative-color-default)"
+        style={{ marginBlockEnd: '0px' }}
+      />
+    );
+    const style = container.firstElementChild?.getAttribute('style');
+    expect(style).toContain('margin-block-end: 0px');
+    expect(style).toContain('--dsn-icon-list-icon-color');
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<IconList className="custom" />);
+    expect(container.firstChild).toHaveClass('dsn-icon-list');
+    expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('renders children', () => {
+    render(
+      <IconList>
+        <IconListItem icon="clock">Duurt 30 minuten</IconListItem>
+      </IconList>
+    );
+    expect(screen.getByText('Duurt 30 minuten')).toBeInTheDocument();
+  });
+
+  it('forwards ref to the list element', () => {
+    const ref = { current: null as HTMLUListElement | null };
+    render(<IconList ref={ref} />);
+    expect(ref.current?.tagName).toBe('UL');
+  });
+
+  it('spreads additional HTML attributes', () => {
+    render(<IconList data-testid="my-list" />);
+    expect(screen.getByTestId('my-list')).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// IconListItem
+// =============================================================================
+
+describe('IconListItem', () => {
+  it('renders as a <li> element', () => {
+    const { container } = render(
+      <IconList>
+        <IconListItem icon="check">Tekst</IconListItem>
+      </IconList>
+    );
+    expect(container.querySelector('li')).toBeInTheDocument();
+  });
+
+  it('always has base dsn-icon-list__item class', () => {
+    const { container } = render(
+      <IconList>
+        <IconListItem icon="check">Tekst</IconListItem>
+      </IconList>
+    );
+    expect(container.querySelector('li')).toHaveClass('dsn-icon-list__item');
+  });
+
+  it('renders the icon with the dsn-icon-list__icon class', () => {
+    const { container } = render(
+      <IconList>
+        <IconListItem icon="check">Tekst</IconListItem>
+      </IconList>
+    );
+    const icon = container.querySelector('svg');
+    expect(icon).toHaveClass('dsn-icon');
+    expect(icon).toHaveClass('dsn-icon-list__icon');
+  });
+
+  it('marks the icon as decorative', () => {
+    const { container } = render(
+      <IconList>
+        <IconListItem icon="check">Tekst</IconListItem>
+      </IconList>
+    );
+    expect(container.querySelector('svg')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+  });
+
+  it('exposes only the item text, the icon adds nothing to the content', () => {
+    render(
+      <IconList>
+        <IconListItem icon="check">Aanvraag goedgekeurd</IconListItem>
+      </IconList>
+    );
+    expect(screen.getByRole('listitem')).toHaveTextContent(
+      /^Aanvraag goedgekeurd$/
+    );
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <IconList>
+        <IconListItem icon="check" className="custom-item">
+          Tekst
+        </IconListItem>
+      </IconList>
+    );
+    expect(container.querySelector('li')).toHaveClass('custom-item');
+  });
+
+  it('forwards ref to the li element', () => {
+    const ref = { current: null as HTMLLIElement | null };
+    render(
+      <IconList>
+        <IconListItem icon="check" ref={ref}>
+          Tekst
+        </IconListItem>
+      </IconList>
+    );
+    expect(ref.current?.tagName).toBe('LI');
+  });
+
+  it('spreads additional HTML attributes', () => {
+    render(
+      <IconList>
+        <IconListItem icon="check" data-testid="my-item">
+          Tekst
+        </IconListItem>
+      </IconList>
+    );
+    expect(screen.getByTestId('my-item')).toBeInTheDocument();
+  });
+});

--- a/packages/components-react/src/IconList/IconList.tsx
+++ b/packages/components-react/src/IconList/IconList.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { classNames } from '@dsn-starter-kit/core';
+import { Icon } from '../Icon';
+import type { IconName } from '../Icon';
+import './IconList.css';
+
+// =============================================================================
+// IconList
+// =============================================================================
+
+export interface IconListProps extends React.HTMLAttributes<
+  HTMLUListElement | HTMLOListElement
+> {
+  /**
+   * Semantic list element
+   * @default 'ul'
+   */
+  as?: 'ul' | 'ol';
+
+  /**
+   * CSS color value that overrides `--dsn-icon-list-icon-color` for the whole
+   * list; accepts any `var(--dsn-color-*-color-default)`
+   */
+  iconColor?: string;
+
+  /**
+   * Additional CSS class names
+   */
+  className?: string;
+
+  /**
+   * `IconListItem` elements
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * List where every item carries an icon instead of a bullet or number
+ *
+ * `role="list"` is set explicitly: `list-style-type: none` makes
+ * Safari/VoiceOver drop the list announcement, and the role restores it.
+ *
+ * @example
+ * ```tsx
+ * <IconList>
+ *   <IconListItem icon="calendar-event">Afspraak op maandag 24 maart</IconListItem>
+ *   <IconListItem icon="clock">Duurt 30 minuten</IconListItem>
+ * </IconList>
+ *
+ * // Ordered steps
+ * <IconList as="ol">
+ *   <IconListItem icon="calendar-event">Maak een afspraak</IconListItem>
+ *   <IconListItem icon="clock">Wacht op bevestiging</IconListItem>
+ * </IconList>
+ *
+ * // Positive status color for the whole list
+ * <IconList iconColor="var(--dsn-color-positive-color-default)">
+ *   <IconListItem icon="check">Aanvraag goedgekeurd</IconListItem>
+ * </IconList>
+ * ```
+ */
+export const IconList = React.forwardRef<
+  HTMLUListElement | HTMLOListElement,
+  IconListProps
+>(({ as = 'ul', iconColor, className, children, style, ...props }, ref) => {
+  const Element = as;
+  const classes = classNames('dsn-icon-list', className);
+
+  const styles = iconColor
+    ? ({
+        ...style,
+        '--dsn-icon-list-icon-color': iconColor,
+      } as React.CSSProperties)
+    : style;
+
+  return (
+    <Element
+      ref={ref as React.Ref<HTMLUListElement & HTMLOListElement>}
+      className={classes}
+      role="list"
+      style={styles}
+      {...props}
+    >
+      {children}
+    </Element>
+  );
+});
+
+IconList.displayName = 'IconList';
+
+// =============================================================================
+// IconListItem
+// =============================================================================
+
+export interface IconListItemProps extends React.LiHTMLAttributes<HTMLLIElement> {
+  /**
+   * Icon name from the icon set; the icon is decorative and replaces the marker
+   */
+  icon: IconName;
+
+  /**
+   * Additional CSS class names
+   */
+  className?: string;
+
+  /**
+   * Item text content
+   */
+  children?: React.ReactNode;
+}
+
+export const IconListItem = React.forwardRef<HTMLLIElement, IconListItemProps>(
+  ({ icon, className, children, ...props }, ref) => {
+    const classes = classNames('dsn-icon-list__item', className);
+
+    return (
+      <li ref={ref} className={classes} {...props}>
+        <Icon name={icon} className="dsn-icon-list__icon" />
+        {children}
+      </li>
+    );
+  }
+);
+
+IconListItem.displayName = 'IconListItem';

--- a/packages/components-react/src/IconList/index.ts
+++ b/packages/components-react/src/IconList/index.ts
@@ -1,0 +1,3 @@
+export { IconList, IconListItem } from './IconList';
+
+export type { IconListProps, IconListItemProps } from './IconList';

--- a/packages/components-react/src/index.ts
+++ b/packages/components-react/src/index.ts
@@ -22,6 +22,7 @@ export * from './Paragraph';
 export * from './Link';
 export * from './UnorderedList';
 export * from './OrderedList';
+export * from './IconList';
 
 // Buttons & Icons
 export * from './Button';

--- a/packages/design-tokens/src/tokens/components/icon-list.json
+++ b/packages/design-tokens/src/tokens/components/icon-list.json
@@ -1,0 +1,63 @@
+{
+  "dsn": {
+    "icon-list": {
+      "color": {
+        "$value": "{dsn.color.neutral.color-document}",
+        "$type": "color",
+        "$description": "Icon list text color"
+      },
+      "font-family": {
+        "$value": "{dsn.text.font-family.default}",
+        "$type": "fontFamily",
+        "$description": "Icon list font family"
+      },
+      "font-size": {
+        "$value": "{dsn.text.font-size.md}",
+        "$type": "fontSize",
+        "$description": "Icon list font size"
+      },
+      "font-weight": {
+        "$value": "{dsn.text.font-weight.default}",
+        "$type": "fontWeight",
+        "$description": "Icon list font weight"
+      },
+      "line-height": {
+        "$value": "{dsn.text.line-height.md}",
+        "$type": "lineHeight",
+        "$description": "Icon list line height"
+      },
+      "max-inline-size": {
+        "$value": "{dsn.text.max-inline-size}",
+        "$type": "sizing",
+        "$description": "Icon list max width for readability"
+      },
+      "gap": {
+        "$value": "{dsn.space.row.sm}",
+        "$type": "spacing",
+        "$description": "Space between list items"
+      },
+      "margin-block-end": {
+        "$value": "{dsn.space.row.lg}",
+        "$type": "spacing",
+        "$description": "Icon list bottom margin"
+      },
+      "icon": {
+        "color": {
+          "$value": "{dsn.color.accent-1.color-default}",
+          "$type": "color",
+          "$description": "Default icon color, same as the UnorderedList marker color"
+        },
+        "size": {
+          "$value": "{dsn.icon.size.md}",
+          "$type": "dimension",
+          "$description": "Icon size equal to one line height, scales with the fluid type scale"
+        },
+        "gap": {
+          "$value": "{dsn.space.text.md}",
+          "$type": "spacing",
+          "$description": "Space between icon and text"
+        }
+      }
+    }
+  }
+}

--- a/packages/storybook/src/IconList.docs.md
+++ b/packages/storybook/src/IconList.docs.md
@@ -1,0 +1,80 @@
+# Icon List
+
+Een lijst waarbij elk item een icoon als marker heeft in plaats van een bullet of cijfer.
+
+## Doel
+
+De IconList component toont een opsomming waarbij het icoon per item visuele context toevoegt: welk soort informatie het item bevat, of welke status het heeft. De lijst is standaard semantisch een `<ul>` en kan met `as="ol"` een geordende lijst worden wanneer de volgorde betekenis heeft. De icoonkleur is standaard de accentkleur (gelijk aan de marker-kleur van UnorderedList) en kan per lijst worden overschreven met elke `*-color-default` kleur uit de kleurpaletten.
+
+<!-- VOORBEELD -->
+
+## Use when
+
+- Iconen visuele context toevoegen aan elk item, bijvoorbeeld voordelen, kenmerken of praktische details.
+- Je categorisch onderscheid wilt maken tussen items via verschillende iconen.
+- Je een status per item wilt tonen met een semantische kleur (positief, negatief, waarschuwing).
+- Je geordende stappen toont waarbij een icoon duidelijker is dan een cijfer.
+
+## Don't use when
+
+- De items geen visueel onderscheidend icoon nodig hebben: gebruik dan de [Unordered List](/docs/components-unorderedlist--docs) of [Ordered List](/docs/components-orderedlist--docs).
+- Het nummer van elke stap zelf betekenis heeft en genoemd moet worden: gebruik dan de [Ordered List](/docs/components-orderedlist--docs), die het cijfer zichtbaar houdt.
+- De items volledige statusberichten zijn die aandacht vragen: gebruik dan [Alert](/docs/components-alert--docs) of [Note](/docs/components-note--docs).
+- Je key-value informatie toont: gebruik dan de [Summary List](/docs/components-summarylist--docs).
+
+## Best practices
+
+### Icoonkeuze
+
+- **Kies iconen die het item verduidelijken.** Een icoon dat niets toevoegt, leidt af. Als je geen betekenisvol icoon kunt kiezen, is een gewone lijst beter.
+- **Wees consequent binnen een lijst.** Gebruik óf per item een eigen icoon (categorisch onderscheid), óf voor alle items hetzelfde icoon (statuslijst). Een mix van beide leest onrustig.
+- **Herhaal de icoonbetekenis in de tekst.** Iconen zijn decoratief (`aria-hidden`); alle informatie moet ook uit de tekst blijken.
+
+### Kleurgebruik
+
+- **Gebruik de standaard accentkleur tenzij de kleur betekenis draagt.** Zet `iconColor` alleen wanneer de kleur een status communiceert.
+- **Kleur is nooit de enige drager van betekenis.** Combineer een positieve kleur met een check-icoon en tekst die de status benoemt (WCAG 1.4.1).
+- **Eén kleur per lijst.** `iconColor` geldt voor de hele lijst. Wisselende statussen per item horen in aparte lijsten of in een [Summary List](/docs/components-summarylist--docs).
+
+### Inhoud
+
+- **Houd items compact en scanbaar.** Lange beschrijvingen horen in paragraphs, niet in lijstitems.
+- **Gebruik parallelle grammatica.** Start elk item met hetzelfde type woord.
+- **Kies bewust tussen `ul` en `ol`.** Gebruik `as="ol"` alleen wanneer de volgorde echt betekenis heeft; screenreaders kondigen items dan aan als "item 1 van 3".
+
+## Design tokens
+
+| Token                              | Beschrijving                                        |
+| ---------------------------------- | --------------------------------------------------- |
+| `--dsn-icon-list-color`            | Tekstkleur                                          |
+| `--dsn-icon-list-font-family`      | Lettertypefamilie                                   |
+| `--dsn-icon-list-font-size`        | Font size (md)                                      |
+| `--dsn-icon-list-font-weight`      | Font weight                                         |
+| `--dsn-icon-list-line-height`      | Line height                                         |
+| `--dsn-icon-list-max-inline-size`  | Maximale breedte voor leesbaarheid                  |
+| `--dsn-icon-list-gap`              | Ruimte tussen list items                            |
+| `--dsn-icon-list-margin-block-end` | Ondermarge van de lijst                             |
+| `--dsn-icon-list-icon-color`       | Icoonkleur (accentkleur), overschrijfbaar per lijst |
+| `--dsn-icon-list-icon-size`        | Icoongrootte, gelijk aan één regelhoogte            |
+| `--dsn-icon-list-icon-gap`         | Ruimte tussen icoon en tekst                        |
+
+De icoonkleur is de enige token die bedoeld is om per lijst te overschrijven. In React gaat dat via de `iconColor` prop, in HTML/CSS via een inline custom property op het lijstelement:
+
+```html
+<ul
+  class="dsn-icon-list"
+  role="list"
+  style="--dsn-icon-list-icon-color: var(--dsn-color-positive-color-default)"
+>
+  ...
+</ul>
+```
+
+## Accessibility
+
+- De component gebruikt het semantische `<ul>` of `<ol>` element voor correcte structuur.
+- **`role="list"` staat er altijd op.** `list-style-type: none` laat Safari/VoiceOver de lijstaankondiging weglaten; de expliciete rol herstelt dat en verandert niets in andere browsers. De React-component zet de rol automatisch; neem hem in handgeschreven HTML altijd over.
+- Iconen zijn decoratief (`aria-hidden="true"`) en worden niet uitgesproken. De tekst van het item draagt de volledige betekenis.
+- Bij `as="ol"` kondigen screenreaders elk item aan als "item 1 van 3": semantisch correct voor geordende stappen.
+- De lijst is presentationeel en kent geen eigen toetsenbordinteractie. Bevatten items links of buttons, dan brengen die componenten hun eigen toetsenbordgedrag mee.
+- De icoongrootte is gekoppeld aan de regelhoogte, zodat het icoon meeschaalt wanneer de gebruiker de tekstgrootte vergroot.

--- a/packages/storybook/src/IconList.docs.mdx
+++ b/packages/storybook/src/IconList.docs.mdx
@@ -1,0 +1,38 @@
+import { Meta, Story, Controls, Markdown } from '@storybook/addon-docs/blocks';
+import * as IconListStories from './IconList.stories';
+import docs from './IconList.docs.md?raw';
+import { PreviewFrame, CodeTabs } from './components';
+
+export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
+
+<Meta of={IconListStories} />
+
+<Markdown>{intro}</Markdown>
+
+## Voorbeeld
+
+<PreviewFrame>
+  <Story of={IconListStories.Default} />
+</PreviewFrame>
+
+<CodeTabs
+  of={IconListStories.Default}
+  html={`<ul class="dsn-icon-list" role="list">
+  <li class="dsn-icon-list__item">
+    <svg class="dsn-icon dsn-icon-list__icon" aria-hidden="true"><!-- calendar-event --></svg>
+    Afspraak op maandag 24 maart
+  </li>
+  <li class="dsn-icon-list__item">
+    <svg class="dsn-icon dsn-icon-list__icon" aria-hidden="true"><!-- clock --></svg>
+    Duurt 30 minuten
+  </li>
+  <li class="dsn-icon-list__item">
+    <svg class="dsn-icon dsn-icon-list__icon" aria-hidden="true"><!-- info-circle --></svg>
+    Meer informatie over de procedure
+  </li>
+</ul>`}
+/>
+
+<Controls of={IconListStories.Default} />
+
+<Markdown>{rest}</Markdown>

--- a/packages/storybook/src/IconList.stories.tsx
+++ b/packages/storybook/src/IconList.stories.tsx
@@ -1,0 +1,167 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconList, IconListItem } from '@dsn-starter-kit/components-react';
+import DocsPage from './IconList.docs.mdx';
+import {
+  WEINIG_TEKST,
+  VEEL_TEKST,
+  VEEL_TEKST_AR,
+  rtlDecorator,
+} from './story-helpers';
+
+const meta: Meta<typeof IconList> = {
+  title: 'Components/IconList',
+  component: IconList,
+  parameters: {
+    docs: {
+      page: DocsPage,
+    },
+    dsn: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      htmlTemplate: (args: any) => {
+        // Serialiseer IconListItem-children naar HTML/CSS-markup
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const items: any[] = [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const collect = (n: any) => {
+          if (!n) return;
+          if (Array.isArray(n)) return n.forEach(collect);
+          if (n.props?.icon) items.push(n);
+          else if (n.props?.children) collect(n.props.children);
+        };
+        collect(args.children);
+
+        const tag = args.as === 'ol' ? 'ol' : 'ul';
+        const style = args.iconColor
+          ? ` style="--dsn-icon-list-icon-color: ${args.iconColor}"`
+          : '';
+        const itemsHtml = items
+          .map(
+            (item) =>
+              `  <li class="dsn-icon-list__item">\n` +
+              `    <svg class="dsn-icon dsn-icon-list__icon" aria-hidden="true"><!-- ${item.props.icon} --></svg>\n` +
+              `    ${typeof item.props.children === 'string' ? item.props.children : 'Tekst'}\n` +
+              `  </li>`
+          )
+          .join('\n');
+
+        return `<${tag} class="dsn-icon-list" role="list"${style}>\n${itemsHtml}\n</${tag}>`;
+      },
+    },
+  },
+  args: {
+    children: (
+      <>
+        <IconListItem icon="calendar-event">
+          Afspraak op maandag 24 maart
+        </IconListItem>
+        <IconListItem icon="clock">Duurt 30 minuten</IconListItem>
+        <IconListItem icon="info-circle">
+          Meer informatie over de procedure
+        </IconListItem>
+      </>
+    ),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof IconList>;
+
+// =============================================================================
+// DEFAULT
+// =============================================================================
+
+export const Default: Story = {};
+
+// =============================================================================
+// VARIANTEN
+// =============================================================================
+
+export const Ordered: Story = {
+  args: {
+    as: 'ol',
+    children: (
+      <>
+        <IconListItem icon="calendar-event">Maak een afspraak</IconListItem>
+        <IconListItem icon="clock">Wacht op bevestiging</IconListItem>
+        <IconListItem icon="check">
+          Kom langs op het afgesproken moment
+        </IconListItem>
+      </>
+    ),
+  },
+};
+
+// =============================================================================
+// KLEUREN
+// =============================================================================
+
+export const PositiveColor: Story = {
+  args: {
+    iconColor: 'var(--dsn-color-positive-color-default)',
+    children: (
+      <>
+        <IconListItem icon="check">Aanvraag goedgekeurd</IconListItem>
+        <IconListItem icon="check">Documenten ontvangen</IconListItem>
+        <IconListItem icon="check">Betaling verwerkt</IconListItem>
+      </>
+    ),
+  },
+};
+
+export const NegativeColor: Story = {
+  args: {
+    iconColor: 'var(--dsn-color-negative-color-default)',
+    children: (
+      <>
+        <IconListItem icon="x">Aanvraag afgewezen</IconListItem>
+        <IconListItem icon="x">Documenten ontbreken</IconListItem>
+        <IconListItem icon="x">Betaling mislukt</IconListItem>
+      </>
+    ),
+  },
+};
+
+// =============================================================================
+// TEKST VARIANTEN
+// =============================================================================
+
+export const ShortText: Story = {
+  args: {
+    children: (
+      <>
+        <IconListItem icon="calendar-event">{WEINIG_TEKST}</IconListItem>
+        <IconListItem icon="clock">{WEINIG_TEKST}</IconListItem>
+        <IconListItem icon="info-circle">{WEINIG_TEKST}</IconListItem>
+      </>
+    ),
+  },
+};
+
+export const LongText: Story = {
+  args: {
+    children: (
+      <>
+        <IconListItem icon="calendar-event">{VEEL_TEKST}</IconListItem>
+        <IconListItem icon="clock">{VEEL_TEKST}</IconListItem>
+        <IconListItem icon="info-circle">{VEEL_TEKST}</IconListItem>
+      </>
+    ),
+  },
+};
+
+// =============================================================================
+// RTL
+// =============================================================================
+
+export const RTL: Story = {
+  decorators: [rtlDecorator],
+  args: {
+    children: (
+      <>
+        <IconListItem icon="calendar-event">{VEEL_TEKST_AR}</IconListItem>
+        <IconListItem icon="clock">{VEEL_TEKST_AR}</IconListItem>
+        <IconListItem icon="info-circle">{VEEL_TEKST_AR}</IconListItem>
+      </>
+    ),
+  },
+};

--- a/packages/storybook/src/Introduction.mdx
+++ b/packages/storybook/src/Introduction.mdx
@@ -76,7 +76,7 @@ function App() {
 
 - **Hero**: Prominente introductiesectie direct onder de PageHeader: volledige viewportbreedte, vier achtergrondvarianten (default, inverse, image, image-blend) en uitlijningsopties
 
-### Content Components (9)
+### Content Components (10)
 
 - **Button**: Knoppen met varianten (`strong`, `default`, `subtle`), groottes en laadstatus
 - **ButtonLink**: Semantisch een `<a>`, visueel gestyled als een Button: voor navigatieacties met hoge attentiewaarde
@@ -88,6 +88,7 @@ function App() {
 - **Paragraph**: Body text met lead, default en small-print varianten
 - **Link**: Hyperlinks met icon ondersteuning en externe link handling
 - **Lists**: OrderedList en UnorderedList
+- **IconList**: Lijst waarbij een icoon de bullet of het cijfer vervangt (`IconList` en `IconListItem`), als `ul` of `ol`, met per lijst instelbare icoonkleur
 
 ### Display & Feedback Components (13)
 
@@ -192,4 +193,4 @@ MIT License: zie LICENSE bestand voor details.
 
 ---
 
-**Versie:** 5.39.0 | **Laatste update:** 7 juli 2026 | **Auteur:** Jeffrey Lauwers
+**Versie:** 5.39.0 | **Laatste update:** 24 augustus 2026 | **Auteur:** Jeffrey Lauwers


### PR DESCRIPTION
Closes #106

Nieuw lijstcomponent waarbij een icoon de bullet of het cijfer vervangt. `IconList` rendert als `<ul>` of, met `as="ol"`, als geordende lijst; `IconListItem` neemt een verplichte `icon`-prop uit de iconenset. De icoonkleur staat standaard op de accentkleur (gelijk aan de marker-kleur van UnorderedList) en is per lijst te overschrijven.

## Afwijkingen van de token-tabel in het issue

Het issue vroeg expliciet om review van de token-tabel vóór implementatie. Drie punten zijn afgestemd en aangepast:

| Token | Issue-voorstel | Geïmplementeerd | Reden |
|---|---|---|---|
| `icon.size` | `calc(var(--dsn-text-font-size-md) * var(--dsn-text-line-height-md))` | `{dsn.icon.size.md}` | Die token is al exact die calc-formule. Delegeren houdt de delegatieketen intact (CLAUDE.md regel 4); de computed waarde is identiek. |
| `icon.gap` | `{dsn.space.inline.sm}` (4px) | `{dsn.space.text.md}` (8px) | `space.text.*` is de bestaande conventie voor ruimte tussen icoon en tekst (Link, CheckboxOption, RadioOption). 4px is optisch te krap bij een icoon van 28px. |
| `max-inline-size` | niet opgenomen | `{dsn.text.max-inline-size}` | Consistent met UnorderedList en OrderedList; houdt de regellengte leesbaar bij lange items. |

Daarnaast: de token-JSON gebruikt `$value`/`$type`/`$description` (DTCG), zoals de rest van de repo, in plaats van de `value`/`type`/`comment` uit het issue-voorbeeld.

## Opgeloste open vragen uit het issue

- **`list-style: none` en screenreaders**: opgelost met `role="list"` op het lijstelement. Safari/VoiceOver laat de lijstaankondiging anders weg; de expliciete rol herstelt dat en verandert niets in andere browsers. De React-component zet de rol automatisch, de HTML-docs en de CSS-header tonen hem in elk voorbeeld. Vastgelegd in de Accessibility-sectie van de docs.
- **Verticale uitlijning icoon**: geen offset nodig. Het icoon is exact één regelhoogte hoog (gemeten: 28,195px icoon bij een line box van 28,2px), dus `align-items: flex-start` legt de bovenkant precies gelijk met de eerste tekstregel. Geverifieerd in de browser: `iconTop` = 0.
- **Geneste lijsten**: buiten scope, zoals in het issue afgesproken.

## Wat er is gebouwd

**Tokens** `packages/design-tokens/src/tokens/components/icon-list.json`

**HTML/CSS** `packages/components-html/src/icon-list/icon-list.css`, plus entry in de `exports` map en in `manifest.json`

**React** `IconList` (`as`, `iconColor`, `className`, forwardRef naar `HTMLUListElement | HTMLOListElement`) en `IconListItem` (`icon` verplicht, `className`, forwardRef naar `HTMLLIElement`), beide geëxporteerd uit `packages/components-react/src/index.ts`

**Storybook** `IconList.stories.tsx`, `IconList.docs.mdx`, `IconList.docs.md` met de stories Default, Ordered, Positive Color, Negative Color, Short Text, Long Text en RTL

**Documentatie** `docs/03-components.md`, `docs/changelog.md` en `Introduction.mdx` bijgewerkt

## Verificatie

- `pnpm test`: 1627 tests groen (20 nieuwe voor IconList)
- `pnpm --filter storybook exec tsc --noEmit`: 0 fouten
- `pnpm lint`: 0 fouten, 0 nieuwe warnings
- Visueel geverifieerd in Storybook: alle zeven stories, tekstafbreking over meerdere regels, RTL (iconen spiegelen mee via flexbox), en de computed waarden voor icoongrootte, gap, kleur en `role="list"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)