### PR TITLE
fix(DotBadge): pulse-animatie stopt na 4,5 seconden

### DIFF
--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1261,7 +1261,8 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 
 - Kleine gekleurde stip die `position: absolute` staat t.o.v. de parent-wrapper
 - Altijd `aria-hidden="true"`: toegankelijke context via `dsn-visually-hidden` in de parent
-- `pulse` modifier voegt herhalend ring-effect toe via `::before` pseudo-element
+- `pulse` modifier voegt een ring-effect toe via `::before` pseudo-element
+- Pulse loopt 3 × 1500ms = 4500ms en stopt dan vanzelf (WCAG 2.2.2: beweging korter dan 5 seconden heeft geen stopmechanisme nodig)
 - Logische properties (`inset-block-start`, `inset-inline-end`) voor RTL-correctheid
 - Pulse-animatie respecteert `prefers-reduced-motion: reduce`
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,17 @@ Nog niet gepubliceerde wijzigingen. Schrijf nieuwe changelog-entries hieronder; 
   - De CSS werd hier eenvoudiger van: de ontlink-regel voor `.dsn-breadcrumb-navigation__item--current .dsn-breadcrumb-navigation__link` verviel, en daarmee ook de twee `:not(...)`-guards die hover en active van het huidige item moesten uitsluiten
   - Het huidige item levert geen tabstop meer op, wat toetsenbordgebruikers een navigatie-actie zonder effect bespaart
 
