### PR TITLE
fix(BreadcrumbNavigation): huidige pagina is geen link meer

### DIFF
--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -2327,12 +2327,12 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 **Props: BreadcrumbNavigation:** `aria-label`, `variant`, `children`
 
-**Props: BreadcrumbNavigationItem:** `href`, `current`, `children`
+**Props: BreadcrumbNavigationItem:** `href` (optioneel; weglaten bij `current`), `current`, `children`
 
 **Features:**
 
 - `<nav aria-label>` landmark met `<ol>` voor semantisch geordende hiërarchie
-- `aria-current="page"` automatisch op het huidige pagina-item
+- Huidige pagina is bewust géén link (WCAG 3.2.4): platte tekst met `aria-current="page"` op de `<li>`
 - `default` variant: items wrappen naar de volgende rij bij weinig ruimte (`flex-wrap`)
 - `compact` variant: container query collapst naar enkel het ouder-item met terug-pijl (`← Ouder`) bij smalle container (`max-width: 32rem`)
 - Terug-pijl icoon zit binnen de `<a>`: erft linkkleur en hover-stijl automatisch
@@ -2348,7 +2348,7 @@ const [isOpen, setIsOpen] = React.useState(false);
 | `dsn-breadcrumb-navigation--compact`       | `<nav>` | Activeert container query responsive collapse                                     |
 | `dsn-breadcrumb-navigation__list`          | `<ol>`  | `display: flex; flex-wrap: wrap; align-items: center`                             |
 | `dsn-breadcrumb-navigation__item`          | `<li>`  | `display: flex; align-items: center`                                              |
-| `dsn-breadcrumb-navigation__item--current` | `<li>`  | Huidige pagina; muted color, geen hover                                           |
+| `dsn-breadcrumb-navigation__item--current` | `<li>`  | Huidige pagina; muted color, geen link, draagt `aria-current="page"`              |
 | `dsn-breadcrumb-navigation__link`          | `<a>`   | Link met kleur, underline en hover/active/focus stijlen                           |
 | `dsn-breadcrumb-navigation__separator`     | `<svg>` | Decoratief scheidingsteken (chevron-right); verborgen op laatste item             |
 | `dsn-breadcrumb-navigation__back-icon`     | `<svg>` | Terug-pijl icoon binnen `<a>`; standaard `display: none`; getoond in compact+smal |
@@ -2370,13 +2370,9 @@ const [isOpen, setIsOpen] = React.useState(false);
     </li>
     <li
       class="dsn-breadcrumb-navigation__item dsn-breadcrumb-navigation__item--current"
+      aria-current="page"
     >
-      <a
-        href="/product"
-        class="dsn-breadcrumb-navigation__link"
-        aria-current="page"
-        >Product</a
-      >
+      Product
       <svg
         class="dsn-icon dsn-breadcrumb-navigation__separator"
         aria-hidden="true"
@@ -2392,14 +2388,14 @@ const [isOpen, setIsOpen] = React.useState(false);
 // React: standaard
 <BreadcrumbNavigation aria-label="Broodkruimelpad">
   <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
-  <BreadcrumbNavigationItem href="/product" current>Product</BreadcrumbNavigationItem>
+  <BreadcrumbNavigationItem current>Product</BreadcrumbNavigationItem>
 </BreadcrumbNavigation>
 
 // React: compact variant
 <BreadcrumbNavigation aria-label="Broodkruimelpad" variant="compact">
   <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
   <BreadcrumbNavigationItem href="/categorie">Categorie</BreadcrumbNavigationItem>
-  <BreadcrumbNavigationItem href="/product" current>Product</BreadcrumbNavigationItem>
+  <BreadcrumbNavigationItem current>Product</BreadcrumbNavigationItem>
 </BreadcrumbNavigation>
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,16 @@ All notable changes to this project are documented in this file.
 
 Nog niet gepubliceerde wijzigingen. Schrijf nieuwe changelog-entries hieronder; bij de volgende release wordt deze kop gepromoveerd naar het definitieve versienummer.
 
