### PR TITLE
fix(File): kondig ook een mislukte upload aan in de aria-live regio

### DIFF
--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1429,13 +1429,14 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 
 **Tokens:** `tokens/components/file.json`
 
-**Props:** `fileName`, `fileType`, `fileSize`, `status`, `errorMessage`, `href`, `onDelete`, `deleteLabel`, `ctaVariant`, `ctaLabel`, `mediaType`, `previewSrc`, `loadingLabel`, `uploadedLabel`
+**Props:** `fileName`, `fileType`, `fileSize`, `status`, `errorMessage`, `href`, `onDelete`, `deleteLabel`, `ctaVariant`, `ctaLabel`, `mediaType`, `previewSrc`, `loadingLabel`, `uploadedLabel`, `errorLabel`
 
 **Features:**
 
 - CSS grid met 3 kolommen: `auto 1fr auto` (media-vlak | content | actions)
 - Vier upload-states: `default`, `loading`, `uploaded`, `error`
 - `uploaded` keert automatisch na 2 seconden terug naar `default` via `setTimeout`; aankondiging via `aria-live="polite"`
+- `error` vult dezelfde `aria-live="polite"` regio met `{fileName}: {errorMessage}` (of `{fileName} uploaden mislukt` zonder `errorMessage`), te overschrijven met `errorLabel`; de tekst blijft staan zolang de error-state actief is. `default` en `loading` laten de regio leeg
 - Interactieve variant (stretched-link techniek) wanneer `href` aanwezig is en `onDelete` ontbreekt — zelfde patroon als Card
 - Hover/active/focus op de gehele component via `:hover` / `:has(.dsn-file__name--stretched:active)` / `:has(.dsn-file__name--stretched:focus-visible)`
 - Bestandsnaam als `<a class="dsn-link">` (gestyled als link, bold) wanneer `href` aanwezig; anders `<span>`
