### PR TITLE
feat(Form flow): bestandsupload-patroon met FileInput en File

### DIFF
--- a/docs/07-form-flow-patterns.md
+++ b/docs/07-form-flow-patterns.md
@@ -170,6 +170,74 @@ De breedte van een invulveld communiceert de verwachte invoerlengte. Beschikbare
 
 ---
 
+## Bestanden uploaden
+
+Een uploadstap gebruikt altijd twee componenten. `FileInput` is het kiesmoment, `File` is de terugkoppeling daarna. `FileInput` alleen is niet genoeg: een native `<input type="file">` toont hooguit "3 bestanden gekozen" en zegt niets over wat er daarna met die bestanden gebeurt.
+
+| Component   | Rol                                                                        |
+| ----------- | -------------------------------------------------------------------------- |
+| `FileInput` | Het veld waarmee de gebruiker bestanden kiest                              |
+| `File`      | Toont per bestand de naam, het type, de grootte en de status van de upload |
+| `FileList`  | Wrapper zodra er meer dan één bestand kan zijn                             |
+
+### Voorwaarden vooraf tonen
+
+Zet de eisen (maximale grootte, toegestane bestandstypen) in een `FormFieldDescription` boven het veld, gekoppeld via `aria-describedby`. Wie de eisen vooraf leest, loopt minder vaak tegen een afwijzing aan.
+
+```tsx
+<FormFieldDescription as="div" id="bestand-upload-description">
+  <UnorderedList>
+    <li>Het bestand mag maximaal 10 MB zijn.</li>
+    <li>Toegestane bestandstypen: doc, docx, xlsx, pdf, zip, jpg, png, bmp en gif.</li>
+  </UnorderedList>
+</FormFieldDescription>
+<FileInput
+  id="bestand-upload"
+  aria-describedby="bestand-upload-description"
+  multiple
+/>
+```
+
+### De vier statussen
+
+Elk gekozen bestand doorloopt een eigen cyclus, los van de andere bestanden in de lijst.
+
+| Status     | Wanneer                      | Wat de gebruiker ziet         | Wat er wordt aangekondigd           |
+| ---------- | ---------------------------- | ----------------------------- | ----------------------------------- |
+| `loading`  | Upload loopt                 | Spinner                       | Niets                               |
+| `uploaded` | Upload geslaagd              | Vinkje, 2 seconden lang       | "{bestandsnaam} succesvol geüpload" |
+| `default`  | Bestand staat klaar          | Verwijderknop                 | Niets                               |
+| `error`    | Bestand geweigerd of mislukt | Rode rand plus de foutmelding | Bestandsnaam gevolgd door de reden  |
+
+De aankondigingen komen uit de `aria-live` regio die `File` zelf meebrengt. Zie de Accessibility-sectie van de File-documentatie voor de exacte teksten en hoe je ze overschrijft.
+
+### Controleer bij het kiezen, niet pas bij submit
+
+Grootte en bestandstype zijn direct te controleren zodra de gebruiker een bestand kiest. Wacht daar niet mee tot submit: dan is de gebruiker al doorgelopen naar de volgende velden en moet die terug. Dit is de uitzondering op de regel [valideer bij submit](#wanneer-valideren), die geldt voor invoer die de gebruiker nog aan het typen is.
+
+Een geweigerd bestand verdwijnt niet uit de lijst. Het blijft staan als `File` in de error-status, met de reden eronder, en met een verwijderknop. Zo ziet de gebruiker wat er precies is afgewezen.
+
+Gebruik de vaste foutmeldingsteksten uit [Patronen per inputtype](#patronen-per-inputtype), aangevuld met de reden:
+
+```
+Het gekozen bestand is te groot. Het bestand mag maximaal 10 MB zijn.
+Het gekozen bestandstype is niet toegestaan. Kies een doc, docx, xlsx, pdf, zip, jpg, png, bmp of gif.
+```
+
+### Verwijderen
+
+Geef elk bestand een `onDelete`. De verwijderknop van `File` bevat de volledige bestandsnaam als visueel verborgen tekst, zodat "Verwijder" in een lijst van vijf bestanden alsnog eenduidig is.
+
+### Meerdere bestanden
+
+Zet `multiple` op de `FileInput` en verzamel de keuzes in een `FileList`. Leeg na elke keuze de waarde van de input (`event.target.value = ''`), anders kan de gebruiker hetzelfde bestand niet opnieuw kiezen nadat het is verwijderd.
+
+Juist bij meerdere bestanden verdient de bestandsnaam in de aankondiging zijn plek: "Upload mislukt" zonder naam is onbruikbaar zodra er drie uploads tegelijk lopen.
+
+Zie het template **Form step: Upload** in Storybook voor een werkend voorbeeld met alle statussen, de controle op grootte en type, en het verwijderen van bestanden.
+
+---
+
 ## Validatie
 
 ### Wanneer valideren

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -58,6 +58,21 @@ Nog niet gepubliceerde wijzigingen. Schrijf nieuwe changelog-entries hieronder; 
   - `icon-gap` gebruikt `{dsn.space.text.md}` (8px), de bestaande conventie voor ruimte tussen icoon en tekst, in plaats van de in het issue voorgestelde `{dsn.space.inline.sm}` (4px)
   - `max-inline-size` toegevoegd voor leesbaarheid, consistent met UnorderedList en OrderedList
 
+### Formulierpatronen: bestanden uploaden
+
+#### Added
+
+- **Nieuw patroon "Bestanden uploaden"** (issue [#335](https://github.com/jeffreylauwers/design-system-starter-kit/issues/335)): `FileInput` en `File` kwamen nergens samen. `FileInput` was gedocumenteerd als kiesmoment, `File` als weergave, maar de flow die ze verbindt stond niet beschreven en was nergens te zien. Het template **Form step: Upload** bevatte alleen een `FileInput`: een bestand kiezen leverde geen zichtbaar resultaat op.
+  - Nieuwe sectie in `docs/07-form-flow-patterns.md` (en de kopie in `packages/storybook/src/FormFlowPatterns.docs.md`) met de rolverdeling tussen `FileInput`, `File` en `FileList`, de vier statussen met wat er per status wordt aangekondigd, en het verwijderen van bestanden
+  - Vastgelegd dat grootte en bestandstype bij het kiezen worden gecontroleerd en niet pas bij submit. Dat is de uitzondering op de regel "valideer bij submit", die geldt voor invoer die de gebruiker nog aan het typen is
+  - Een geweigerd bestand verdwijnt niet uit de lijst maar blijft staan in de error-status, met de reden eronder en een verwijderknop
+
+#### Changed
+
+- **Template Form step: Upload doorloopt nu een echte uploadcyclus** (issue [#335](https://github.com/jeffreylauwers/design-system-starter-kit/issues/335)): gekozen bestanden verschijnen in een `FileList` en gaan per bestand door `loading` naar `uploaded`. De controle op grootte (10 MB) en extensie gebruikt de vaste foutmeldingsteksten uit de formulierpatronen. De pagina start in rust: er loopt niets tot de gebruiker een bestand kiest.
+  - Daarmee is ook de tweede helft van issue [#316](https://github.com/jeffreylauwers/design-system-starter-kit/issues/316) afgerond: de `aria-live` aankondigingen van `File` zijn nu met een screenreader te beluisteren. Een live region kondigt alleen aan bij een wijziging van de inhoud, dus de losse component-stories konden dat per definitie niet
+- **`FileInput.docs.md` verwijst niet langer naar `File` als alternatief** maar als tegenhanger: de twee horen in een uploadstap samen. `File.docs.md` verwijst terug naar het patroon en naar het template als plek om de aankondigingen te beluisteren
+
 ### Figma-integratie
 
 #### Added

--- a/packages/storybook/src/File.docs.md
+++ b/packages/storybook/src/File.docs.md
@@ -12,7 +12,7 @@ File ondersteunt vier upload-states (`default`, `loading`, `uploaded`, `error`) 
 
 ## Use when
 
-- De gebruiker een bestand heeft geselecteerd of geüpload binnen een formulier, en feedback nodig heeft over de status.
+- De gebruiker een bestand heeft geselecteerd of geüpload binnen een formulier, en feedback nodig heeft over de status. Gebruik `File` dan samen met `FileInput`, zie het patroon **Bestanden uploaden** onder Patronen/Formulieren en het template **Form step: Upload**.
 - Een eerder geüpload bestand getoond wordt op een controlepagina van een meerstappenformulier, met de mogelijkheid het te bekijken of te downloaden.
 - Een downloadbaar bestand aangeboden wordt op een detailpagina.
 
@@ -202,3 +202,7 @@ Gevolg van die keuze: in de error-state staat de foutmelding twee keer in de acc
 ```
 
 Bij de HTML/CSS-laag regel je dit zelf: schrijf dezelfde tekst in de live region op het moment dat je de status-klasse (`dsn-file--uploaded`, `dsn-file--error`) op de root zet, en maak hem leeg als je die klasse weer verwijdert.
+
+#### Zelf beluisteren
+
+Een live region kondigt alleen aan bij een wijziging van de inhoud, dus de stories hierboven spreken niets uit: die starten al in hun eindtoestand. Wil je de aankondigingen met een screenreader horen, gebruik dan het template **Form step: Upload**. Daar doorloopt elk gekozen bestand een echte cyclus, en levert een bestand groter dan 10 MB of met een niet-toegestane extensie de foutaankondiging op.

--- a/packages/storybook/src/FileInput.docs.md
+++ b/packages/storybook/src/FileInput.docs.md
@@ -18,10 +18,11 @@ De FileInput component biedt een consistent gestyled bestandsinvoerveld. De brow
 ## Don't use when
 
 - Je drag-and-drop functionaliteit nodig hebt: dat vereist een aparte component.
-- Je alleen afbeeldingen wilt tonen of previewen: gebruik dan de `File`-component.
+- Je een al gekozen of geüpload bestand wilt tonen: dat is de rol van de `File`-component. In een uploadstap zijn het geen alternatieven maar een paar, zie hieronder.
 
 ## Best practices
 
+- **Koppel `FileInput` altijd aan `File`.** `FileInput` is het kiesmoment; wat er daarna met het bestand gebeurt (uploaden, geslaagd, geweigerd) toont `File`. Zonder die terugkoppeling ziet de gebruiker hooguit de tekst die de browser zelf naast de knop zet, en hoort een screenreadergebruiker niets over de afloop. Zie het patroon **Bestanden uploaden** onder Patronen/Formulieren, en het template **Form step: Upload**.
 - **Labels zijn verplicht.** Koppel altijd een `<label>` via `htmlFor`, of gebruik `FormFieldLabel` binnen een `FormField`-structuur.
 - **Gebruik `accept` voor filtering.** Beperk het bestandstype via `accept=".pdf,.docx"` om fouten te voorkomen. De browser toont alleen de toegestane bestandstypen in de native kiezer.
 - **Valideer altijd server-side.** `accept` is een hint, geen validatie: gebruikers kunnen het omzeilen.

--- a/packages/storybook/src/FormFlowPatterns.docs.md
+++ b/packages/storybook/src/FormFlowPatterns.docs.md
@@ -170,6 +170,74 @@ De breedte van een invulveld communiceert de verwachte invoerlengte. Beschikbare
 
 ---
 
+## Bestanden uploaden
+
+Een uploadstap gebruikt altijd twee componenten. `FileInput` is het kiesmoment, `File` is de terugkoppeling daarna. `FileInput` alleen is niet genoeg: een native `<input type="file">` toont hooguit "3 bestanden gekozen" en zegt niets over wat er daarna met die bestanden gebeurt.
+
+| Component   | Rol                                                                        |
+| ----------- | -------------------------------------------------------------------------- |
+| `FileInput` | Het veld waarmee de gebruiker bestanden kiest                              |
+| `File`      | Toont per bestand de naam, het type, de grootte en de status van de upload |
+| `FileList`  | Wrapper zodra er meer dan één bestand kan zijn                             |
+
+### Voorwaarden vooraf tonen
+
+Zet de eisen (maximale grootte, toegestane bestandstypen) in een `FormFieldDescription` boven het veld, gekoppeld via `aria-describedby`. Wie de eisen vooraf leest, loopt minder vaak tegen een afwijzing aan.
+
+```tsx
+<FormFieldDescription as="div" id="bestand-upload-description">
+  <UnorderedList>
+    <li>Het bestand mag maximaal 10 MB zijn.</li>
+    <li>Toegestane bestandstypen: doc, docx, xlsx, pdf, zip, jpg, png, bmp en gif.</li>
+  </UnorderedList>
+</FormFieldDescription>
+<FileInput
+  id="bestand-upload"
+  aria-describedby="bestand-upload-description"
+  multiple
+/>
+```
+
+### De vier statussen
+
+Elk gekozen bestand doorloopt een eigen cyclus, los van de andere bestanden in de lijst.
+
+| Status     | Wanneer                      | Wat de gebruiker ziet         | Wat er wordt aangekondigd           |
+| ---------- | ---------------------------- | ----------------------------- | ----------------------------------- |
+| `loading`  | Upload loopt                 | Spinner                       | Niets                               |
+| `uploaded` | Upload geslaagd              | Vinkje, 2 seconden lang       | "{bestandsnaam} succesvol geüpload" |
+| `default`  | Bestand staat klaar          | Verwijderknop                 | Niets                               |
+| `error`    | Bestand geweigerd of mislukt | Rode rand plus de foutmelding | Bestandsnaam gevolgd door de reden  |
+
+De aankondigingen komen uit de `aria-live` regio die `File` zelf meebrengt. Zie de Accessibility-sectie van de File-documentatie voor de exacte teksten en hoe je ze overschrijft.
+
+### Controleer bij het kiezen, niet pas bij submit
+
+Grootte en bestandstype zijn direct te controleren zodra de gebruiker een bestand kiest. Wacht daar niet mee tot submit: dan is de gebruiker al doorgelopen naar de volgende velden en moet die terug. Dit is de uitzondering op de regel [valideer bij submit](#wanneer-valideren), die geldt voor invoer die de gebruiker nog aan het typen is.
+
+Een geweigerd bestand verdwijnt niet uit de lijst. Het blijft staan als `File` in de error-status, met de reden eronder, en met een verwijderknop. Zo ziet de gebruiker wat er precies is afgewezen.
+
+Gebruik de vaste foutmeldingsteksten uit [Patronen per inputtype](#patronen-per-inputtype), aangevuld met de reden:
+
+```
+Het gekozen bestand is te groot. Het bestand mag maximaal 10 MB zijn.
+Het gekozen bestandstype is niet toegestaan. Kies een doc, docx, xlsx, pdf, zip, jpg, png, bmp of gif.
+```
+
+### Verwijderen
+
+Geef elk bestand een `onDelete`. De verwijderknop van `File` bevat de volledige bestandsnaam als visueel verborgen tekst, zodat "Verwijder" in een lijst van vijf bestanden alsnog eenduidig is.
+
+### Meerdere bestanden
+
+Zet `multiple` op de `FileInput` en verzamel de keuzes in een `FileList`. Leeg na elke keuze de waarde van de input (`event.target.value = ''`), anders kan de gebruiker hetzelfde bestand niet opnieuw kiezen nadat het is verwijderd.
+
+Juist bij meerdere bestanden verdient de bestandsnaam in de aankondiging zijn plek: "Upload mislukt" zonder naam is onbruikbaar zodra er drie uploads tegelijk lopen.
+
+Zie het template **Form step: Upload** in Storybook voor een werkend voorbeeld met alle statussen, de controle op grootte en type, en het verwijderen van bestanden.
+
+---
+
 ## Validatie
 
 ### Wanneer valideren

--- a/packages/storybook/src/templates/FormStepUploadPage.stories.tsx
+++ b/packages/storybook/src/templates/FormStepUploadPage.stories.tsx
@@ -5,7 +5,9 @@ import {
   Body,
   Button,
   EmailInput,
+  File,
   FileInput,
+  FileList,
   FormField,
   FormFieldDescription,
   FormFieldLabel,
@@ -44,6 +46,99 @@ import {
 const mainStyle: React.CSSProperties = {
   paddingBlock: 'var(--dsn-space-block-6xl)',
 };
+
+// =============================================================================
+// UPLOAD-REGELS
+// =============================================================================
+
+/** Maximale bestandsgrootte, gelijk aan de voorwaarde die op de pagina staat. */
+const MAX_BYTES = 10 * 1024 * 1024;
+
+/** Toegestane extensies, gelijk aan de voorwaarde die op de pagina staat. */
+const TOEGESTANE_EXTENSIES = [
+  'doc',
+  'docx',
+  'xlsx',
+  'pdf',
+  'zip',
+  'jpg',
+  'png',
+  'bmp',
+  'gif',
+];
+
+/**
+ * Duur van de gesimuleerde upload. Lang genoeg om de loading-state waar te
+ * nemen, kort genoeg om niet te vervelen bij het doorlopen van de flow.
+ */
+const UPLOAD_DUUR_MS = 1500;
+
+type UploadStatus = 'default' | 'loading' | 'uploaded' | 'error';
+
+interface GekozenBestand {
+  id: number;
+  /** Volledige bestandsnaam inclusief extensie. */
+  naam: string;
+  /** Extensie in hoofdletters: "PDF". */
+  type: string;
+  /** Geformatteerde grootte: "1,2 MB". */
+  grootte: string;
+  status: UploadStatus;
+  foutmelding?: string;
+}
+
+function extensieVan(bestandsnaam: string): string {
+  const laatstePunt = bestandsnaam.lastIndexOf('.');
+  return laatstePunt > 0
+    ? bestandsnaam.slice(laatstePunt + 1).toLowerCase()
+    : '';
+}
+
+function formatteerGrootte(bytes: number): string {
+  const eenheden = ['B', 'KB', 'MB', 'GB'];
+  let waarde = bytes;
+  let index = 0;
+  while (waarde >= 1024 && index < eenheden.length - 1) {
+    waarde /= 1024;
+    index += 1;
+  }
+  const getal = new Intl.NumberFormat('nl-NL', {
+    maximumFractionDigits: index === 0 ? 0 : 1,
+  }).format(waarde);
+  return `${getal} ${eenheden[index]}`;
+}
+
+/**
+ * Beoordeelt een gekozen bestand tegen de voorwaarden die zichtbaar op de
+ * pagina staan. Foutmeldingsteksten volgen docs/07-form-flow-patterns.md.
+ */
+function beoordeel(
+  bestandsnaam: string,
+  bytes: number
+): {
+  status: UploadStatus;
+  foutmelding?: string;
+} {
+  const extensie = extensieVan(bestandsnaam);
+
+  if (!TOEGESTANE_EXTENSIES.includes(extensie)) {
+    return {
+      status: 'error',
+      foutmelding:
+        'Het gekozen bestandstype is niet toegestaan. Kies een doc, docx, xlsx, pdf, zip, jpg, png, bmp of gif.',
+    };
+  }
+
+  if (bytes > MAX_BYTES) {
+    return {
+      status: 'error',
+      foutmelding:
+        'Het gekozen bestand is te groot. Het bestand mag maximaal 10 MB zijn.',
+    };
+  }
+
+  return { status: 'loading' };
+}
 
 // =============================================================================
 // HELPER COMPONENTS
@@ -110,6 +205,56 @@ function FormModals({
 
 function UploadPage() {
   const [activeModal, setActiveModal] = React.useState<ActiveModal>(null);
+  const [bestanden, setBestanden] = React.useState<GekozenBestand[]>([]);
+  const volgendeId = React.useRef(0);
+  const timers = React.useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  // Ruim lopende upload-timers op bij unmount
+  React.useEffect(() => {
+    const lopend = timers.current;
+    return () => lopend.forEach(clearTimeout);
+  }, []);
+
+  function handleBestandskeuze(event: React.ChangeEvent<HTMLInputElement>) {
+    const gekozen = Array.from(event.target.files ?? []);
+    if (gekozen.length === 0) return;
+
+    const nieuwe: GekozenBestand[] = gekozen.map((bestand) => {
+      volgendeId.current += 1;
+      const { status, foutmelding } = beoordeel(bestand.name, bestand.size);
+      return {
+        id: volgendeId.current,
+        naam: bestand.name,
+        type: extensieVan(bestand.name).toUpperCase(),
+        grootte: formatteerGrootte(bestand.size),
+        status,
+        foutmelding,
+      };
+    });
+
+    setBestanden((huidig) => [...huidig, ...nieuwe]);
+
+    // Leeg de input, zodat hetzelfde bestand opnieuw gekozen kan worden
+    event.target.value = '';
+
+    // Simuleer de upload voor alles wat door de controle kwam
+    nieuwe
+      .filter((bestand) => bestand.status === 'loading')
+      .forEach((bestand) => {
+        const timer = setTimeout(() => {
+          setBestanden((huidig) =>
+            huidig.map((item) =>
+              item.id === bestand.id ? { ...item, status: 'uploaded' } : item
+            )
+          );
+        }, UPLOAD_DUUR_MS);
+        timers.current.push(timer);
+      });
+  }
+
+  function verwijder(id: number) {
+    setBestanden((huidig) => huidig.filter((bestand) => bestand.id !== id));
+  }
 
   return (
     <Body>
@@ -157,8 +302,30 @@ function UploadPage() {
                         <FileInput
                           id="bestand-upload"
                           aria-describedby="bestand-upload-description"
+                          onChange={handleBestandskeuze}
+                          multiple
                           required
                         />
+
+                        {bestanden.length > 0 && (
+                          <FileList
+                            style={{
+                              marginBlockStart: 'var(--dsn-space-block-lg)',
+                            }}
+                          >
+                            {bestanden.map((bestand) => (
+                              <File
+                                key={bestand.id}
+                                fileName={bestand.naam}
+                                fileType={bestand.type}
+                                fileSize={bestand.grootte}
+                                status={bestand.status}
+                                errorMessage={bestand.foutmelding}
+                                onDelete={() => verwijder(bestand.id)}
+                              />
+                            ))}
+                          </FileList>
+                        )}
                       </div>
 
                       <ActionGroup


### PR DESCRIPTION
Closes #335

## Aanleiding

`FileInput` en `File` kwamen nergens samen. `FileInput` was gedocumenteerd als kiesmoment, `File` als weergave, maar de flow die ze verbindt stond niet beschreven en was nergens te zien:

- `Templates/Form flow/Form step: Upload` bevatte alleen een `FileInput`. Een bestand kiezen leverde geen zichtbaar resultaat op
- `docs/07-form-flow-patterns.md` had geen kopje over bestanden uploaden
- De enige verwijzing tussen de componenten stond bij "Don't use when" in `FileInput.docs.md` en stuurde naar `File` "als je alleen afbeeldingen wilt tonen", wat de werkelijke relatie verhult

## Template

De uploadstap doorloopt nu een echte cyclus. Er wordt niets nagebootst met knoppen: de `FileInput` is een native `<input type="file">`, dus de bestandsnaam en de grootte komen van het bestand dat de gebruiker zelf kiest.

- Gekozen bestanden verschijnen in een `FileList`, elk bestand doorloopt zijn eigen cyclus van `loading` naar `uploaded`
- Grootte (10 MB) en extensie worden gecontroleerd bij het kiezen. Dat zijn precies de voorwaarden die al zichtbaar boven het veld stonden
- Een geweigerd bestand blijft staan in de error-status, met de reden eronder en een verwijderknop
- `multiple` staat aan; de waarde van de input wordt na elke keuze geleegd, zodat hetzelfde bestand opnieuw gekozen kan worden nadat het is verwijderd
- De pagina start in rust: er loopt geen timer tot de gebruiker iets kiest

De foutmeldingsteksten stonden al voorgeschreven in `docs/07-form-flow-patterns.md` onder "Patronen per inputtype", die zijn overgenomen en aangevuld met de reden.

## Waarom dit het testbaarheidsprobleem uit #316 oplost

Een live region kondigt alleen aan bij een *wijziging* van de inhoud. De stories `Uploaded` en `Error` starten al in hun eindtoestand en spreken dus per definitie niets uit. De overgang die de aankondiging veroorzaakt bestaat alleen in een flow. Die is er nu, inclusief twee manieren om het foutpad te bereiken die iedereen kan uitvoeren: een bestand groter dan 10 MB, of een bestand met een niet-toegestane extensie (een `.txt` volstaat).

## Documentatie

- Nieuwe sectie **Bestanden uploaden** in `docs/07-form-flow-patterns.md`, met de kopie in `packages/storybook/src/FormFlowPatterns.docs.md` gelijkgetrokken: de rolverdeling tussen `FileInput`, `File` en `FileList`, de vier statussen met wat er per status wordt aangekondigd, het verwijderen, en de reden om bij het kiezen te controleren in plaats van bij submit
- `FileInput.docs.md`: de misleidende regel bij "Don't use when" is gecorrigeerd, en er is een best practice bijgekomen die de koppeling met `File` benoemt
- `File.docs.md`: verwijst terug naar het patroon, en het kopje "De aria-live regio" wijst het template aan als plek om de aankondigingen te beluisteren

## Geverifieerd in de browser

Drie bestanden tegelijk aangeboden via de echte `change`-event van de input:

| Bestand | Uitkomst |
| --- | --- |
| `jaarrekening-2024.pdf` (1,2 MB) | `loading` naar `uploaded` naar `default` |
| `notities.txt` (2 KB) | `error`, "Het gekozen bestandstype is niet toegestaan. ..." |
| `scan-groot.pdf` (11 MB) | `error`, "Het gekozen bestand is te groot. ..." |

De cyclus van een geldig bestand, gemeten op drie momenten:

| Moment | Status | Zichtbaar | aria-live |
| --- | --- | --- | --- |
| t=0,2s | `loading` | spinner | leeg |
| t=1,7s | `uploaded` | vinkje | "bewijsstuk.pdf succesvol geüpload" |
| t=3,7s | `default` | verwijderknop | leeg |

Verwijderen getest: de knop draagt de volledige bestandsnaam ("Verwijder bewijsstuk.pdf") en haalt het juiste item uit de lijst.

## Kwaliteitscontrole

Volledige CI-keten lokaal gedraaid: `pnpm lint`, `pnpm format:check`, `pnpm type-check`, `pnpm --filter storybook exec tsc --noEmit`, `pnpm build` en `pnpm test` (1635 tests). Allemaal groen.

## Bewust buiten scope

`FormStepAllTypesPage` heeft dezelfde onafgemaakte `FileInput`, maar die pagina toont per formuliertype één control. Een volledige uploadflow daar herhalen zou de opzet van die pagina doorbreken. `KitchenSinkPage` blijft om dezelfde reden ongemoeid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)