+### BreadcrumbNavigation
+
+#### Changed
+
+- **Huidige pagina is geen link meer** (issue [#298](https://github.com/jeffreylauwers/design-system-starter-kit/issues/298)): het laatste item van de breadcrumb werd als `<a>` gerenderd en vervolgens met CSS ontdaan van underline en pointer-cursor. Dat is een link die eruitziet als tekst en bij activeren niets doet. Het item rendert nu als platte tekst binnen de `<li>`, en `aria-current="page"` staat op de `<li>` in plaats van op de link. Gerelateerd succescriterium: [WCAG 3.2.4 Consistent Identification](https://www.w3.org/WAI/WCAG22/quickref/#consistent-identification).
+  - Breaking voor de HTML/CSS-laag: wie de markup met de hand schrijft, verplaatst `aria-current="page"` naar de `<li>` en haalt de `<a>` rond de huidige paginatitel weg
+  - React-consumers hoeven niets te doen. `href` is optioneel geworden en wordt genegeerd zodra `current` is gezet, dus bestaande `<BreadcrumbNavigationItem href="/x" current>` blijft compileren en rendert vanzelf de nieuwe markup. Het weglaten van `href` is de nieuwe, schone vorm
+  - De CSS werd hier eenvoudiger van: de ontlink-regel voor `.dsn-breadcrumb-navigation__item--current .dsn-breadcrumb-navigation__link` verviel, en daarmee ook de twee `:not(...)`-guards die hover en active van het huidige item moesten uitsluiten
+  - Het huidige item levert geen tabstop meer op, wat toetsenbordgebruikers een navigatie-actie zonder effect bespaart
+
 ### IconList
 
 #### Added

--- a/packages/components-html/src/breadcrumb-navigation/breadcrumb-navigation.css
+++ b/packages/components-html/src/breadcrumb-navigation/breadcrumb-navigation.css
@@ -19,8 +19,12 @@
  *       </a>
  *       <svg class="dsn-icon dsn-breadcrumb-navigation__separator" aria-hidden="true"><!-- chevron-right --></svg>
  *     </li>
- *     <li class="dsn-breadcrumb-navigation__item dsn-breadcrumb-navigation__item--current">
- *       <a href="/appel" class="dsn-breadcrumb-navigation__link" aria-current="page">Appel</a>
+ * <!-- Huidige pagina: geen link, aria-current op de <li> -->
+ *     <li
+ *       class="dsn-breadcrumb-navigation__item dsn-breadcrumb-navigation__item--current"
+ *       aria-current="page"
+ *     >
+ *       Appel
  *     </li>
  *   </ol>
  * </nav>
@@ -98,17 +102,8 @@
       var(--dsn-transition-easing-default);
 }
 
-/* Current link — muted color, no underline, no hover effect */
-.dsn-breadcrumb-navigation__item--current .dsn-breadcrumb-navigation__link {
-  color: var(--dsn-breadcrumb-navigation-current-color);
-  text-decoration-line: none;
-  cursor: default;
-}
-
 /* Hover */
-.dsn-breadcrumb-navigation__link:hover:not(
-    .dsn-breadcrumb-navigation__item--current .dsn-breadcrumb-navigation__link
-  ) {
+.dsn-breadcrumb-navigation__link:hover {
   color: var(--dsn-breadcrumb-navigation-link-hover-color);
   text-decoration-line: var(
     --dsn-breadcrumb-navigation-link-hover-text-decoration-line
@@ -116,9 +111,7 @@
 }
 
 /* Active */
-.dsn-breadcrumb-navigation__link:active:not(
-    .dsn-breadcrumb-navigation__item--current .dsn-breadcrumb-navigation__link
-  ) {
+.dsn-breadcrumb-navigation__link:active {
   color: var(--dsn-breadcrumb-navigation-link-active-color);
   text-decoration-line: var(
     --dsn-breadcrumb-navigation-link-active-text-decoration-line

--- a/packages/components-react/src/BreadcrumbNavigation/BreadcrumbNavigation.test.tsx
+++ b/packages/components-react/src/BreadcrumbNavigation/BreadcrumbNavigation.test.tsx
@@ -10,9 +10,7 @@ const renderBreadcrumb = (props = {}) =>
       <BreadcrumbNavigationItem href="/categorie">
         Categorie
       </BreadcrumbNavigationItem>
-      <BreadcrumbNavigationItem href="/product" current>
-        Product
-      </BreadcrumbNavigationItem>
+      <BreadcrumbNavigationItem current>Product</BreadcrumbNavigationItem>
     </BreadcrumbNavigation>
   );
 
@@ -125,9 +123,7 @@ describe('BreadcrumbNavigation', () => {
     render(
       <BreadcrumbNavigation ref={ref}>
         <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/huidig" current>
-          Huidig
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
     expect(ref.current).toBeInstanceOf(HTMLElement);
@@ -149,9 +145,7 @@ describe('BreadcrumbNavigationItem', () => {
     const { container } = render(
       <BreadcrumbNavigation>
         <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/huidig" current>
-          Huidig
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
     const items = container.querySelectorAll('li');
@@ -162,9 +156,7 @@ describe('BreadcrumbNavigationItem', () => {
     render(
       <BreadcrumbNavigation>
         <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/huidig" current>
-          Huidig
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
     expect(screen.getByText('Home').closest('a')).toHaveAttribute(
@@ -177,9 +169,7 @@ describe('BreadcrumbNavigationItem', () => {
     render(
       <BreadcrumbNavigation>
         <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/huidig" current>
-          Huidig
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
     expect(screen.getByText('Home')).toBeInTheDocument();
@@ -193,9 +183,7 @@ describe('BreadcrumbNavigationItem', () => {
     const { container } = render(
       <BreadcrumbNavigation>
         <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/huidig" current>
-          Huidig
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
     const items = container.querySelectorAll('li');
@@ -208,9 +196,7 @@ describe('BreadcrumbNavigationItem', () => {
     const { container } = render(
       <BreadcrumbNavigation>
         <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/huidig" current>
-          Huidig
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
     const currentItem = container.querySelector(
@@ -223,9 +209,7 @@ describe('BreadcrumbNavigationItem', () => {
     const { container } = render(
       <BreadcrumbNavigation>
         <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/huidig" current>
-          Huidig
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
     const links = container.querySelectorAll(
@@ -238,16 +222,14 @@ describe('BreadcrumbNavigationItem', () => {
   // Accessibility
   // ===========================
 
-  it('adds aria-current="page" on current item link', () => {
+  it('adds aria-current="page" on the current <li>', () => {
     render(
       <BreadcrumbNavigation>
         <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/huidig" current>
-          Huidig
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
-    expect(screen.getByText('Huidig').closest('a')).toHaveAttribute(
+    expect(screen.getByText('Huidig').closest('li')).toHaveAttribute(
       'aria-current',
       'page'
     );
@@ -257,23 +239,56 @@ describe('BreadcrumbNavigationItem', () => {
     render(
       <BreadcrumbNavigation>
         <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/huidig" current>
-          Huidig
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
-    expect(screen.getByText('Home').closest('a')).not.toHaveAttribute(
+    expect(screen.getByText('Home').closest('li')).not.toHaveAttribute(
       'aria-current'
     );
   });
 
-  it('separator icon has aria-hidden', () => {
+  it('does not render the current page as a link', () => {
+    render(
+      <BreadcrumbNavigation>
+        <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
+      </BreadcrumbNavigation>
+    );
+    expect(screen.getByText('Huidig').closest('a')).toBeNull();
+    // Alleen de bovenliggende items zijn nog links
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+  });
+
+  it('ignores href on the current item', () => {
     const { container } = render(
       <BreadcrumbNavigation>
         <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
         <BreadcrumbNavigationItem href="/huidig" current>
           Huidig
         </BreadcrumbNavigationItem>
+      </BreadcrumbNavigation>
+    );
+    expect(container.querySelector('a[href="/huidig"]')).toBeNull();
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+  });
+
+  it('renders as plain text when href is omitted on a non-current item', () => {
+    render(
+      <BreadcrumbNavigation>
+        <BreadcrumbNavigationItem>Zonder href</BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
+      </BreadcrumbNavigation>
+    );
+    // Nooit een <a> zonder href: die is niet focusbaar en heeft geen linkrol
+    expect(screen.getByText('Zonder href').closest('a')).toBeNull();
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
+  it('separator icon has aria-hidden', () => {
+    const { container } = render(
+      <BreadcrumbNavigation>
+        <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
     const separators = container.querySelectorAll(
@@ -295,9 +310,7 @@ describe('BreadcrumbNavigationItem', () => {
         <BreadcrumbNavigationItem href="/categorie">
           Categorie
         </BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/huidig" current>
-          Huidig
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
     const separators = container.querySelectorAll(
@@ -318,9 +331,7 @@ describe('BreadcrumbNavigationItem', () => {
         <BreadcrumbNavigationItem ref={ref} href="/home">
           Home
         </BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/huidig" current>
-          Huidig
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>Huidig</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     );
     expect(ref.current).toBeInstanceOf(HTMLElement);

--- a/packages/components-react/src/BreadcrumbNavigation/BreadcrumbNavigation.tsx
+++ b/packages/components-react/src/BreadcrumbNavigation/BreadcrumbNavigation.tsx
@@ -34,14 +34,14 @@ export interface BreadcrumbNavigationProps extends React.HTMLAttributes<HTMLElem
  * <BreadcrumbNavigation aria-label="Broodkruimelpad">
  *   <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
  *   <BreadcrumbNavigationItem href="/categorie">Categorie</BreadcrumbNavigationItem>
- *   <BreadcrumbNavigationItem href="/product" current>Product</BreadcrumbNavigationItem>
+ *   <BreadcrumbNavigationItem current>Product</BreadcrumbNavigationItem>
  * </BreadcrumbNavigation>
  *
  * // Compact variant
  * <BreadcrumbNavigation aria-label="Broodkruimelpad" variant="compact">
  *   <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
  *   <BreadcrumbNavigationItem href="/categorie">Categorie</BreadcrumbNavigationItem>
- *   <BreadcrumbNavigationItem href="/product" current>Product</BreadcrumbNavigationItem>
+ *   <BreadcrumbNavigationItem current>Product</BreadcrumbNavigationItem>
  * </BreadcrumbNavigation>
  * ```
  */

--- a/packages/components-react/src/BreadcrumbNavigation/BreadcrumbNavigationItem.tsx
+++ b/packages/components-react/src/BreadcrumbNavigation/BreadcrumbNavigationItem.tsx
@@ -4,12 +4,14 @@ import { Icon } from '../Icon';
 
 export interface BreadcrumbNavigationItemProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   /**
-   * URL van de pagina
+   * URL van de pagina. Laat weg bij het huidige pagina-item: dat wordt
+   * als platte tekst gerenderd en niet als link
    */
-  href: string;
+  href?: string;
 
   /**
-   * Markeert het huidige pagina-item; voegt `aria-current="page"` toe
+   * Markeert het huidige pagina-item. Rendert de tekst zonder link en
+   * zet `aria-current="page"` op de `<li>`
    * @default false
    */
   current?: boolean;
@@ -29,10 +31,14 @@ export interface BreadcrumbNavigationItemProps extends React.AnchorHTMLAttribute
  * BreadcrumbNavigationItem component
  * Enkel item in een BreadcrumbNavigation. Gebruik altijd binnen een `<BreadcrumbNavigation>`.
  *
+ * Het huidige pagina-item is bewust géén link: een link naar de pagina waar je
+ * al bent doet niets, terwijl hij er wel uitziet als de andere items. Zie
+ * WCAG 3.2.4 Consistent Identification.
+ *
  * @example
  * ```tsx
  * <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
- * <BreadcrumbNavigationItem href="/categorie" current>Categorie</BreadcrumbNavigationItem>
+ * <BreadcrumbNavigationItem current>Categorie</BreadcrumbNavigationItem>
  * ```
  */
 export const BreadcrumbNavigationItem = React.forwardRef<
@@ -56,23 +62,32 @@ export const BreadcrumbNavigationItem = React.forwardRef<
       className
     );
 
+    // Het huidige item krijgt geen link; zonder href valt een item daar ook op terug
+    const renderAsLink = !current && href !== undefined;
+
     return (
-      <li ref={ref} className={itemClasses}>
-        <a
-          href={href}
-          className="dsn-breadcrumb-navigation__link"
-          aria-current={current ? 'page' : undefined}
-          {...props}
-        >
-          {showBackIcon && (
-            <Icon
-              name="arrow-left"
-              className="dsn-breadcrumb-navigation__back-icon"
-              aria-hidden
-            />
-          )}
-          {children}
-        </a>
+      <li
+        ref={ref}
+        className={itemClasses}
+        aria-current={current ? 'page' : undefined}
+        {...(renderAsLink
+          ? {}
+          : (props as React.LiHTMLAttributes<HTMLLIElement>))}
+      >
+        {renderAsLink ? (
+          <a href={href} className="dsn-breadcrumb-navigation__link" {...props}>
+            {showBackIcon && (
+              <Icon
+                name="arrow-left"
+                className="dsn-breadcrumb-navigation__back-icon"
+                aria-hidden
+              />
+            )}
+            {children}
+          </a>
+        ) : (
+          children
+        )}
         <Icon
           name="chevron-right"
           className="dsn-breadcrumb-navigation__separator"

--- a/packages/storybook/src/BreadcrumbNavigation.docs.md
+++ b/packages/storybook/src/BreadcrumbNavigation.docs.md
@@ -4,7 +4,7 @@ Toont de hiërarchische locatie van de gebruiker en biedt navigatie naar bovenli
 
 ## Doel
 
-De BreadcrumbNavigation component geeft gebruikers inzicht in hun positie binnen de sitestructuur. Elke stap in het pad is een link naar het bijbehorende niveau. De huidige pagina wordt visueel onderscheiden en is gemarkeerd met `aria-current="page"`. De component ondersteunt een compacte variant die via een container query automatisch terugvalt naar enkel het ouder-niveau met een terug-pijl wanneer de beschikbare ruimte te klein is.
+De BreadcrumbNavigation component geeft gebruikers inzicht in hun positie binnen de sitestructuur. Elke stap in het pad is een link naar het bijbehorende niveau. De huidige pagina is bewust geen link, wordt visueel onderscheiden en is gemarkeerd met `aria-current="page"`. De component ondersteunt een compacte variant die via een container query automatisch terugvalt naar enkel het ouder-niveau met een terug-pijl wanneer de beschikbare ruimte te klein is.
 
 <!-- VOORBEELD -->
 
@@ -28,7 +28,8 @@ De BreadcrumbNavigation component geeft gebruikers inzicht in hun positie binnen
 ### Inhoud
 
 - Gebruik de paginatitels als linktekst: consistent met de `<h1>` van elke pagina.
-- Voeg de huidige pagina altijd toe als laatste item met `current`, zelfs als het een link is. Dit geeft gebruikers bevestiging van hun locatie.
+- Voeg de huidige pagina altijd toe als laatste item met `current`. Dit geeft gebruikers bevestiging van hun locatie.
+- Geef het huidige item geen `href`: het wordt als platte tekst gerenderd. Een link naar de pagina waar je al bent doet niets, terwijl hij er wel uitziet als de andere items in het pad.
 
 ### Compact variant
 
@@ -64,6 +65,7 @@ De BreadcrumbNavigation component geeft gebruikers inzicht in hun positie binnen
 
 - `<nav>` met `aria-label` identificeert de breadcrumb als navigatielandmark. Gebruik een beschrijvend label (standaard: `"Broodkruimelpad"`) zodat deze te onderscheiden is van andere `<nav>` landmarks op de pagina.
 - `<ol>` signaleert aan screenreaders dat de volgorde van items semantisch betekenisvol is.
-- `aria-current="page"` op de link van de huidige pagina informeert hulptechnologie over de huidige locatie.
+- `aria-current="page"` op de `<li>` van de huidige pagina informeert hulptechnologie over de huidige locatie.
+- Het huidige item is geen link. Elementen die hetzelfde doen moeten er hetzelfde uitzien, en een link die niet navigeert breekt die verwachting (WCAG 3.2.4 Consistent Identification). Dat scheelt screenreader- en toetsenbordgebruikers ook een zinloze tabstop.
 - Alle scheidingstekens en het terug-pijl icoon zijn decoratief en hebben `aria-hidden="true"`.
-- Alle links zijn volledig toetsenbordtoegankelijk via Tab: geen extra ARIA of tabindex vereist.
+- Alle links zijn volledig toetsenbordtoegankelijk via Tab: geen extra ARIA of tabindex vereist. Het huidige item krijgt geen tabstop omdat het geen link is.

--- a/packages/storybook/src/BreadcrumbNavigation.docs.mdx
+++ b/packages/storybook/src/BreadcrumbNavigation.docs.mdx
@@ -31,8 +31,11 @@ export const [intro, rest] = docs.split('<!-- VOORBEELD -->');
       <a href="/fruit" class="dsn-breadcrumb-navigation__link">Fruit</a>
       <svg class="dsn-icon dsn-breadcrumb-navigation__separator" aria-hidden="true"><!-- chevron-right --></svg>
     </li>
-    <li class="dsn-breadcrumb-navigation__item dsn-breadcrumb-navigation__item--current">
-      <a href="/appel" class="dsn-breadcrumb-navigation__link" aria-current="page">Appel</a>
+    <li
+      class="dsn-breadcrumb-navigation__item dsn-breadcrumb-navigation__item--current"
+      aria-current="page"
+    >
+      Appel
       <svg class="dsn-icon dsn-breadcrumb-navigation__separator" aria-hidden="true"><!-- chevron-right --></svg>
     </li>
   </ol>

--- a/packages/storybook/src/BreadcrumbNavigation.stories.tsx
+++ b/packages/storybook/src/BreadcrumbNavigation.stories.tsx
@@ -27,18 +27,30 @@ const meta: Meta<typeof BreadcrumbNavigation> = {
           { href: '/home', label: 'Home' },
           { href: '/supermarkt', label: 'Supermarkt' },
           { href: '/fruit', label: 'Fruit' },
-          { href: '/appel', label: 'Appel', current: true },
+          { label: 'Appel', current: true },
         ];
+        const separator = `      <svg class="dsn-icon dsn-breadcrumb-navigation__separator" aria-hidden="true"><!-- chevron-right --></svg>`;
         const itemsHtml = items
           .map((item, index) => {
             const isParentOfCurrent = compact && index === items.length - 2;
-            const itemCls = `dsn-breadcrumb-navigation__item${item.current ? ' dsn-breadcrumb-navigation__item--current' : ''}`;
+
+            // Het huidige item is geen link: platte tekst met aria-current op de <li>
+            if (item.current) {
+              return `    <li
+      class="dsn-breadcrumb-navigation__item dsn-breadcrumb-navigation__item--current"
+      aria-current="page"
+    >
+      ${item.label}
+${separator}
+    </li>`;
+            }
+
             const backIcon = isParentOfCurrent
               ? `\n        <svg class="dsn-icon dsn-breadcrumb-navigation__back-icon" aria-hidden="true"><!-- arrow-left --></svg>`
               : '';
-            return `    <li class="${itemCls}">
-      <a href="${item.href}" class="dsn-breadcrumb-navigation__link"${item.current ? ' aria-current="page"' : ''}>${backIcon}${backIcon ? `\n        ${item.label}\n      ` : item.label}</a>
-      <svg class="dsn-icon dsn-breadcrumb-navigation__separator" aria-hidden="true"><!-- chevron-right --></svg>
+            return `    <li class="dsn-breadcrumb-navigation__item">
+      <a href="${item.href}" class="dsn-breadcrumb-navigation__link">${backIcon}${backIcon ? `\n        ${item.label}\n      ` : item.label}</a>
+${separator}
     </li>`;
           })
           .join('\n');
@@ -80,9 +92,7 @@ export const Default: Story = {
         Supermarkt
       </BreadcrumbNavigationItem>
       <BreadcrumbNavigationItem href="/fruit">Fruit</BreadcrumbNavigationItem>
-      <BreadcrumbNavigationItem href="/appel" current>
-        Appel
-      </BreadcrumbNavigationItem>
+      <BreadcrumbNavigationItem current>Appel</BreadcrumbNavigationItem>
     </BreadcrumbNavigation>
   ),
 };
@@ -100,9 +110,7 @@ export const Compact: Story = {
         Supermarkt
       </BreadcrumbNavigationItem>
       <BreadcrumbNavigationItem href="/fruit">Fruit</BreadcrumbNavigationItem>
-      <BreadcrumbNavigationItem href="/appel" current>
-        Appel
-      </BreadcrumbNavigationItem>
+      <BreadcrumbNavigationItem current>Appel</BreadcrumbNavigationItem>
     </BreadcrumbNavigation>
   ),
 };
@@ -112,9 +120,7 @@ export const TwoItems: Story = {
   render: (args: BreadcrumbNavigationProps) => (
     <BreadcrumbNavigation {...args}>
       <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
-      <BreadcrumbNavigationItem href="/appel" current>
-        Appel
-      </BreadcrumbNavigationItem>
+      <BreadcrumbNavigationItem current>Appel</BreadcrumbNavigationItem>
     </BreadcrumbNavigation>
   ),
 };
@@ -137,9 +143,7 @@ export const ManyItems: Story = {
         Subcategorie
       </BreadcrumbNavigationItem>
       <BreadcrumbNavigationItem href="/fruit">Fruit</BreadcrumbNavigationItem>
-      <BreadcrumbNavigationItem href="/appel" current>
-        Appel
-      </BreadcrumbNavigationItem>
+      <BreadcrumbNavigationItem current>Appel</BreadcrumbNavigationItem>
     </BreadcrumbNavigation>
   ),
 };
@@ -160,9 +164,7 @@ export const RTL: Story = {
         <BreadcrumbNavigationItem href="/supermarkt">
           السوبرماركت
         </BreadcrumbNavigationItem>
-        <BreadcrumbNavigationItem href="/fruit" current>
-          الفاكهة
-        </BreadcrumbNavigationItem>
+        <BreadcrumbNavigationItem current>الفاكهة</BreadcrumbNavigationItem>
       </BreadcrumbNavigation>
     </div>
   ),

--- a/packages/storybook/src/templates/KitchenSinkPage.stories.tsx
+++ b/packages/storybook/src/templates/KitchenSinkPage.stories.tsx
@@ -460,7 +460,7 @@ export const Default: Story = {
                   <BreadcrumbNavigationItem href="#">
                     Tekst
                   </BreadcrumbNavigationItem>
-                  <BreadcrumbNavigationItem href="#" current>
+                  <BreadcrumbNavigationItem current>
                     Tekst
                   </BreadcrumbNavigationItem>
                 </BreadcrumbNavigation>

--- a/packages/storybook/src/templates/WithSidebarPage.stories.tsx
+++ b/packages/storybook/src/templates/WithSidebarPage.stories.tsx
@@ -704,7 +704,7 @@ export const Level2a: Story = {
                 <BreadcrumbNavigationItem href="/level-1a">
                   Level 1a
                 </BreadcrumbNavigationItem>
-                <BreadcrumbNavigationItem href="/level-2a" current>
+                <BreadcrumbNavigationItem current>
                   Level 2a
                 </BreadcrumbNavigationItem>
               </BreadcrumbNavigation>
@@ -760,7 +760,7 @@ export const Level3a: Story = {
                 <BreadcrumbNavigationItem href="/level-2b">
                   Level 2b
                 </BreadcrumbNavigationItem>
-                <BreadcrumbNavigationItem href="/level-3a" current>
+                <BreadcrumbNavigationItem current>
                   Level 3a
                 </BreadcrumbNavigationItem>
               </BreadcrumbNavigation>
@@ -819,7 +819,7 @@ export const Level4a: Story = {
                 <BreadcrumbNavigationItem href="/level-3b">
                   Level 3b
                 </BreadcrumbNavigationItem>
-                <BreadcrumbNavigationItem href="/level-4a" current>
+                <BreadcrumbNavigationItem current>
                   Level 4a
                 </BreadcrumbNavigationItem>
               </BreadcrumbNavigation>


### PR DESCRIPTION
Closes #298

## Wat en waarom

Het laatste breadcrumb-item werd als `<a>` gerenderd en vervolgens met CSS ontdaan van underline en pointer-cursor. Het resultaat was een link die eruitziet als tekst en bij activeren niets doet: dezelfde rol, andere presentatie, geen effect. Dat botst met [WCAG 3.2.4 Consistent Identification](https://www.w3.org/WAI/WCAG22/quickref/#consistent-identification).

Het huidige item rendert nu als platte tekst binnen de `<li>`, met `aria-current="page"` op de `<li>` in plaats van op de link, conform het voorstel in het issue.

**Voor:**

```html
<li class="dsn-breadcrumb-navigation__item dsn-breadcrumb-navigation__item--current">
  <a href="/appel" class="dsn-breadcrumb-navigation__link" aria-current="page">Appel</a>
</li>
```

**Na:**

```html
<li
  class="dsn-breadcrumb-navigation__item dsn-breadcrumb-navigation__item--current"
  aria-current="page"
>
  Appel
</li>
```

## Impact

- **HTML/CSS-laag: breaking.** Wie de markup met de hand schrijft, verplaatst `aria-current="page"` naar de `<li>` en haalt de `<a>` rond de huidige paginatitel weg.
- **React-consumers: niets te doen.** `href` is optioneel geworden en wordt genegeerd zodra `current` is gezet, dus bestaande `<BreadcrumbNavigationItem href="/x" current>` blijft compileren en krijgt de nieuwe markup vanzelf. Het weglaten van `href` is de nieuwe, schone vorm.
- Het huidige item levert geen tabstop meer op, wat toetsenbordgebruikers een navigatie-actie zonder effect bespaart.

De CSS werd hier eenvoudiger van: de ontlink-regel voor `.dsn-breadcrumb-navigation__item--current .dsn-breadcrumb-navigation__link` verviel, en daarmee ook de twee `:not(...)`-guards die hover en active van het huidige item moesten uitsluiten.

Een item zonder `href` valt sowieso terug op platte tekst. Zo ontstaat er nooit een `<a>` zonder `href`, die niet focusbaar is en geen linkrol krijgt.

## Verificatie

- `pnpm test`: 1630 tests groen (79 bestanden), waarvan 28 voor dit component. Drie nieuwe tests: current rendert geen link, `href` wordt genegeerd bij `current`, en een item zonder `href` wordt platte tekst.
- `pnpm --filter storybook exec tsc --noEmit`: schoon.
- `pnpm lint`: 0 errors, 96 warnings, gelijk aan `main` (allemaal pre-existing `no-redundant-story-name`).
- In Storybook gecontroleerd: accessibility tree toont drie `listitem > link` en "Appel" als kale `listitem`; visuele weergave is ongewijzigd; alle vier items houden dezelfde hoogte. Compact-variant en de container-query collapse op smalle viewport werken onveranderd, met de terug-pijl nog steeds in het ouder-item.
- Meegenomen: `htmlTemplate` in de stories, de HTML/CSS-tab in de docs, en de breadcrumbs in Detailpage en KitchenSinkPage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)