@@ -1485,7 +1486,7 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 >
 ```
 
-**Tests:** React (52 tests)
+**Tests:** React (55 tests)
 
 ### FileList
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,21 @@ Nog niet gepubliceerde wijzigingen. Schrijf nieuwe changelog-entries hieronder; 
   - De dot zelf blijft na de animatie gewoon staan: alleen de beweging stopt, de statusinformatie niet
   - De Storybook-story "With pulse" heeft een knop gekregen om de animatie opnieuw af te spelen, omdat een eindige animatie anders niet te beoordelen is in de docs
 
+### File
+
+#### Changed
+
+- **De aria-live regio kondigt nu ook een mislukte upload aan** (issue [#316](https://github.com/jeffreylauwers/design-system-starter-kit/issues/316)): de visueel verborgen `aria-live="polite"` regio werd alleen gevuld bij `status="uploaded"`. Ging een upload mis, dan verscheen de foutmelding uitsluitend visueel, in een gewone `<p>` die niet wordt aangekondigd. Screenreadergebruikers hoorden succes wel en falen niet. Gerelateerd succescriterium: [WCAG 4.1.3 Statusberichten](https://www.w3.org/WAI/WCAG22/quickref/#status-messages).
+  - Bij `status="error"` komt nu `{fileName}: {errorMessage}` in de regio, of `{fileName} uploaden mislukt` wanneer er geen `errorMessage` is meegegeven
+  - Nieuwe prop `errorLabel` om die tekst te overschrijven, in lijn met de bestaande `uploadedLabel`
+  - De aankondiging bevat altijd de volledige bestandsnaam inclusief extensie. In een `FileList` met meerdere uploads is dat het enige dat de melding koppelt aan het juiste bestand
+  - De tekst blijft staan zolang de error-state actief is, anders dan bij `uploaded` (2 seconden). Een fout gaat niet vanzelf over en vraagt actie van de gebruiker. Bij terugkeer naar `default` of `loading` maakt het component de regio leeg
+  - `loading` kondigt bewust niets aan: de Spinner heeft al een visueel verborgen label en het startmoment is een gebruikersactie
+
+#### Documentation
+
+- **De Accessibility-sectie beschrijft nu de volledige inhoud van de aria-live regio** (issue [#316](https://github.com/jeffreylauwers/design-system-starter-kit/issues/316)): nieuw kopje "De aria-live regio" met per state de exacte tekst, de onderbouwing van de woordkeuze, de levensduur van de melding en hoe je de teksten overschrijft. De htmlTemplate in de stories rendert de regio niet langer altijd leeg, maar toont per state dezelfde tekst als de React-laag, zodat de HTML/CSS-consument ziet wat hij zelf moet schrijven.
+
 ### IconList
 
 #### Added

--- a/packages/components-react/src/File/File.test.tsx
+++ b/packages/components-react/src/File/File.test.tsx
@@ -283,6 +283,66 @@ describe('File', () => {
       );
       expect(queryByText('Upload mislukt.')).not.toBeInTheDocument();
     });
+
+    it('vult de aria-live regio met bestandsnaam en errorMessage', () => {
+      const { container } = render(
+        <File
+          fileName="document.pdf"
+          status="error"
+          errorMessage="Upload mislukt. Probeer het opnieuw."
+        />
+      );
+      const liveRegion = container.querySelector('[aria-live="polite"]');
+      expect(liveRegion).toHaveTextContent(
+        'document.pdf: Upload mislukt. Probeer het opnieuw.'
+      );
+    });
+
+    it('valt terug op een generieke tekst zonder errorMessage', () => {
+      const { container } = render(
+        <File fileName="document.pdf" status="error" />
+      );
+      const liveRegion = container.querySelector('[aria-live="polite"]');
+      expect(liveRegion).toHaveTextContent('document.pdf uploaden mislukt');
+    });
+
+    it('gebruikt een aangepaste errorLabel', () => {
+      const { container } = render(
+        <File
+          fileName="document.pdf"
+          status="error"
+          errorMessage="Upload mislukt. Probeer het opnieuw."
+          errorLabel="Uploaden van document.pdf is mislukt"
+        />
+      );
+      const liveRegion = container.querySelector('[aria-live="polite"]');
+      expect(liveRegion).toHaveTextContent(
+        'Uploaden van document.pdf is mislukt'
+      );
+    });
+
+    it('maakt de aria-live regio leeg wanneer de status weer default wordt', () => {
+      const { container, rerender } = render(
+        <File
+          fileName="document.pdf"
+          status="error"
+          errorMessage="Upload mislukt."
+        />
+      );
+      const liveRegion = container.querySelector('[aria-live="polite"]');
+      expect(liveRegion).toHaveTextContent('document.pdf: Upload mislukt.');
+
+      rerender(<File fileName="document.pdf" status="default" />);
+      expect(liveRegion).toHaveTextContent('');
+    });
+
+    it('kondigt niets aan bij de loading state', () => {
+      const { container } = render(
+        <File fileName="document.pdf" status="loading" />
+      );
+      const liveRegion = container.querySelector('[aria-live="polite"]');
+      expect(liveRegion).toHaveTextContent('');
+    });
   });
 
   describe('verwijder-knop', () => {

--- a/packages/components-react/src/File/File.tsx
+++ b/packages/components-react/src/File/File.tsx
@@ -76,6 +76,13 @@ export interface FileProps extends React.HTMLAttributes<HTMLDivElement> {
    * @default "{fileName} succesvol geüpload"
    */
   uploadedLabel?: string;
+
+  /**
+   * Tekst voor de aria-live regio bij de error state.
+   * Standaard "{fileName}: {errorMessage}", of "{fileName} uploaden mislukt"
+   * wanneer er geen errorMessage is.
+   */
+  errorLabel?: string;
 }
 
 /**
@@ -131,6 +138,7 @@ export const File = React.forwardRef<HTMLDivElement, FileProps>(
       previewSrc,
       loadingLabel = 'Bezig met uploaden',
       uploadedLabel,
+      errorLabel,
       ...props
     },
     ref
@@ -144,21 +152,37 @@ export const File = React.forwardRef<HTMLDivElement, FileProps>(
       setCurrentStatus(status);
     }, [status]);
 
-    // Bij uploaded: vul aria-live regio en keer na 2s terug naar default
+    // Vul de aria-live regio bij een eindstatus van de upload.
+    // De tekst wordt pas ná de eerste render gezet, zodat screenreaders de
+    // wijziging in de regio waarnemen en aankondigen.
     React.useEffect(() => {
-      if (currentStatus !== 'uploaded') return;
+      // Uploaded: kondig succes aan en keer na 2s terug naar default
+      if (currentStatus === 'uploaded') {
+        setLiveText(uploadedLabel ?? `${fileName} succesvol geüpload`);
 
-      const resolvedUploadedLabel =
-        uploadedLabel ?? `${fileName} succesvol geüpload`;
-      setLiveText(resolvedUploadedLabel);
+        const timer = setTimeout(() => {
+          setCurrentStatus('default');
+          setLiveText('');
+        }, 2000);
 
-      const timer = setTimeout(() => {
-        setCurrentStatus('default');
-        setLiveText('');
-      }, 2000);
+        return () => clearTimeout(timer);
+      }
 
-      return () => clearTimeout(timer);
-    }, [currentStatus, fileName, uploadedLabel]);
+      // Error: kondig de mislukking aan, inclusief de reden wanneer bekend.
+      // De tekst blijft staan zolang de error-state actief is.
+      if (currentStatus === 'error') {
+        setLiveText(
+          errorLabel ??
+            (errorMessage
+              ? `${fileName}: ${errorMessage}`
+              : `${fileName} uploaden mislukt`)
+        );
+        return;
+      }
+
+      // Default en loading: geen aankondiging
+      setLiveText('');
+    }, [currentStatus, fileName, uploadedLabel, errorLabel, errorMessage]);
 
     // Bestandsnaam zonder extensie voor visuele weergave
     const fileNameWithoutExt = React.useMemo(() => {

--- a/packages/components-react/src/File/File.tsx
+++ b/packages/components-react/src/File/File.tsx
@@ -177,11 +177,12 @@ export const File = React.forwardRef<HTMLDivElement, FileProps>(
               ? `${fileName}: ${errorMessage}`
               : `${fileName} uploaden mislukt`)
         );
-        return;
+        return undefined;
       }
 
       // Default en loading: geen aankondiging
       setLiveText('');
+      return undefined;
     }, [currentStatus, fileName, uploadedLabel, errorLabel, errorMessage]);
 
     // Bestandsnaam zonder extensie voor visuele weergave

--- a/packages/storybook/src/File.docs.md
+++ b/packages/storybook/src/File.docs.md
@@ -50,7 +50,7 @@ De verwijderknop bevat altijd de volledige bestandsnaam als visueel verborgen te
 | `default`  | Bestand is geselecteerd of eerder geüpload. Toont naam als link (indien `href` aanwezig) en verwijderknop.                        |
 | `loading`  | Upload is in uitvoering. Toont naam als tekst (geen link), Spinner in actions.                                                    |
 | `uploaded` | Upload geslaagd. Toont naam als link, check-icoon in actions, `aria-live` aankondiging. Keert na 2 seconden terug naar `default`. |
-| `error`    | Upload mislukt. Toont rode randkleur, foutmelding onder de meta, verwijderknop.                                                   |
+| `error`    | Upload mislukt. Toont rode randkleur, foutmelding onder de meta, verwijderknop, `aria-live` aankondiging.                         |
 
 ### Interactieve variant
 
@@ -148,6 +148,57 @@ Gebruik `FileList` als wrapper wanneer je meerdere `File` componenten toont. De 
 - `dsn-file__media` heeft altijd `aria-hidden="true"`: het icoon en de preview zijn decoratief.
 - `<img class="dsn-file__preview" alt="">` heeft een lege `alt` — de media-container is toch `aria-hidden`.
 - De verwijderknop bevat de bestandsnaam inclusief extensie als visueel verborgen tekst. Gebruik nooit `aria-label`.
-- Elk `File` component bevat een visueel verborgen `<span aria-live="polite" aria-atomic="true">`. Bij de `uploaded` state wordt deze gevuld met de bevestigingstekst; bij terugkeer naar `default` wordt hij leeggemaakt.
+- Elk `File` component bevat een visueel verborgen `<span aria-live="polite" aria-atomic="true">`. Zie het kopje "De aria-live regio" hieronder voor wat daar precies in komt.
 - In de interactieve variant (stretched link) is de bestandsnaam het enige focuspunt. Bij de download-variant heeft de download-link `aria-hidden="true"` en `tabindex="-1"` — de bestandsnaam is het primaire focuspunt.
 - `FileList` rendert `<ul role="list">` met `<li>` wrappers om lijstsemantiek te bewaren bij CSS-resets.
+
+### De aria-live regio
+
+Een upload verandert van status zonder dat de gebruiker iets doet: de statuswissel is puur visueel (spinner, vinkje, rode rand). Screenreadergebruikers krijgen die wissel niet mee. Daarom bevat elk `File` component een altijd aanwezige, visueel verborgen live region die de uitkomst van de upload uitspreekt.
+
+```html
+<span class="dsn-visually-hidden" aria-live="polite" aria-atomic="true"></span>
+```
+
+De regio staat altijd in de DOM, ook als hij leeg is. Dat is een voorwaarde: een live region die pas bij de statuswissel wordt toegevoegd, wordt door de meeste screenreaders genegeerd. Alleen de inhoud verandert.
+
+#### Wat komt er in per state
+
+| State      | Inhoud van de regio                                                                              | Voorbeeld                                            |
+| ---------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| `default`  | Leeg                                                                                             |                                                      |
+| `loading`  | Leeg                                                                                             |                                                      |
+| `uploaded` | `{fileName} succesvol geüpload`                                                                  | "document.pdf succesvol geüpload"                    |
+| `error`    | `{fileName}: {errorMessage}`, of `{fileName} uploaden mislukt` wanneer er geen `errorMessage` is | "document.pdf: Upload mislukt. Probeer het opnieuw." |
+
+Drie principes achter deze teksten:
+
+1. **Altijd de volledige bestandsnaam, inclusief extensie.** Visueel wordt de extensie afgekapt, maar in een lijst met meerdere bestanden is de naam het enige dat de aankondiging koppelt aan het juiste bestand. "Upload mislukt" alleen is onbruikbaar bij drie tegelijk uploadende bestanden.
+2. **Bij een fout ook de reden.** De zichtbare foutmelding staat in een gewone `<p>` en wordt dus niet automatisch voorgelezen op het moment dat de fout ontstaat. De live region herhaalt hem daarom, zodat de gebruiker meteen weet wat er mis ging en niet eerst terug hoeft te navigeren.
+3. **Geen aankondiging tijdens `loading`.** De Spinner heeft al een visueel verborgen label ("Bezig met uploaden") en het startmoment van een upload is een gebruikersactie: die verrast niemand. Elke tussenstap aankondigen maakt de regio juist onbruikbaar bij meerdere bestanden.
+
+#### Levensduur van de tekst
+
+Bij `uploaded` blijft de tekst 2 seconden staan, waarna het component terugkeert naar `default` en de regio wordt leeggemaakt. Bij `error` blijft de tekst staan zolang de error-state actief is: de fout is niet vanzelf voorbij en de gebruiker moet actie ondernemen. Zodra de status weer `default` of `loading` wordt (bijvoorbeeld na opnieuw proberen), maakt het component de regio leeg.
+
+Gevolg van die keuze: in de error-state staat de foutmelding twee keer in de accessibility tree, één keer zichtbaar en één keer in de live region. Dat is bewust. De aankondiging op het juiste moment weegt zwaarder dan de dubbeling bij lineair doorlezen. Wil je die dubbeling niet, geef dan via `errorLabel` een kortere tekst mee.
+
+#### Teksten overschrijven
+
+| Prop            | State      | Standaardwaarde                                                      |
+| --------------- | ---------- | -------------------------------------------------------------------- |
+| `uploadedLabel` | `uploaded` | `{fileName} succesvol geüpload`                                      |
+| `errorLabel`    | `error`    | `{fileName}: {errorMessage}`, of `{fileName} uploaden mislukt`       |
+| `loadingLabel`  | `loading`  | `Bezig met uploaden` (label van de Spinner, niet van de live region) |
+
+```tsx
+<File
+  fileName="jaarrekening-2024.pdf"
+  fileType="PDF"
+  status="error"
+  errorMessage="Het bestand is groter dan 10 MB."
+  errorLabel="jaarrekening-2024.pdf is te groot en niet geüpload"
+/>
+```
+
+Bij de HTML/CSS-laag regel je dit zelf: schrijf dezelfde tekst in de live region op het moment dat je de status-klasse (`dsn-file--uploaded`, `dsn-file--error`) op de root zet, en maak hem leeg als je die klasse weer verwijdert.

--- a/packages/storybook/src/File.stories.tsx
+++ b/packages/storybook/src/File.stories.tsx
@@ -92,6 +92,18 @@ const meta: Meta<typeof File> = {
 
         const actionsContent = spinnerEl || checkEl || deleteEl || ctaEl || '';
 
+        // aria-live regio: alleen gevuld bij een eindstatus van de upload
+        let liveText = '';
+        if (isUploaded) {
+          liveText = args.uploadedLabel ?? `${fileName} succesvol geüpload`;
+        } else if (isError) {
+          liveText =
+            args.errorLabel ??
+            (args.errorMessage
+              ? `${fileName}: ${args.errorMessage}`
+              : `${fileName} uploaden mislukt`);
+        }
+
         const mediaEl = args.previewSrc
           ? `<img class="dsn-file__preview" src="${args.previewSrc}" alt="" />`
           : `<svg class="dsn-icon" aria-hidden="true"><!-- ${args.mediaType === 'image' ? 'photo' : 'file-description'}.svg --></svg>`;
@@ -107,7 +119,7 @@ const meta: Meta<typeof File> = {
   <div class="dsn-file__actions">
     ${actionsContent}
   </div>
-  <span class="dsn-visually-hidden" aria-live="polite" aria-atomic="true"></span>
+  <span class="dsn-visually-hidden" aria-live="polite" aria-atomic="true">${liveText}</span>
 </div>`;
       },
     },