+### DotBadge
+
+#### Changed
+
+- **Pulse-animatie stopt na 4,5 seconden** (issues [#301](https://github.com/jeffreylauwers/design-system-starter-kit/issues/301) en [#302](https://github.com/jeffreylauwers/design-system-starter-kit/issues/302)): de `pulse`-modifier draaide `infinite` en bleef dus onbeperkt bewegen naast de rest van de pagina. De animatie loopt nu 3 keer (3 × 1500ms = 4500ms) en stopt daarna vanzelf. Gerelateerd succescriterium: [WCAG 2.2.2 Pauzeren, stoppen, verbergen](https://www.w3.org/WAI/WCAG22/quickref/#pause-stop-hide).
+  - 2.2.2 vraagt bij automatisch startende beweging die langer dan 5 seconden duurt om een pauzeer-, stop- of verbergmechanisme. Een stopknop naast een decoratieve stip zou meer in de weg zitten dan helpen, dus is gekozen voor de andere route die het criterium biedt: de animatie eindigt binnen 5 seconden vanzelf
+  - Nieuw token `--dsn-dot-badge-pulse-iteration-count` (`3`). Wie de duur aanpast, past duration en iteration-count samen aan en houdt het product onder de 5 seconden
+  - `animation-fill-mode: forwards` houdt het laatste keyframe vast, zodat de ring uitgefadet blijft in plaats van terug te springen naar een zichtbare cirkel
+  - De dot zelf blijft na de animatie gewoon staan: alleen de beweging stopt, de statusinformatie niet
+  - De Storybook-story "With pulse" heeft een knop gekregen om de animatie opnieuw af te spelen, omdat een eindige animatie anders niet te beoordelen is in de docs
+
 ### IconList
 
 #### Added

--- a/packages/components-html/src/dot-badge/dot-badge.css
+++ b/packages/components-html/src/dot-badge/dot-badge.css
@@ -62,7 +62,13 @@
   --dsn-dot-badge-color: var(--dsn-color-neutral-inverse-bg-default);
 }
 
-/* Pulse-effect via ::before pseudo-element — geen extra DOM-nodes nodig */
+/* Pulse-effect via ::before pseudo-element — geen extra DOM-nodes nodig.
+   De animatie loopt bewust een eindig aantal keer (3 × 1500ms = 4500ms) en stopt
+   dus binnen 5 seconden: WCAG 2.2.2 Pauzeren, stoppen, verbergen vraagt voor
+   automatisch startende beweging naast andere content ofwel een stopmechanisme,
+   ofwel een animatie die vanzelf binnen 5 seconden eindigt.
+   animation-fill-mode: forwards houdt het laatste keyframe vast (opacity: 0),
+   zodat de ring uitgefadet blijft en de dot zelf zichtbaar achterblijft. */
 .dsn-dot-badge--pulse::before {
   content: '';
   display: block;
@@ -71,7 +77,8 @@
   border-radius: 50%;
   background-color: var(--dsn-dot-badge-color);
   animation: dsn-dot-badge-pulse var(--dsn-dot-badge-pulse-duration)
-    var(--dsn-dot-badge-pulse-easing) infinite;
+    var(--dsn-dot-badge-pulse-easing) var(--dsn-dot-badge-pulse-iteration-count)
+    forwards;
 }
 
 @keyframes dsn-dot-badge-pulse {

--- a/packages/components-react/src/DotBadge/DotBadge.tsx
+++ b/packages/components-react/src/DotBadge/DotBadge.tsx
@@ -17,7 +17,9 @@ export interface DotBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   variant?: DotBadgeVariant;
 
   /**
-   * Voegt een pulserend ring-effect toe om extra aandacht te trekken
+   * Voegt een pulserend ring-effect toe om extra aandacht te trekken.
+   * De pulse loopt 3 keer (4500ms) en stopt dan vanzelf, zodat de beweging
+   * binnen de 5 seconden van WCAG 2.2.2 blijft. De dot zelf blijft staan.
    * @default false
    */
   pulse?: boolean;

--- a/packages/design-tokens/src/tokens/components/dot-badge.json
+++ b/packages/design-tokens/src/tokens/components/dot-badge.json
@@ -21,6 +21,11 @@
         "$type": "duration",
         "$description": "Duur van de pulse-animatie — bewust hoger dan transition.duration.slower (500ms): dit is een herhalende ambient animatie, geen UI-transition"
       },
+      "pulse-iteration-count": {
+        "$value": "3",
+        "$type": "number",
+        "$description": "Aantal herhalingen van de pulse-animatie — 3 × 1500ms = 4500ms, bewust onder de 5 seconden van WCAG 2.2.2 Pauzeren, stoppen, verbergen"
+      },
       "pulse-easing": {
         "$value": "{dsn.transition.easing.default}",
         "$description": "Easing van de pulse-animatie"

--- a/packages/storybook/src/DotBadge.docs.md
+++ b/packages/storybook/src/DotBadge.docs.md
@@ -68,6 +68,10 @@ DotBadge heeft altijd `aria-hidden="true"`: screenreaders negeren de dot volledi
 
 Gebruik de `pulse`-modifier alleen voor urgente, tijdkritische statuswijzigingen. De animatie respecteert `prefers-reduced-motion: reduce`: bij verminderde bewegingsvoorkeur vervalt de animatie maar blijft de dot zichtbaar.
 
+De pulse loopt drie keer (3 × 1500ms = 4500ms) en stopt daarna vanzelf. Dat is een bewuste keuze: [WCAG 2.2.2 Pauzeren, stoppen, verbergen](https://www.w3.org/WAI/WCAG22/quickref/#pause-stop-hide) vraagt voor beweging die automatisch start en naast andere content staat ofwel een mechanisme om te pauzeren, stoppen of verbergen, ofwel een animatie die binnen 5 seconden vanzelf eindigt. Een stopknop bij een decoratieve stip zou meer in de weg zitten dan helpen, dus eindigt de animatie zichzelf. De dot blijft daarna gewoon staan: de statusinformatie gaat niet verloren, alleen de beweging stopt.
+
+Wil je een andere duur, pas dan `--dsn-dot-badge-pulse-duration` en `--dsn-dot-badge-pulse-iteration-count` samen aan en houd het product van beide onder de 5 seconden.
+
 ```html
 <span
   class="dsn-dot-badge dsn-dot-badge--negative dsn-dot-badge--pulse"
@@ -81,14 +85,15 @@ Bij dynamisch bijwerken van de dot (bijv. nieuwe berichten binnenkomen): voeg `a
 
 ## Design tokens
 
-| Token                               | Beschrijving                                      |
-| ----------------------------------- | ------------------------------------------------- |
-| `--dsn-dot-badge-size`              | Diameter van de dot (8px)                         |
-| `--dsn-dot-badge-color`             | Achtergrondkleur: wordt per variant ingesteld     |
-| `--dsn-dot-badge-inset-block-start` | Verticale offset t.o.v. rechterbovenhoek parent   |
-| `--dsn-dot-badge-inset-inline-end`  | Horizontale offset t.o.v. rechterbovenhoek parent |
-| `--dsn-dot-badge-pulse-duration`    | Duur van de pulse-animatie                        |
-| `--dsn-dot-badge-pulse-easing`      | Easing van de pulse-animatie                      |
+| Token                                   | Beschrijving                                      |
+| --------------------------------------- | ------------------------------------------------- |
+| `--dsn-dot-badge-size`                  | Diameter van de dot (8px)                         |
+| `--dsn-dot-badge-color`                 | Achtergrondkleur: wordt per variant ingesteld     |
+| `--dsn-dot-badge-inset-block-start`     | Verticale offset t.o.v. rechterbovenhoek parent   |
+| `--dsn-dot-badge-inset-inline-end`      | Horizontale offset t.o.v. rechterbovenhoek parent |
+| `--dsn-dot-badge-pulse-duration`        | Duur van één pulse-cyclus (1500ms)                |
+| `--dsn-dot-badge-pulse-iteration-count` | Aantal herhalingen van de pulse (3)               |
+| `--dsn-dot-badge-pulse-easing`          | Easing van de pulse-animatie                      |
 
 ## Accessibility
 
@@ -97,3 +102,5 @@ Bij dynamisch bijwerken van de dot (bijv. nieuwe berichten binnenkomen): voeg `a
 - Gebruik nooit `aria-label` op DotBadge zelf.
 - Bij dynamisch bijwerken: voeg `aria-live="polite"` toe op een hoger niveau.
 - Pulse-animatie respecteert `prefers-reduced-motion: reduce`: animatie vervalt, dot blijft zichtbaar.
+- Pulse-animatie stopt na 4500ms vanzelf, ruim binnen de 5 seconden van [WCAG 2.2.2 Pauzeren, stoppen, verbergen](https://www.w3.org/WAI/WCAG22/quickref/#pause-stop-hide). Er is daarom geen stopknop nodig.
+- Pulse-animatie is uitgeschakeld in forced-colors mode: een opacity-animatie op systeemkleuren is onbetrouwbaar.

--- a/packages/storybook/src/DotBadge.stories.tsx
+++ b/packages/storybook/src/DotBadge.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Button, DotBadge, Icon } from '@dsn-starter-kit/components-react';
 import DocsPage from './DotBadge.docs.mdx';
@@ -102,50 +103,71 @@ export const AllVariants: Story = {
   ),
 };
 
-export const WithPulse: Story = {
-  name: 'With pulse',
-  render: () => (
+/**
+ * De pulse loopt 3 × 1500ms = 4500ms en stopt daarna vanzelf, binnen de 5 seconden
+ * van WCAG 2.2.2. De knop remount de dots zodat de animatie opnieuw te zien is.
+ */
+const PulseShowcase = () => {
+  const [run, setRun] = useState(0);
+
+  return (
     <div
       style={{
         display: 'flex',
-        gap: '2rem',
+        flexDirection: 'column',
+        gap: '1.5rem',
+        alignItems: 'flex-start',
         padding: '0.75rem',
-        alignItems: 'center',
       }}
     >
-      {(['negative', 'positive', 'warning', 'info', 'neutral'] as const).map(
-        (variant) => (
-          <div
-            key={variant}
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              gap: '0.5rem',
-            }}
-          >
+      <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
+        {(['negative', 'positive', 'warning', 'info', 'neutral'] as const).map(
+          (variant) => (
             <div
+              key={variant}
               style={{
-                position: 'relative',
-                display: 'inline-block',
-                padding: '0.75rem',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: '0.5rem',
               }}
             >
-              <DotBadge variant={variant} pulse />
+              <div
+                style={{
+                  position: 'relative',
+                  display: 'inline-block',
+                  padding: '0.75rem',
+                }}
+              >
+                <DotBadge key={run} variant={variant} pulse />
+              </div>
+              <span
+                style={{
+                  fontSize: '0.75rem',
+                  color: 'var(--dsn-color-neutral-color-default)',
+                }}
+              >
+                {variant}
+              </span>
             </div>
-            <span
-              style={{
-                fontSize: '0.75rem',
-                color: 'var(--dsn-color-neutral-color-default)',
-              }}
-            >
-              {variant}
-            </span>
-          </div>
-        )
-      )}
+          )
+        )}
+      </div>
+
+      <Button
+        variant="default"
+        size="small"
+        onClick={() => setRun((value) => value + 1)}
+      >
+        Animatie opnieuw afspelen
+      </Button>
     </div>
-  ),
+  );
+};
+
+export const WithPulse: Story = {
+  name: 'With pulse',
+  render: () => <PulseShowcase />,
 };
 
 // =============================================================================


### PR DESCRIPTION
## Wat en waarom

De `pulse`-modifier van DotBadge draaide `infinite` en bleef dus onbeperkt bewegen naast de rest van de pagina. [WCAG 2.2.2 Pauzeren, stoppen, verbergen](https://www.w3.org/WAI/WCAG22/quickref/#pause-stop-hide) vraagt bij beweging die automatisch start, langer dan 5 seconden duurt en naast andere content staat om een mechanisme om te pauzeren, stoppen of verbergen.

Het criterium biedt twee routes. Een stopknop naast een decoratieve stip zou meer in de weg zitten dan helpen, dus is gekozen voor de andere: de animatie eindigt binnen 5 seconden vanzelf. De pulse loopt nu 3 × 1500ms = 4500ms en stopt daarna.

De dot zelf blijft na de animatie gewoon staan. Alleen de beweging stopt, de statusinformatie niet.

## Wijzigingen

- Nieuw token `--dsn-dot-badge-pulse-iteration-count` (`3`) in `dot-badge.json`
- `dot-badge.css`: `infinite` vervangen door de nieuwe iteration-count, plus `animation-fill-mode: forwards` zodat het laatste keyframe (`opacity: 0`) blijft staan en de ring niet terugspringt naar een zichtbare cirkel
- Docs bijgewerkt: `DotBadge.docs.md` (Pulse-effect, tokentabel, Accessibility), `docs/03-components.md`, `docs/changelog.md`, JSDoc op de `pulse`-prop
- Story "With pulse" heeft een knop "Animatie opnieuw afspelen" gekregen. Zonder die knop is een eindige animatie niet te beoordelen in de docs

Wie de duur wil aanpassen, past `--dsn-dot-badge-pulse-duration` en `--dsn-dot-badge-pulse-iteration-count` samen aan en houdt het product onder de 5 seconden. Dat staat zo ook in de docs.

## Verificatie

`pnpm test` (1630 tests), `tsc --noEmit` (0 fouten) en `pnpm lint` (0 errors) zijn groen.

In Storybook gemeten op de story "With pulse", via de Web Animations API op het `::before` pseudo-element:

| Meting | Waarde |
| --- | --- |
| `activeDuration` | `4500` ms |
| `iterations` | `3` |
| `fill` | `forwards` |
| `playState` op t=4500 | `finished` |
| `playState` op t=60000 | `finished` |
| Ring-opacity na afloop | `0` |
| Achtergrondkleur dot na afloop | `rgb(183, 0, 0)`, dus onveranderd zichtbaar |

De knop "Animatie opnieuw afspelen" brengt alle vijf de dots van `finished` terug naar `running` op t=0. Geen console-errors.

Niet aangeraakt: de bestaande `prefers-reduced-motion: reduce`- en `forced-colors: active`-regels zetten de animatie nog steeds volledig uit.

Fixes #301
Fixes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)