### PR DESCRIPTION
Closes #316

## Aanleiding

Het issue vroeg om documentatie: beschrijf bij "Accessibility" wat er in de `aria-live` region komt bij succes en bij mislukken. Bij het uitzoeken bleek er onder die vraag een echt gat te zitten.

De regio werd **alleen** gevuld bij `status="uploaded"`. Ging een upload mis, dan verscheen de foutmelding uitsluitend visueel, in een gewone `<p>` (`FormFieldErrorMessage`) die niet automatisch wordt aangekondigd. Screenreadergebruikers hoorden succes wel en falen niet. Puur documenteren had dus een gat vastgelegd in plaats van de user story opgelost. Gerelateerd succescriterium: [WCAG 4.1.3 Statusberichten](https://www.w3.org/WAI/WCAG22/quickref/#status-messages).

## Wijzigingen

**Component**

- `status="error"` vult de bestaande `aria-live="polite"` regio met `{fileName}: {errorMessage}`, of `{fileName} uploaden mislukt` wanneer er geen `errorMessage` is meegegeven
- Nieuwe prop `errorLabel` om die tekst te overschrijven, in lijn met de bestaande `uploadedLabel`
- De tekst wordt gezet in een effect, dus ná de eerste render. Zo neemt de screenreader een wijziging in de regio waar in plaats van tekst die er al stond
- De tekst blijft staan zolang de error-state actief is, anders dan bij `uploaded` (2 seconden). Een fout gaat niet vanzelf over en vraagt actie. Bij terugkeer naar `default` of `loading` wordt de regio leeggemaakt
- `loading` kondigt bewust niets aan: de Spinner heeft al een visueel verborgen label en het startmoment is een gebruikersactie

**Documentatie**

- Nieuw kopje "De aria-live regio" onder Accessibility met een tabel per state (exacte tekst plus voorbeeld), de onderbouwing van de woordkeuze, de levensduur van de melding en een tabel met de overschrijfbare props
- Expliciet vastgelegd dat de foutmelding in de error-state twee keer in de accessibility tree staat (zichtbaar plus live region) en waarom die keuze zo is gemaakt
- De `htmlTemplate` in de stories rendert de regio niet langer altijd leeg, maar toont per state dezelfde tekst als de React-laag. De HTML/CSS-consument ziet nu in het code-tabblad van de Error- en Uploaded-story wat hij zelf moet schrijven
- `docs/03-components.md` en `docs/changelog.md` bijgewerkt

## Overweging: bestandsnaam in de melding

De aankondiging bevat altijd de volledige bestandsnaam inclusief extensie, ook al toont het component de naam visueel zonder extensie. In een `FileList` met meerdere uploads is de naam het enige dat de melding koppelt aan het juiste bestand. "Upload mislukt" alleen is onbruikbaar zodra er drie bestanden tegelijk lopen.

## Tests

5 nieuwe tests bij `status: error` (tekst met en zonder `errorMessage`, `errorLabel`-override, leegmaken bij statuswissel, geen aankondiging bij `loading`).

- `pnpm test`: 1635 tests groen
- `pnpm --filter storybook exec tsc --noEmit`: 0 fouten
- `pnpm lint`: 0 fouten, geen nieuwe warnings

Geverifieerd in Storybook: de Error-story levert `document.pdf: Upload mislukt. Probeer het opnieuw.` in de regio, Loading en (na 2 seconden) Uploaded leveren een lege regio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)