### PR TITLE
fix(FormField): koppel description, error en status via aria-describedby

### DIFF
--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1393,7 +1393,7 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 - Natief `<progress>`-element met impliciete `role="progressbar"`, `aria-valuenow`, `aria-valuemin` en `aria-valuemax`
 - `<label>` gekoppeld via `for`/`id`: robuuster dan `aria-label`
 - Percentage automatisch berekend: `Math.round((value / max) * 100)`, boven de balk getoond met `aria-hidden="true"`
-- Optionele `description` onder de balk
+- Optionele `description` onder de balk, gekoppeld aan het `<progress>`-element via `aria-describedby`
 - Cross-browser CSS: `::-webkit-progress-bar/value` (Chrome/Safari) + `::-moz-progress-bar` (Firefox)
 - Pill-vorm via `border-radius: round`, fill-animatie met `prefers-reduced-motion` support
 - `useId()` voor automatisch gegenereerd ID als geen `id` prop meegegeven
@@ -3360,25 +3360,25 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 **Tokens:** `tokens/components/form-field.json`
 
-**Features:** div/label container for single-value inputs (TextInput, EmailInput, Select, etc.). Combines Label, Description, Control, Error, and Status with automatic aria-describedby linking.
+**Features:** div/label container for single-value inputs (TextInput, EmailInput, Select, etc.). Combines Label, Description, Control, Error, and Status. Generates IDs for description/error/status and sets `aria-describedby` on the control by cloning the child element (existing values are preserved). Order: description, error, status.
 
 **Invalid state:** Red left border via `form-field.invalid` tokens
 
-**Props:** `label`, `htmlFor`, `labelSuffix`, `description`, `error`, `status`, `children`
+**Props:** `label`, `htmlFor`, `labelSuffix`, `description`, `error`, `status`, `statusVariant`, `statusLive`, `children`
 
-**Tests:** React (11 tests)
+**Tests:** React (21 tests)
 
 #### FormFieldset
 
 **Tokens:** `tokens/components/form-fieldset.json`
 
-**Features:** fieldset/legend container for group controls (CheckboxGroup, RadioGroup, DateInputGroup). Combines FormFieldLegend, FormFieldDescription, FormFieldErrorMessage, and the group control.
+**Features:** fieldset/legend container for group controls (CheckboxGroup, RadioGroup, DateInputGroup). Combines FormFieldLegend, FormFieldDescription, FormFieldErrorMessage, and the group control. Generates IDs for description/error/status and sets `aria-describedby` on the `<fieldset>` itself: a group has no single control to hang the association on.
 
 **Invalid state:** Red left border when `error` prop is set (same as FormField)
 
-**Props:** `legend`, `hideLegend`, `description`, `error`, `status`, `children`
+**Props:** `legend`, `legendSuffix`, `description`, `error`, `status`, `statusVariant`, `statusLive`, `id`, `children`
 
-**Tests:** React (9 tests)
+**Tests:** React (12 tests)
 
 #### FormFieldLabel
 
@@ -3394,31 +3394,31 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 **Tokens:** `tokens/components/form-field-description.json`
 
-**Features:** Help text for form fields
+**Features:** Help text for form fields. Needs an `id` plus `aria-describedby` on the control; FormField and FormFieldset do this for you.
 
-**Props:** `id`, `children`
+**Props:** `as`, `id`, `children`
 
-**Tests:** React (7 tests)
+**Tests:** React (9 tests)
 
 #### FormFieldErrorMessage
 
 **Tokens:** `tokens/components/form-field-error-message.json`
 
-**Features:** Validation error messages
+**Features:** Validation error messages. Needs an `id` plus `aria-describedby` on the control; FormField and FormFieldset do this for you.
 
-**Props:** `id`, `children`
+**Props:** `id`, `showIcon`, `children`
 
-**Tests:** React (7 tests)
+**Tests:** React (11 tests)
 
 #### FormFieldStatus
 
 **Tokens:** `tokens/components/form-field-status.json`
 
-**Features:** Status messages (e.g., character count)
+**Features:** Status messages (e.g., character count). With `live` the message becomes an `aria-live="polite"` region, for status that changes during interaction.
 
-**Props:** `id`, `children`
+**Props:** `id`, `variant`, `showIcon`, `live`, `children`
 
-**Tests:** React (7 tests)
+**Tests:** React (11 tests)
 
 ### Shared Form Control Tokens
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,6 +46,42 @@ Nog niet gepubliceerde wijzigingen. Schrijf nieuwe changelog-entries hieronder; 
 
 - **De Accessibility-sectie beschrijft nu de volledige inhoud van de aria-live regio** (issue [#316](https://github.com/jeffreylauwers/design-system-starter-kit/issues/316)): nieuw kopje "De aria-live regio" met per state de exacte tekst, de onderbouwing van de woordkeuze, de levensduur van de melding en hoe je de teksten overschrijft. De htmlTemplate in de stories rendert de regio niet langer altijd leeg, maar toont per state dezelfde tekst als de React-laag, zodat de HTML/CSS-consument ziet wat hij zelf moet schrijven.
 
+### FormField, FormFieldset, FormFieldStatus & ProgressBar
+
+#### Fixed
+
+- **Description, error en status zijn nu gekoppeld via `aria-describedby`** (issue [#317](https://github.com/jeffreylauwers/design-system-starter-kit/issues/317)): `FormField` genereerde de ID's `{htmlFor}-description`, `{htmlFor}-error` en `{htmlFor}-status`, zette ze op de teksten, en gebruikte ze vervolgens nergens. De control kreeg geen `aria-describedby`, dus een screenreadergebruiker kreeg de hulptekst en de foutmelding niet te horen bij het veld. `FormFieldset` was er slechter aan toe: daar werden de ID's niet eens gegenereerd. Gerelateerde succescriteria: [WCAG 1.3.1 Info en relaties](https://www.w3.org/WAI/WCAG22/quickref/#info-and-relationships) en [WCAG 3.3.2 Labels of instructies](https://www.w3.org/WAI/WCAG22/quickref/#labels-or-instructions).
+  - `FormField` kloont het child-element en zet `aria-describedby` in de volgorde description, error, status. Dat is dezelfde volgorde als de teksten visueel staan, zodat oog en screenreader dezelfde route lopen
+  - Een `aria-describedby` die de consument zelf op de control heeft gezet blijft behouden en wordt achteraan toegevoegd; dubbele ID's worden verwijderd
+  - Geef één element als child mee dat zijn props doorgeeft aan het DOM-element. Bij een fragment of meerdere children blijft de control ongewijzigd en zet je het attribuut zelf. Alle inputcomponenten in dit systeem spreiden `...props` door, dus die werken zonder aanpassing
+  - `FormField` werkt nu ook zonder `htmlFor`: de ID's vallen dan terug op `useId()`. De koppeling van de tekst werkt dan wel, die van het label niet, dus `htmlFor` blijft de aanbevolen route
+  - `FormFieldset` genereert de ID's en zet `aria-describedby` op het `<fieldset>` zelf. Bij een groep is dat de juiste plek: er is geen enkele control om de koppeling aan te hangen, en de beschrijving geldt voor de hele groep. Nieuwe optionele `id`-prop als basis voor de gegenereerde ID's
+  - `ProgressBar` had dezelfde fout: de `description` stond als losse `<p>` zonder ID onder de balk. Die krijgt nu een ID en is via `aria-describedby` aan het `<progress>`-element gekoppeld
+  - Geen breaking change: bestaande React-code blijft werken en krijgt de koppeling er vanzelf bij. Voor de HTML/CSS-laag wél iets te doen: wie de markup met de hand schrijft, zet nu zelf de ID's op description, error en status en het `aria-describedby` op de control
+
+#### Added
+
+- **`live`-prop op `FormFieldStatus`, `statusLive` op `FormField` en `FormFieldset`** (issue [#317](https://github.com/jeffreylauwers/design-system-starter-kit/issues/317)): een status die tijdens interactie verandert, zoals een character counter, werd nergens aangekondigd. `aria-describedby` alleen is daarvoor niet genoeg: dat wordt voorgelezen bij het betreden van het veld, niet bij elke wijziging. Gerelateerd succescriterium: [WCAG 4.1.3 Statusberichten](https://www.w3.org/WAI/WCAG22/quickref/#status-messages).
+  - Met `live` rendert `FormFieldStatus` `aria-live="polite"` en `aria-atomic="true"`, zodat de nieuwe tekst als geheel wordt aangekondigd in plaats van alleen het gewijzigde stuk
+  - Bewust opt-in en standaard uit: een status die niet verandert zou als live region zowel via `aria-describedby` als via de live region worden voorgelezen
+  - Nieuwe story "Live status" bij FormField met een werkende character counter, en "Live region" bij FormFieldStatus
+
+#### Documentation
+
+- **De onterechte belofte over automatische koppeling is gecorrigeerd** (issue [#317](https://github.com/jeffreylauwers/design-system-starter-kit/issues/317)): op vijf plekken stond dat FormField de koppeling al automatisch regelde, terwijl dat niet gebeurde. Dat is de reden dat de fout lang onopgemerkt bleef: wie de docs las, had geen aanleiding om het na te meten.
+  - Gecorrigeerd in `FormField.docs.md` (drie plekken), `DateInputGroup.docs.md` en `docs/03-components.md`
+  - `FormField.docs.md` en `FormFieldset.docs.md` tonen nu de gerenderde HTML van het volledige voorbeeld, inclusief de ID's en het `aria-describedby`, zodat de belofte controleerbaar is in plaats van beweerd
+  - De `htmlTemplate` van FormField, FormFieldset, FormFieldStatus en ProgressBar rendert de ID's en `aria-describedby`. De HTML/CSS-tab liet tot nu toe markup zien die de consument letterlijk overnam, inclusief de fout
+  - De props- en testtellingen van FormField, FormFieldset, FormFieldDescription, FormFieldErrorMessage en FormFieldStatus in `docs/03-components.md` klopten niet meer en zijn bijgewerkt. Bij FormFieldset stond een niet-bestaande prop `hideLegend` en ontbrak `legendSuffix`
+
+#### Testing
+
+- **Tests dekken nu de hele koppelketen** (issue [#317](https://github.com/jeffreylauwers/design-system-starter-kit/issues/317)): de bestaande test controleerde alleen dát de description een ID kreeg, nooit dat er iets naar verwijst. Precies de helft van de keten, en de helft waar de fout niet in zat.
+  - `FormField` heeft er 10 tests bij, waaronder de volgorde van de ID's, het behouden van een eigen `aria-describedby`, de fallback zonder `htmlFor` en het geval waarin het child geen enkel element is
+  - `FormFieldset` had helemaal geen testbestand, terwijl `docs/03-components.md` "React (9 tests)" claimde. Nieuw bestand met 12 tests
+  - Nieuwe tests bij `FormFieldStatus` (live region) en `ProgressBar` (koppeling van de description)
+  - De assertions gebruiken `toHaveAccessibleDescription`, dat de `aria-describedby`-keten daadwerkelijk oplost. Een test die alleen het attribuut vergelijkt, zou een verwijzing naar een niet-bestaand ID goedkeuren
+
 ### IconList
 
 #### Added

--- a/packages/components-react/src/FormField/FormField.test.tsx
+++ b/packages/components-react/src/FormField/FormField.test.tsx
@@ -118,4 +118,136 @@ describe('FormField', () => {
       container.querySelector('.dsn-form-field--invalid')
     ).toBeInTheDocument();
   });
+
+  // ===========================================================================
+  // ARIA-DESCRIBEDBY KOPPELING (issue #317)
+  // ===========================================================================
+
+  it('links the description to the control via aria-describedby', () => {
+    render(
+      <FormField label="Test" htmlFor="test" description="Help text">
+        <TextInput id="test" />
+      </FormField>
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', 'test-description');
+    expect(input).toHaveAccessibleDescription('Help text');
+  });
+
+  it('links the error message to the control via aria-describedby', () => {
+    render(
+      <FormField label="Test" htmlFor="test" error="Error message">
+        <TextInput id="test" invalid />
+      </FormField>
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', 'test-error');
+    expect(input).toHaveAccessibleDescription('Error message');
+  });
+
+  it('links the status message to the control via aria-describedby', () => {
+    render(
+      <FormField label="Test" htmlFor="test" status="Status message">
+        <TextInput id="test" />
+      </FormField>
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', 'test-status');
+    expect(input).toHaveAccessibleDescription('Status message');
+  });
+
+  it('links description, error and status in visual order', () => {
+    render(
+      <FormField
+        label="Test"
+        htmlFor="test"
+        description="Help text"
+        error="Error message"
+        status="Status message"
+      >
+        <TextInput id="test" invalid />
+      </FormField>
+    );
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'aria-describedby',
+      'test-description test-error test-status'
+    );
+  });
+
+  it('sets no aria-describedby when there is no extra text', () => {
+    render(
+      <FormField label="Test" htmlFor="test">
+        <TextInput id="test" />
+      </FormField>
+    );
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('preserves an aria-describedby the consumer set on the control', () => {
+    render(
+      <>
+        <FormField label="Test" htmlFor="test" description="Help text">
+          <TextInput id="test" aria-describedby="extern" />
+        </FormField>
+        <p id="extern">Externe uitleg</p>
+      </>
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute(
+      'aria-describedby',
+      'test-description extern'
+    );
+    expect(input).toHaveAccessibleDescription('Help text Externe uitleg');
+  });
+
+  it('still links the description when htmlFor is omitted', () => {
+    render(
+      <FormField label="Test" description="Help text">
+        <TextInput />
+      </FormField>
+    );
+    const input = screen.getByRole('textbox');
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)).toHaveTextContent(
+      'Help text'
+    );
+  });
+
+  it('does not make the status a live region by default', () => {
+    render(
+      <FormField label="Test" htmlFor="test" status="Status message">
+        <TextInput id="test" />
+      </FormField>
+    );
+    expect(screen.getByText('Status message')).not.toHaveAttribute('aria-live');
+  });
+
+  it('makes the status a live region when statusLive is set', () => {
+    render(
+      <FormField label="Test" htmlFor="test" status="1 van 500" statusLive>
+        <TextInput id="test" />
+      </FormField>
+    );
+    expect(screen.getByText('1 van 500')).toHaveAttribute(
+      'aria-live',
+      'polite'
+    );
+  });
+
+  it('renders without crashing when children is not a single element', () => {
+    render(
+      <FormField label="Test" htmlFor="test" description="Help text">
+        <>
+          <TextInput id="test" />
+          <TextInput id="test-2" />
+        </>
+      </FormField>
+    );
+    expect(screen.getAllByRole('textbox')).toHaveLength(2);
+    expect(screen.getByText('Help text')).toHaveAttribute(
+      'id',
+      'test-description'
+    );
+  });
 });

--- a/packages/components-react/src/FormField/FormField.tsx
+++ b/packages/components-react/src/FormField/FormField.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { classNames } from '@dsn-starter-kit/core';
 import { FormFieldLabel } from '../FormFieldLabel';
 import { FormFieldDescription } from '../FormFieldDescription';
 import { FormFieldErrorMessage } from '../FormFieldErrorMessage';
 import { FormFieldStatus, FormFieldStatusVariant } from '../FormFieldStatus';
+import { describeControl } from '../utils/describeControl';
 import './FormField.css';
 
 export interface FormFieldProps {
@@ -13,7 +14,9 @@ export interface FormFieldProps {
   label: string;
 
   /**
-   * The ID of the form control (used for htmlFor/aria-describedby)
+   * The ID of the form control. Used for the label's htmlFor and as the base
+   * for the generated description/error/status IDs. When omitted, the IDs are
+   * generated via useId(), but the label is no longer explicitly linked.
    */
   htmlFor?: string;
 
@@ -44,6 +47,14 @@ export interface FormFieldProps {
   statusVariant?: FormFieldStatusVariant;
 
   /**
+   * Announce status changes to screen readers via an aria-live region.
+   * Only enable this for status text that changes during interaction,
+   * such as a character counter.
+   * @default false
+   */
+  statusLive?: boolean;
+
+  /**
    * Additional CSS class names
    */
   className?: string;
@@ -58,6 +69,11 @@ export interface FormFieldProps {
  * Form Field component
  * Container that combines FormFieldLabel, FormFieldDescription, Control, FormFieldErrorMessage, and FormFieldStatus
  * Uses div/label structure (for fieldset/legend use FormFieldset component)
+ *
+ * Description, error and status are linked to the control via aria-describedby.
+ * FormField clones the child element to add the attribute, so the child must be
+ * a single element that forwards props to its DOM node. An aria-describedby the
+ * consumer already set on the control is preserved.
  *
  * @example
  * ```tsx
@@ -75,11 +91,12 @@ export interface FormFieldProps {
  *   <PasswordInput id="password" invalid />
  * </FormField>
  *
- * // With status (character counter)
+ * // With status (character counter): statusLive announces each change
  * <FormField
  *   label="Bio"
  *   htmlFor="bio"
  *   status="280 van 500 karakters gebruikt"
+ *   statusLive
  * >
  *   <TextArea id="bio" rows={4} />
  * </FormField>
@@ -105,15 +122,26 @@ export const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>(
       error,
       status,
       statusVariant = 'default',
+      statusLive = false,
       className,
       children,
     },
     ref
   ) => {
-    const descriptionId =
-      htmlFor && description ? `${htmlFor}-description` : undefined;
-    const errorId = htmlFor && error ? `${htmlFor}-error` : undefined;
-    const statusId = htmlFor && status ? `${htmlFor}-status` : undefined;
+    const generatedId = useId();
+    const idBase = htmlFor ?? generatedId;
+
+    const descriptionId = description ? `${idBase}-description` : undefined;
+    const errorId = error ? `${idBase}-error` : undefined;
+    const statusId = status ? `${idBase}-status` : undefined;
+
+    // Koppel de extra teksten aan de control zelf. De volgorde volgt de
+    // visuele volgorde, zodat een screenreader dezelfde route loopt als het oog.
+    const control = describeControl(children, [
+      descriptionId,
+      errorId,
+      statusId,
+    ]);
 
     const containerClasses = classNames(
       'dsn-form-field',
@@ -139,10 +167,14 @@ export const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>(
           <FormFieldErrorMessage id={errorId}>{error}</FormFieldErrorMessage>
         )}
 
-        {children}
+        {control}
 
         {status && (
-          <FormFieldStatus id={statusId} variant={statusVariant}>
+          <FormFieldStatus
+            id={statusId}
+            variant={statusVariant}
+            live={statusLive}
+          >
             {status}
           </FormFieldStatus>
         )}

--- a/packages/components-react/src/FormFieldStatus/FormFieldStatus.test.tsx
+++ b/packages/components-react/src/FormFieldStatus/FormFieldStatus.test.tsx
@@ -57,4 +57,18 @@ describe('FormFieldStatus', () => {
     render(<FormFieldStatus>Voldoet aan alle eisen</FormFieldStatus>);
     expect(screen.getByText('Voldoet aan alle eisen')).toBeInTheDocument();
   });
+
+  it('is not a live region by default', () => {
+    render(<FormFieldStatus>Tekst</FormFieldStatus>);
+    const status = screen.getByText('Tekst');
+    expect(status).not.toHaveAttribute('aria-live');
+    expect(status).not.toHaveAttribute('aria-atomic');
+  });
+
+  it('becomes a polite live region when live is set', () => {
+    render(<FormFieldStatus live>Tekst</FormFieldStatus>);
+    const status = screen.getByText('Tekst');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveAttribute('aria-atomic', 'true');
+  });
 });

--- a/packages/components-react/src/FormFieldStatus/FormFieldStatus.tsx
+++ b/packages/components-react/src/FormFieldStatus/FormFieldStatus.tsx
@@ -24,6 +24,15 @@ export interface FormFieldStatusProps extends React.HTMLAttributes<HTMLParagraph
   showIcon?: boolean;
 
   /**
+   * Whether to announce changes to this status via an aria-live region.
+   * Enable this only for status text that changes during interaction, such as
+   * a character counter. A status that never changes should not be a live
+   * region: it would be announced twice.
+   * @default false
+   */
+  live?: boolean;
+
+  /**
    * Status content
    */
   children?: React.ReactNode;
@@ -61,7 +70,14 @@ export const FormFieldStatus = React.forwardRef<
   FormFieldStatusProps
 >(
   (
-    { className, variant = 'default', showIcon = true, children, ...props },
+    {
+      className,
+      variant = 'default',
+      showIcon = true,
+      live = false,
+      children,
+      ...props
+    },
     ref
   ) => {
     const classes = classNames(
@@ -79,7 +95,13 @@ export const FormFieldStatus = React.forwardRef<
     const shouldShowIcon = showIcon && iconName && variant !== 'default';
 
     return (
-      <p ref={ref} className={classes} {...props}>
+      <p
+        ref={ref}
+        className={classes}
+        aria-live={live ? 'polite' : undefined}
+        aria-atomic={live ? true : undefined}
+        {...props}
+      >
         {shouldShowIcon && <Icon name={iconName} aria-hidden="true" />}
         {children}
       </p>

--- a/packages/components-react/src/FormFieldset/FormFieldset.test.tsx
+++ b/packages/components-react/src/FormFieldset/FormFieldset.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FormFieldset } from './FormFieldset';
+import { CheckboxGroup } from '../CheckboxGroup';
+import { CheckboxOption } from '../CheckboxOption';
+
+const renderGroup = () => (
+  <CheckboxGroup>
+    <CheckboxOption label="Sport" value="sport" />
+    <CheckboxOption label="Muziek" value="music" />
+  </CheckboxGroup>
+);
+
+describe('FormFieldset', () => {
+  it('renders as fieldset with a legend', () => {
+    const { container } = render(
+      <FormFieldset legend="Interesses">{renderGroup()}</FormFieldset>
+    );
+    expect(
+      container.querySelector('fieldset.dsn-form-field')
+    ).toBeInTheDocument();
+    const legend = screen.getByText('Interesses');
+    expect(legend.tagName).toBe('LEGEND');
+  });
+
+  it('renders legend with suffix', () => {
+    render(
+      <FormFieldset legend="Interesses" legendSuffix="(niet verplicht)">
+        {renderGroup()}
+      </FormFieldset>
+    );
+    expect(screen.getByText('(niet verplicht)')).toBeInTheDocument();
+  });
+
+  it('renders description, error and status', () => {
+    render(
+      <FormFieldset
+        legend="Interesses"
+        description="Help text"
+        error="Error message"
+        status="Status message"
+      >
+        {renderGroup()}
+      </FormFieldset>
+    );
+    expect(screen.getByText('Help text')).toBeInTheDocument();
+    expect(screen.getByText('Error message')).toBeInTheDocument();
+    expect(screen.getByText('Status message')).toBeInTheDocument();
+  });
+
+  it('adds invalid modifier class when error is present', () => {
+    const { container } = render(
+      <FormFieldset legend="Interesses" error="Error message">
+        {renderGroup()}
+      </FormFieldset>
+    );
+    expect(
+      container.querySelector('.dsn-form-field--invalid')
+    ).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <FormFieldset legend="Interesses" className="custom-class">
+        {renderGroup()}
+      </FormFieldset>
+    );
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('forwards ref to fieldset', () => {
+    const ref = React.createRef<HTMLFieldSetElement>();
+    render(
+      <FormFieldset legend="Interesses" ref={ref}>
+        {renderGroup()}
+      </FormFieldset>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLFieldSetElement);
+  });
+
+  // ===========================================================================
+  // ARIA-DESCRIBEDBY KOPPELING (issue #317)
+  // ===========================================================================
+
+  it('links the description to the fieldset via aria-describedby', () => {
+    render(
+      <FormFieldset legend="Interesses" id="hobbies" description="Help text">
+        {renderGroup()}
+      </FormFieldset>
+    );
+    const fieldset = screen.getByRole('group');
+    expect(fieldset).toHaveAttribute('aria-describedby', 'hobbies-description');
+    expect(fieldset).toHaveAccessibleDescription('Help text');
+  });
+
+  it('links the error message to the fieldset via aria-describedby', () => {
+    render(
+      <FormFieldset legend="Interesses" id="hobbies" error="Error message">
+        {renderGroup()}
+      </FormFieldset>
+    );
+    const fieldset = screen.getByRole('group');
+    expect(fieldset).toHaveAttribute('aria-describedby', 'hobbies-error');
+    expect(fieldset).toHaveAccessibleDescription('Error message');
+  });
+
+  it('links description, error and status in visual order', () => {
+    render(
+      <FormFieldset
+        legend="Interesses"
+        id="hobbies"
+        description="Help text"
+        error="Error message"
+        status="Status message"
+      >
+        {renderGroup()}
+      </FormFieldset>
+    );
+    expect(screen.getByRole('group')).toHaveAttribute(
+      'aria-describedby',
+      'hobbies-description hobbies-error hobbies-status'
+    );
+  });
+
+  it('still links the description when id is omitted', () => {
+    render(
+      <FormFieldset legend="Interesses" description="Help text">
+        {renderGroup()}
+      </FormFieldset>
+    );
+    const fieldset = screen.getByRole('group');
+    const describedBy = fieldset.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)).toHaveTextContent(
+      'Help text'
+    );
+  });
+
+  it('sets no aria-describedby when there is no extra text', () => {
+    render(<FormFieldset legend="Interesses">{renderGroup()}</FormFieldset>);
+    expect(screen.getByRole('group')).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('makes the status a live region when statusLive is set', () => {
+    render(
+      <FormFieldset legend="Interesses" status="1 van 3 gekozen" statusLive>
+        {renderGroup()}
+      </FormFieldset>
+    );
+    expect(screen.getByText('1 van 3 gekozen')).toHaveAttribute(
+      'aria-live',
+      'polite'
+    );
+  });
+});

--- a/packages/components-react/src/FormFieldset/FormFieldset.tsx
+++ b/packages/components-react/src/FormFieldset/FormFieldset.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { classNames } from '@dsn-starter-kit/core';
 import { FormFieldLegend } from '../FormFieldLegend';
 import { FormFieldDescription } from '../FormFieldDescription';
@@ -39,6 +39,19 @@ export interface FormFieldsetProps {
   statusVariant?: FormFieldStatusVariant;
 
   /**
+   * Announce status changes to screen readers via an aria-live region.
+   * Only enable this for status text that changes during interaction.
+   * @default false
+   */
+  statusLive?: boolean;
+
+  /**
+   * Optional ID for the fieldset. Used as the base for the generated
+   * description/error/status IDs. Generated via useId() when omitted.
+   */
+  id?: string;
+
+  /**
    * Additional CSS class names
    */
   className?: string;
@@ -53,6 +66,9 @@ export interface FormFieldsetProps {
  * Form Fieldset component
  * Container that combines FormFieldLegend, FormFieldDescription, Control, FormFieldErrorMessage, and FormFieldStatus
  * Uses fieldset/legend structure for group controls (CheckboxGroup, RadioGroup, DateInputGroup)
+ *
+ * Description, error and status are linked via aria-describedby on the fieldset
+ * itself: a group has no single control to hang the association on.
  *
  * @example
  * ```tsx
@@ -104,11 +120,26 @@ export const FormFieldset = React.forwardRef<
       error,
       status,
       statusVariant = 'default',
+      statusLive = false,
+      id,
       className,
       children,
     },
     ref
   ) => {
+    const generatedId = useId();
+    const idBase = id ?? generatedId;
+
+    const descriptionId = description ? `${idBase}-description` : undefined;
+    const errorId = error ? `${idBase}-error` : undefined;
+    const statusId = status ? `${idBase}-status` : undefined;
+
+    // Bij een groep controls hangt de koppeling aan het fieldset zelf: er is
+    // geen enkele control om hem aan te hangen. De volgorde volgt de visuele
+    // volgorde, zodat een screenreader dezelfde route loopt als het oog.
+    const describedBy =
+      [descriptionId, errorId, statusId].filter(Boolean).join(' ') || undefined;
+
     const containerClasses = classNames(
       'dsn-form-field',
       {
@@ -118,19 +149,34 @@ export const FormFieldset = React.forwardRef<
     );
 
     return (
-      <fieldset ref={ref} className={containerClasses}>
+      <fieldset
+        ref={ref}
+        id={id}
+        className={containerClasses}
+        aria-describedby={describedBy}
+      >
         <FormFieldLegend suffix={legendSuffix}>{legend}</FormFieldLegend>
 
         {description && (
-          <FormFieldDescription>{description}</FormFieldDescription>
+          <FormFieldDescription id={descriptionId}>
+            {description}
+          </FormFieldDescription>
         )}
 
-        {error && <FormFieldErrorMessage>{error}</FormFieldErrorMessage>}
+        {error && (
+          <FormFieldErrorMessage id={errorId}>{error}</FormFieldErrorMessage>
+        )}
 
         {children}
 
         {status && (
-          <FormFieldStatus variant={statusVariant}>{status}</FormFieldStatus>
+          <FormFieldStatus
+            id={statusId}
+            variant={statusVariant}
+            live={statusLive}
+          >
+            {status}
+          </FormFieldStatus>
         )}
       </fieldset>
     );

--- a/packages/components-react/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/components-react/src/ProgressBar/ProgressBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { ProgressBar } from './ProgressBar';
 
 describe('ProgressBar', () => {
@@ -161,5 +161,28 @@ describe('ProgressBar', () => {
     expect(
       container.querySelector('.dsn-progress-bar__percentage')
     ).toBeInTheDocument();
+  });
+
+  it('links the description to the progress element via aria-describedby', () => {
+    const { container } = render(
+      <ProgressBar
+        label="Upload"
+        value={35}
+        id="upload"
+        description="Bestand wordt geupload, even geduld..."
+      />
+    );
+    const progress = container.querySelector('progress');
+    expect(progress).toHaveAttribute('aria-describedby', 'upload-description');
+    expect(
+      screen.getByText('Bestand wordt geupload, even geduld...')
+    ).toHaveAttribute('id', 'upload-description');
+  });
+
+  it('sets no aria-describedby when there is no description', () => {
+    const { container } = render(<ProgressBar label="Upload" value={35} />);
+    expect(container.querySelector('progress')).not.toHaveAttribute(
+      'aria-describedby'
+    );
   });
 });

--- a/packages/components-react/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components-react/src/ProgressBar/ProgressBar.tsx
@@ -78,6 +78,7 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   ) => {
     const generatedId = useId();
     const progressId = id ?? generatedId;
+    const descriptionId = description ? `${progressId}-description` : undefined;
     const percentage = Math.round((value / max) * 100);
 
     return (
@@ -104,11 +105,15 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
           className="dsn-progress-bar__bar"
           value={value}
           max={max}
+          aria-describedby={descriptionId}
         >
           {percentage}%
         </progress>
         {description && (
-          <p className="dsn-paragraph dsn-progress-bar__description">
+          <p
+            id={descriptionId}
+            className="dsn-paragraph dsn-progress-bar__description"
+          >
             {description}
           </p>
         )}

--- a/packages/components-react/src/utils/describeControl.tsx
+++ b/packages/components-react/src/utils/describeControl.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface DescribableProps {
+  'aria-describedby'?: string;
+}
+
+/**
+ * Koppelt extra teksten (description, error, status) aan een form control door
+ * `aria-describedby` op het child-element te zetten.
+ *
+ * Een bestaande `aria-describedby` op de control blijft behouden: de
+ * gegenereerde ID's komen eerst, gevolgd door wat de consument zelf meegaf.
+ * Dubbele ID's worden verwijderd.
+ *
+ * Wanneer er geen ID's zijn, of het child geen React-element is (bijvoorbeeld
+ * een string of een fragment), blijft de control ongewijzigd.
+ */
+export function describeControl(
+  control: React.ReactNode,
+  ids: ReadonlyArray<string | undefined>
+): React.ReactNode {
+  const generated = ids.filter((id): id is string => Boolean(id));
+
+  if (generated.length === 0 || !React.isValidElement(control)) {
+    return control;
+  }
+
+  const element = control as React.ReactElement<DescribableProps>;
+  const existing = element.props['aria-describedby'];
+  const merged = [
+    ...generated,
+    ...(existing ? existing.split(/\s+/).filter(Boolean) : []),
+  ]
+    .filter((id, index, all) => all.indexOf(id) === index)
+    .join(' ');
+
+  return React.cloneElement(element, { 'aria-describedby': merged });
+}

--- a/packages/storybook/src/DateInputGroup.docs.md
+++ b/packages/storybook/src/DateInputGroup.docs.md
@@ -35,7 +35,7 @@ Gebruik `FormFieldset` als wrapper voor een volledig formulierveld met legend, b
 - Elk veld heeft een zichtbaar label ("Dag", "Maand", "Jaar") gekoppeld via `htmlFor`
 - De `id` prop genereert automatisch `{id}-dag`, `{id}-maand` en `{id}-jaar` als input-id's
 - De `invalid` prop zet `aria-invalid="true"` op alle drie de inputs
-- De foutmelding van `FormFieldset` is via `aria-describedby` automatisch gekoppeld aan de fieldset
+- `FormFieldset` genereert een ID voor de foutmelding en koppelt die via `aria-describedby` aan het `<fieldset>`, zodat een screenreader hem meeneemt bij de hele groep
 - De `legend` verbindt de drie velden semantisch voor screenreaders via het `<fieldset>` element
 
 ## States

--- a/packages/storybook/src/FormField.docs.md
+++ b/packages/storybook/src/FormField.docs.md
@@ -4,7 +4,7 @@ Container component dat label, description, error message, form control en statu
 
 ## Doel
 
-De FormField component is een complete form field container die alle onderdelen samenbrengt: FormFieldLabel (met optionele suffix), FormFieldDescription, FormFieldErrorMessage, de form control zelf, en FormFieldStatus. Het zorgt voor correcte volgorde, spacing en koppeling via aria-attributen. De component gebruikt een `<div>` wrapper met `<label>` element en is uitsluitend bedoeld voor enkelvoudige inputs. Voor groep controls (CheckboxGroup, RadioGroup) gebruik je [FormFieldset](/docs/components-formfieldset--docs). FormField handelt automatisch ID's af voor aria-describedby koppelingen.
+De FormField component is een complete form field container die alle onderdelen samenbrengt: FormFieldLabel (met optionele suffix), FormFieldDescription, FormFieldErrorMessage, de form control zelf, en FormFieldStatus. Het zorgt voor correcte volgorde, spacing en koppeling via aria-attributen. De component gebruikt een `<div>` wrapper met `<label>` element en is uitsluitend bedoeld voor enkelvoudige inputs. Voor groep controls (CheckboxGroup, RadioGroup) gebruik je [FormFieldset](/docs/components-formfieldset--docs). FormField genereert de ID's voor description, error en status en zet `aria-describedby` op de control, zodat een screenreader die teksten meeneemt.
 
 > **Codevoorbeeld met context**: De HTML/CSS tab toont een `EmailInput` als representatief child. `FormField` is een wrapper: het form control dat je als child meegeeft bepaalt de daadwerkelijke invoer.
 
@@ -14,7 +14,7 @@ De FormField component is een complete form field container die alle onderdelen 
 
 - Je een complete form field nodig hebt met label en control.
 - Je een consistente form field structuur wilt in je formulieren.
-- Je automatische aria-describedby koppelingen wilt voor accessibility.
+- Je wilt dat description, error en status automatisch via `aria-describedby` aan de control gekoppeld worden.
 
 ## Don't use when
 
@@ -47,6 +47,7 @@ Wanneer er een `error` prop aanwezig is, krijgt het hele FormField een dikke rod
 - **error** - Voor validatie fouten, toon alleen na interactie
 - **status** - Voor realtime feedback (character count, password strength)
 - **statusVariant** - 'default' (subtle), 'positive' (success), 'warning' (caution)
+- **statusLive** - Alleen aanzetten wanneer de statustekst tijdens interactie verandert (character counter). Een statische status als live region wordt dubbel voorgelezen.
 
 ### Timing
 
@@ -79,12 +80,14 @@ Plus de tokens van de sub-componenten:
 
 ## Accessibility
 
-- **htmlFor prop** - Koppelt label aan control via ID
-- **Automatische IDs** - FormField genereert IDs voor description/error/status
-- **aria-describedby** - Form controls krijgen automatisch aria-describedby met description/error/status IDs
+- **htmlFor prop** - Koppelt label aan control via ID. Geef altijd hetzelfde ID mee aan de control zelf.
+- **Automatische IDs** - FormField genereert `{htmlFor}-description`, `{htmlFor}-error` en `{htmlFor}-status` voor de teksten die je meegeeft. Zonder `htmlFor` vallen de ID's terug op `useId()`: de koppeling werkt dan nog steeds, maar het label niet meer.
+- **aria-describedby** - FormField zet `aria-describedby` op de control, in de volgorde description → error → status. Dat is dezelfde volgorde als de teksten visueel staan, zodat oog en screenreader dezelfde route lopen. Een `aria-describedby` die je zelf op de control zet blijft behouden en wordt achteraan toegevoegd.
+- **Enkel element als child** - De koppeling gebeurt door het child-element te klonen. Geef daarom één element mee dat zijn props doorgeeft aan het DOM-element. Bij een fragment of meerdere children kun je `aria-describedby` niet automatisch gezet worden en moet je het zelf zetten.
 - **Logische volgorde** - Screenreaders lezen: label → description → error → control → status
 - **Invalid state** - Zet `invalid` prop op de control zelf, niet op FormField
 - **Required** - Gebruik labelSuffix + aria-required op de control
+- **Dynamische status** - Gebruik `statusLive` voor status die verandert tijdens interactie, zoals een character counter. Zonder die prop hoort een screenreadergebruiker de wijziging niet.
 
 ## Voorbeelden
 
@@ -102,7 +105,41 @@ Plus de tokens van de sub-componenten:
   description="Minimaal 8 tekens"
   error="Te kort"
   status="5 van 8 tekens"
+  statusLive
 >
   <TextInput id="password" type="password" invalid />
 </FormField>
+```
+
+De gerenderde HTML van dat laatste voorbeeld:
+
+```html
+<div class="dsn-form-field dsn-form-field--invalid">
+  <label class="dsn-form-field-label" for="password">
+    Wachtwoord
+    <span class="dsn-form-field-label-suffix">(verplicht)</span>
+  </label>
+  <p class="dsn-form-field-description" id="password-description">
+    Minimaal 8 tekens
+  </p>
+  <p class="dsn-form-field-error-message" id="password-error">
+    <svg class="dsn-icon" aria-hidden="true"><!-- exclamation-circle --></svg>
+    Te kort
+  </p>
+  <input
+    type="password"
+    class="dsn-text-input"
+    id="password"
+    aria-invalid="true"
+    aria-describedby="password-description password-error password-status"
+  />
+  <p
+    class="dsn-form-field-status"
+    id="password-status"
+    aria-live="polite"
+    aria-atomic="true"
+  >
+    5 van 8 tekens
+  </p>
+</div>
 ```

--- a/packages/storybook/src/FormField.stories.tsx
+++ b/packages/storybook/src/FormField.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
   FormField,
@@ -27,23 +28,32 @@ const meta: Meta<typeof FormField> = {
         const cls = ['dsn-form-field', args.error && 'dsn-form-field--invalid']
           .filter(Boolean)
           .join(' ');
-        const forAttr = args.htmlFor ? ` for="${args.htmlFor}"` : '';
+        const id = args.htmlFor || 'field';
         const suffix = args.labelSuffix
           ? `<span class="dsn-form-field-label-suffix">${args.labelSuffix}</span>`
           : '';
+        // De extra teksten krijgen een id en worden via aria-describedby aan de
+        // control gekoppeld, in dezelfde volgorde als ze visueel staan.
+        const describedBy = [
+          args.description && `${id}-description`,
+          args.error && `${id}-error`,
+          args.status && `${id}-status`,
+        ]
+          .filter(Boolean)
+          .join(' ');
         let html = `<div class="${cls}">\n`;
-        html += `  <label class="dsn-form-field-label"${forAttr}>${args.label ?? 'Label'}${suffix}</label>\n`;
+        html += `  <label class="dsn-form-field-label" for="${id}">${args.label ?? 'Label'}${suffix}</label>\n`;
         if (args.description)
-          html += `  <p class="dsn-form-field-description">${args.description}</p>\n`;
+          html += `  <p class="dsn-form-field-description" id="${id}-description">${args.description}</p>\n`;
         if (args.error)
-          html += `  <p class="dsn-form-field-error-message"><!-- exclamation-circle icon -->${args.error}</p>\n`;
-        html += `  <input type="text" class="dsn-text-input"${args.htmlFor ? ` id="${args.htmlFor}"` : ''} />\n`;
+          html += `  <p class="dsn-form-field-error-message" id="${id}-error"><!-- exclamation-circle icon -->${args.error}</p>\n`;
+        html += `  <input\n    type="text"\n    class="dsn-text-input"\n    id="${id}"${args.error ? '\n    aria-invalid="true"' : ''}${describedBy ? `\n    aria-describedby="${describedBy}"` : ''}\n  />\n`;
         if (args.status) {
           const variantCls =
             args.statusVariant && args.statusVariant !== 'default'
               ? ` dsn-form-field-status--${args.statusVariant}`
               : '';
-          html += `  <p class="dsn-form-field-status${variantCls}">${args.status}</p>\n`;
+          html += `  <p class="dsn-form-field-status${variantCls}" id="${id}-status">${args.status}</p>\n`;
         }
         html += `</div>`;
         return html;
@@ -61,6 +71,7 @@ const meta: Meta<typeof FormField> = {
       control: 'select',
       options: ['default', 'positive', 'warning'],
     },
+    statusLive: { control: 'boolean' },
   },
   args: {
     label: TEKST,
@@ -180,6 +191,46 @@ export const AllStates: Story = {
       </div>
     </div>
   ),
+};
+
+// =============================================================================
+// LIVE STATUS
+// =============================================================================
+
+export const LiveStatus: Story = {
+  name: 'Live status',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Een status die tijdens het typen verandert, hoort een live region te zijn. Zet daarvoor `statusLive`. Laat het uit bij een status die niet verandert: die wordt dan dubbel voorgelezen.',
+      },
+    },
+  },
+  render: () => {
+    const MAX = 50;
+    const CharacterCounter = () => {
+      const [waarde, setWaarde] = React.useState('');
+      return (
+        <FormField
+          label={TEKST}
+          htmlFor="live-status"
+          description={TEKST}
+          status={`${waarde.length} van ${MAX} tekens gebruikt`}
+          statusLive
+        >
+          <TextArea
+            id="live-status"
+            rows={3}
+            maxLength={MAX}
+            value={waarde}
+            onChange={(event) => setWaarde(event.target.value)}
+          />
+        </FormField>
+      );
+    };
+    return <CharacterCounter />;
+  },
 };
 
 // =============================================================================

--- a/packages/storybook/src/FormFieldDescription.docs.md
+++ b/packages/storybook/src/FormFieldDescription.docs.md
@@ -26,7 +26,7 @@ De FormFieldDescription component toont aanvullende informatie of instructies vo
 
 - **Houd het kort.** Descriptions moeten bondig zijn (1-2 zinnen meestal).
 - **Wees specifiek.** Geef concrete voorbeelden of requirements ("Minimaal 8 tekens" in plaats van "Kies een sterk wachtwoord").
-- **Gebruik aria-describedby.** Geef de description een `id` en koppel het aan de form control.
+- **Gebruik aria-describedby.** Geef de description een `id` en koppel het aan de form control. Binnen [FormField](/docs/components-formfield--docs) of [FormFieldset](/docs/components-formfieldset--docs) gebeurt dat automatisch: die genereren het ID en zetten `aria-describedby`.
 - **Gebruik `as="div"` voor lijsten.** Als de description een `UnorderedList` of andere block-level elementen bevat, render dan als `<div>` — een `<ul>` is geen geldig kind van een `<p>`.
 - **Niet voor errors.** Gebruik FormFieldErrorMessage voor validatie feedback.
 - **Niet voor status.** Gebruik FormFieldStatus voor success/info/warning feedback.
@@ -46,7 +46,7 @@ De FormFieldDescription component toont aanvullende informatie of instructies vo
 ## Accessibility
 
 - Gebruik `id` attribuut op de description.
-- Koppel de description aan de form control met `aria-describedby`.
+- Koppel de description aan de form control met `aria-describedby`. Gebruik je FormField of FormFieldset, dan is dat al geregeld.
 - Screenreaders lezen de description voor na het label.
 - Descriptions moeten altijd zichtbaar zijn (niet verbergen achter tooltips).
 - Zorg dat kleurcontrast voldoende is (subtiele kleur maar nog leesbaar).

--- a/packages/storybook/src/FormFieldErrorMessage.docs.md
+++ b/packages/storybook/src/FormFieldErrorMessage.docs.md
@@ -38,7 +38,7 @@ De FormFieldErrorMessage component toont validatie foutmeldingen bij form fields
 ### Technisch
 
 - **Icon standaard aan.** Laat het icoon zichtbaar tenzij er een goede reden is (meestal wel).
-- **Gebruik ID + aria-describedby.** Geef de error message een `id` en koppel het aan de form control.
+- **Gebruik ID + aria-describedby.** Geef de error message een `id` en koppel het aan de form control. Binnen [FormField](/docs/components-formfield--docs) of [FormFieldset](/docs/components-formfieldset--docs) gebeurt dat automatisch.
 - **aria-invalid="true".** Zet dit attribuut op de form control zelf.
 - **Meerdere errors.** Gebruik meerdere FormFieldErrorMessage componenten voor verschillende fouten.
 
@@ -58,7 +58,7 @@ De FormFieldErrorMessage component toont validatie foutmeldingen bij form fields
 ## Accessibility
 
 - Gebruik `id` attribuut op de error message.
-- Koppel de error message aan de form control met `aria-describedby`.
+- Koppel de error message aan de form control met `aria-describedby`. Gebruik je FormField of FormFieldset, dan is dat al geregeld.
 - Zet `aria-invalid="true"` op de form control zelf (niet op de error message).
 - Screenreaders kondigen errors aan wanneer de gebruiker naar het veld navigeert.
 - Het icoon heeft `aria-hidden="true"` omdat de tekst zelf al voldoende context geeft.

--- a/packages/storybook/src/FormFieldStatus.docs.md
+++ b/packages/storybook/src/FormFieldStatus.docs.md
@@ -62,7 +62,8 @@ De FormFieldStatus component toont status informatie onder een form control. Het
 
 - **Icon default aan:** Voor positive/warning, laat icoon zichtbaar (default `showIcon={true}`)
 - **Positionering:** Status komt onder de input, ErrorMessage komt boven de input
-- **aria-describedby:** Geef status een `id` en koppel aan form control indien nuttig
+- **aria-describedby:** Geef status een `id` en koppel aan de form control. Binnen [FormField](/docs/components-formfield--docs) of [FormFieldset](/docs/components-formfieldset--docs) gebeurt dat automatisch
+- **live:** Zet `live` aan wanneer de statustekst verandert tijdens interactie (character counter, wachtwoordsterkte). De status wordt dan een `aria-live="polite"`-regio. Laat het uit bij statische tekst: die wordt anders dubbel voorgelezen
 - **Combineer slim:** Default status (counter) + positive/warning feedback kan samen
 
 ## Design tokens
@@ -84,7 +85,8 @@ De FormFieldStatus component toont status informatie onder een form control. Het
 
 - Default variant heeft subtiele kleur maar nog voldoende contrast.
 - Positive en warning varianten hebben duidelijke kleuren voor zichtbaarheid.
-- Gebruik `id` attribuut en koppel met `aria-describedby` indien de status essentiële info bevat.
+- Gebruik `id` attribuut en koppel met `aria-describedby` indien de status essentiële info bevat. Binnen FormField en FormFieldset wordt dat automatisch gedaan.
 - Icons hebben `aria-hidden="true"` omdat de tekst zelf voldoende context geeft.
 - Kleur alleen is niet voldoende: de icons helpen bij kleurenblindheid.
-- Bij character limits, update aria-live regions voor screenreader feedback.
+- Bij een veranderende status (character counter, wachtwoordsterkte) zet je `live`. De component rendert dan `aria-live="polite"` en `aria-atomic="true"`, zodat een screenreader de nieuwe tekst als geheel aankondigt. Via FormField en FormFieldset regel je dit met `statusLive`.
+- Zet `live` niet aan bij een status die niet verandert: die wordt dan zowel via `aria-describedby` als via de live region voorgelezen.

--- a/packages/storybook/src/FormFieldStatus.stories.tsx
+++ b/packages/storybook/src/FormFieldStatus.stories.tsx
@@ -35,9 +35,12 @@ const meta: Meta<typeof FormFieldStatus> = {
               ? 'alert-triangle'
               : null;
         const idAttr = args.id ? ` id="${args.id}"` : '';
+        const liveAttrs = args.live
+          ? ' aria-live="polite" aria-atomic="true"'
+          : '';
         const icon =
           showIcon && iconName ? `<!-- ${iconName} icon -->\n  ` : '';
-        return `<p class="${cls}"${idAttr}>\n  ${icon}${args.children ?? 'Tekst'}\n</p>`;
+        return `<p class="${cls}"${idAttr}${liveAttrs}>\n  ${icon}${args.children ?? 'Tekst'}\n</p>`;
       },
     },
   },
@@ -47,6 +50,7 @@ const meta: Meta<typeof FormFieldStatus> = {
       options: ['default', 'positive', 'warning'],
     },
     showIcon: { control: 'boolean' },
+    live: { control: 'boolean' },
     id: { control: 'text' },
   },
   args: {
@@ -80,6 +84,19 @@ export const Warning: Story = {
 export const WithoutIcon: Story = {
   name: 'Without icon',
   args: { showIcon: false, children: TEKST },
+};
+
+export const LiveRegion: Story = {
+  name: 'Live region',
+  args: { live: true, children: TEKST },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Met `live` wordt de status een `aria-live="polite"`-regio: een screenreader kondigt elke wijziging aan. Gebruik dit alleen voor status die tijdens interactie verandert, zoals een character counter. Een status die niet verandert, wordt zo dubbel voorgelezen.',
+      },
+    },
+  },
 };
 
 // =============================================================================

--- a/packages/storybook/src/FormFieldset.docs.md
+++ b/packages/storybook/src/FormFieldset.docs.md
@@ -4,7 +4,7 @@ Container component voor groep controls die fieldset/legend gebruikt voor semant
 
 ## Doel
 
-De FormFieldset component is de fieldset/legend variant van FormField. Het combineert FormFieldLegend, FormFieldDescription, FormFieldErrorMessage, groep controls (CheckboxGroup, RadioGroup, DateInputGroup), en FormFieldStatus. Gebruikt `<fieldset>` en `<legend>` elementen voor correcte semantiek bij groep controls. De legend hergebruikt FormFieldLabel CSS classes voor consistente styling. Net als FormField krijgt het een dikke rode linker border bij invalid state. FormFieldset is specifiek voor groepen - gebruik FormField voor individuele controls.
+De FormFieldset component is de fieldset/legend variant van FormField. Het combineert FormFieldLegend, FormFieldDescription, FormFieldErrorMessage, groep controls (CheckboxGroup, RadioGroup, DateInputGroup), en FormFieldStatus. Gebruikt `<fieldset>` en `<legend>` elementen voor correcte semantiek bij groep controls. De legend hergebruikt FormFieldLabel CSS classes voor consistente styling. Net als FormField krijgt het een dikke rode linker border bij invalid state. Description, error en status worden via `aria-describedby` op het `<fieldset>` zelf gekoppeld: een groep heeft geen enkele control om die koppeling aan te hangen. FormFieldset is specifiek voor groepen - gebruik FormField voor individuele controls.
 
 > **Codevoorbeeld met context**: De HTML/CSS tab toont een `CheckboxGroup` met `CheckboxOption` componenten als representatieve children. `FormFieldset` is een wrapper voor groep controls: de children vormen de daadwerkelijke invoergroep.
 
@@ -47,6 +47,8 @@ Wanneer er een `error` prop aanwezig is, krijgt het hele FormFieldset een dikke 
 - **error** - Voor validatie fouten, toon alleen na interactie
 - **status** - Voor realtime feedback
 - **statusVariant** - 'default' (subtle), 'positive' (success), 'warning' (caution)
+- **statusLive** - Alleen aanzetten wanneer de statustekst tijdens interactie verandert. Een statische status als live region wordt dubbel voorgelezen.
+- **id** - Optioneel. Wordt de basis voor de gegenereerde ID's van description, error en status. Zonder `id` valt dit terug op `useId()`.
 
 ### Timing
 
@@ -83,6 +85,7 @@ Plus de tokens van de sub-componenten:
 
 - **fieldset/legend** - Semantisch correct voor groep controls
 - **legend element** - Wordt door screenreaders aangekondigd als groepslabel
+- **aria-describedby op het fieldset** - FormFieldset genereert ID's voor description, error en status en zet `aria-describedby` op het `<fieldset>`, in de volgorde description → error → status. Bij een groep is dat de juiste plek: er is geen enkele control om de koppeling aan te hangen, en de beschrijving geldt voor de hele groep.
 - **Groepering** - Screenreaders kondigen aan: "groep: [legend], [aantal opties]"
 - **Navigatie** - Tab key navigeert tussen opties in de groep
 - **Radio groups** - Pijltjestoetsen navigeren binnen de groep
@@ -107,10 +110,37 @@ Plus de tokens van de sub-componenten:
   description="Kies hoe je bestelling wilt ontvangen"
   error="Selecteer een optie"
   status="Gratis vanaf €50"
+  id="verzendmethode"
 >
   <RadioGroup>
     <RadioOption name="shipping" label="Standaard" value="standard" />
     <RadioOption name="shipping" label="Express" value="express" />
   </RadioGroup>
 </FormFieldset>
+```
+
+De gerenderde HTML van dat laatste voorbeeld:
+
+```html
+<fieldset
+  class="dsn-form-field dsn-form-field--invalid"
+  id="verzendmethode"
+  aria-describedby="verzendmethode-description verzendmethode-error verzendmethode-status"
+>
+  <legend class="dsn-form-field-label">
+    Verzendmethode
+    <span class="dsn-form-field-label-suffix">(verplicht)</span>
+  </legend>
+  <p class="dsn-form-field-description" id="verzendmethode-description">
+    Kies hoe je bestelling wilt ontvangen
+  </p>
+  <p class="dsn-form-field-error-message" id="verzendmethode-error">
+    <svg class="dsn-icon" aria-hidden="true"><!-- exclamation-circle --></svg>
+    Selecteer een optie
+  </p>
+  <div class="dsn-radio-group"><!-- RadioOptions --></div>
+  <p class="dsn-form-field-status" id="verzendmethode-status">
+    Gratis vanaf €50
+  </p>
+</fieldset>
 ```

--- a/packages/storybook/src/FormFieldset.stories.tsx
+++ b/packages/storybook/src/FormFieldset.stories.tsx
@@ -32,12 +32,21 @@ const meta: Meta<typeof FormFieldset> = {
         const suffix = args.legendSuffix
           ? `<span class="dsn-form-field-label-suffix">${args.legendSuffix}</span>`
           : '';
-        let html = `<fieldset class="${cls}">\n`;
+        // Bij een groep hangt de koppeling aan het fieldset zelf: er is geen
+        // enkele control om hem aan te hangen.
+        const describedBy = [
+          args.description && 'group-description',
+          args.error && 'group-error',
+          args.status && 'group-status',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        let html = `<fieldset class="${cls}"${describedBy ? ` aria-describedby="${describedBy}"` : ''}>\n`;
         html += `  <legend class="dsn-form-field-label">${args.legend ?? 'Legenda'}${suffix}</legend>\n`;
         if (args.description)
-          html += `  <p class="dsn-form-field-description">${args.description}</p>\n`;
+          html += `  <p class="dsn-form-field-description" id="group-description">${args.description}</p>\n`;
         if (args.error)
-          html += `  <p class="dsn-form-field-error-message"><svg class="dsn-icon" aria-hidden="true"><!-- exclamation-circle --></svg>${args.error}</p>\n`;
+          html += `  <p class="dsn-form-field-error-message" id="group-error"><svg class="dsn-icon" aria-hidden="true"><!-- exclamation-circle --></svg>${args.error}</p>\n`;
         const option = (
           value: string
         ) => `    <label class="dsn-checkbox-option">
@@ -55,7 +64,7 @@ const meta: Meta<typeof FormFieldset> = {
             args.statusVariant && args.statusVariant !== 'default'
               ? ` dsn-form-field-status--${args.statusVariant}`
               : '';
-          html += `  <p class="dsn-form-field-status${variantCls}">${args.status}</p>\n`;
+          html += `  <p class="dsn-form-field-status${variantCls}" id="group-status">${args.status}</p>\n`;
         }
         html += `</fieldset>`;
         return html;
@@ -72,6 +81,7 @@ const meta: Meta<typeof FormFieldset> = {
       control: 'select',
       options: ['default', 'positive', 'warning'],
     },
+    statusLive: { control: 'boolean' },
   },
   args: {
     legend: TEKST,

--- a/packages/storybook/src/ProgressBar.docs.md
+++ b/packages/storybook/src/ProgressBar.docs.md
@@ -87,6 +87,7 @@ Toon een beschrijving wanneer de balk 100% bereikt:
 
 - Het native `<progress>`-element heeft impliciete `role="progressbar"`, `aria-valuenow`, `aria-valuemin` (0) en `aria-valuemax`.
 - Een `<label>` is gekoppeld via `for`/`id` — robuuster dan `aria-label`.
+- De `description` krijgt een `id` en is via `aria-describedby` aan het `<progress>`-element gekoppeld, zodat een screenreadergebruiker de toelichting hoort en niet alleen het percentage.
 - De percentage-tekst heeft `aria-hidden="true"`: screenreaders lezen de native voortgangswaarde al voor via `<progress>`.
 - De fallback-tekst binnen `<progress>` (bijv. `35%`) dient als tekstalternatief voor browsers zonder HTML5-ondersteuning.
 - Bij dynamische `value`-wijzigingen kondigt de screenreader de nieuwe waarde aan via de ingebouwde live-regiofunctionaliteit van `role="progressbar"`.

--- a/packages/storybook/src/ProgressBar.stories.tsx
+++ b/packages/storybook/src/ProgressBar.stories.tsx
@@ -15,14 +15,17 @@ const meta: Meta<typeof ProgressBar> = {
         const percentage = Math.round((value / max) * 100);
         const label = args.label ?? 'Bestand uploaden';
         const description = args.description
-          ? `\n  <p class="dsn-paragraph dsn-progress-bar__description">${args.description}</p>`
+          ? `\n  <p class="dsn-paragraph dsn-progress-bar__description" id="pb-example-description">${args.description}</p>`
+          : '';
+        const describedBy = args.description
+          ? ' aria-describedby="pb-example-description"'
           : '';
         return `<div class="dsn-progress-bar">
   <label class="dsn-visually-hidden" for="pb-example">${label}</label>
   <div class="dsn-progress-bar__header">
     <p class="dsn-paragraph dsn-progress-bar__percentage" aria-hidden="true">${percentage}%</p>
   </div>
-  <progress id="pb-example" class="dsn-progress-bar__bar" value="${value}" max="${max}">${percentage}%</progress>${description}
+  <progress id="pb-example" class="dsn-progress-bar__bar" value="${value}" max="${max}"${describedBy}>${percentage}%</progress>${description}
 </div>`;
       },
     },


### PR DESCRIPTION
Fixes #317

## Wat er mis was

`FormField` genereerde de ID's `{htmlFor}-description`, `{htmlFor}-error` en `{htmlFor}-status`, zette ze netjes op de teksten, en gebruikte ze vervolgens nergens. De control kreeg geen `aria-describedby`, dus een screenreadergebruiker hoorde de hulptekst en de foutmelding niet bij het veld.

De gerenderde DOM vóór deze PR:

```html
<div class="dsn-form-field dsn-form-field--invalid">
  <label class="dsn-form-field-label" for="s4">Tekst</label>
  <p class="dsn-form-field-description" id="s4-description">Desc</p>
  <p class="dsn-form-field-error-message" id="s4-error">Err</p>
  <input type="text" class="dsn-text-input" aria-invalid="true" id="s4">
  <p class="dsn-form-field-status" id="s4-status">Stat</p>
</div>
```

## Wat het onderzoek verder opleverde

Naast de vier stories uit het issue bleek dezelfde fout op drie andere plekken te zitten:

| Plek | Wat er mis was |
| --- | --- |
| `FormFieldset` | Genereerde niet eens ID's. Geen enkele koppeling, bij elke CheckboxGroup, RadioGroup en DateInputGroup met een description of error. Had ook geen testbestand, terwijl `docs/03-components.md` "React (9 tests)" claimde |
| `ProgressBar` | `description` als losse `<p>` zonder ID onder de balk, `<progress>` zonder `aria-describedby` |
| De `htmlTemplate`s | De HTML/CSS-tab van FormField en FormFieldset toonde markup zonder ID's en zonder `aria-describedby`. Omdat de HTML/CSS-laag de bron van waarheid is, nam iedereen die die tab kopieerde de fout letterlijk over |

En de reden dat het lang onopgemerkt bleef: de documentatie beloofde op vijf plekken actief dat het al geregeld was, onder meer *"Form controls krijgen automatisch aria-describedby met description/error/status IDs"*. Wie dat las had geen aanleiding om het na te meten. De bestaande test controleerde alleen dát de description een ID kreeg, nooit dat er iets naar verwijst: precies de helft van de keten, en de helft waar de fout niet in zat.

## Wat deze PR doet

**Koppeling**
- `FormField` kloont het child-element en zet `aria-describedby` in de volgorde description, error, status. Dezelfde volgorde als de teksten visueel staan, zodat oog en screenreader dezelfde route lopen
- Een `aria-describedby` die de consument zelf op de control zette blijft behouden en wordt achteraan toegevoegd; dubbele ID's worden verwijderd
- `FormField` werkt nu ook zonder `htmlFor`: de ID's vallen dan terug op `useId()`
- `FormFieldset` zet `aria-describedby` op het `<fieldset>` zelf. Bij een groep is dat de juiste plek: er is geen enkele control om de koppeling aan te hangen. Nieuwe optionele `id`-prop als basis voor de ID's
- `ProgressBar` koppelt zijn `description` aan het `<progress>`-element

**Live region** (het tweede deel van het issue)
- Nieuwe `live`-prop op `FormFieldStatus` rendert `aria-live="polite"` en `aria-atomic="true"`; via `FormField`/`FormFieldset` te bereiken met `statusLive`
- Bewust opt-in: een status die niet verandert zou anders zowel via `aria-describedby` als via de live region worden voorgelezen
- Nieuwe stories "Live status" (werkende character counter) en "Live region"

**Docs en tests**
- De vijf onterechte claims gecorrigeerd in `FormField.docs.md`, `DateInputGroup.docs.md` en `docs/03-components.md`
- `FormField.docs.md` en `FormFieldset.docs.md` tonen nu de gerenderde HTML van het volledige voorbeeld, zodat de belofte controleerbaar is in plaats van beweerd
- De `htmlTemplate`s van FormField, FormFieldset, FormFieldStatus en ProgressBar renderen de ID's en het `aria-describedby`
- 26 tests erbij, waaronder het ontbrekende `FormFieldset`-testbestand (12 tests). De assertions gebruiken `toHaveAccessibleDescription`, dat de keten daadwerkelijk oplost: een test die alleen het attribuut vergelijkt zou een verwijzing naar een niet-bestaand ID goedkeuren

## Verificatie

De story "All states" uit het issue, uitgelezen in de draaiende Storybook:

| id | aria-describedby |
| --- | --- |
| s1 (basic) | *(geen, correct)* |
| s2 (description) | `s2-description` |
| s3 (suffix) | *(geen, correct)* |
| s4 (error) | `s4-error` |
| s5 (status positive) | `s5-status` |
| s6 (status warning) | `s6-status` |
| s7 (TextArea) | `s7-description` |

Daarnaast alle 638 stories met Playwright gecrawld en de echte DOM gecontroleerd op twee dingen: `aria-describedby` dat naar een niet-bestaand ID wijst, en beschrijvende tekst waar niets naar verwijst. **0 dangling references.** De resterende losse teksten zijn de geïsoleerde sub-componentdemo's (FormFieldDescription/ErrorMessage/Status los, en de KitchenSink-showcase), waar per definitie geen control aanwezig is, plus de foutmelding binnen `File`, die inhoud van het lijstitem is en al een eigen `aria-live`-regio heeft.

`pnpm lint` (0 errors, 96 warnings gelijk aan baseline), `pnpm format:check`, `pnpm type-check`, `pnpm --filter storybook exec tsc --noEmit`, `pnpm test` (1661 tests) en `pnpm build` zijn groen.

## Breaking?

Niet voor React-consumers: bestaande code blijft werken en krijgt de koppeling er vanzelf bij. Wél iets te doen voor de HTML/CSS-laag: wie de markup met de hand schrijft, zet nu zelf de ID's op description, error en status en het `aria-describedby` op de control. De bijgewerkte HTML/CSS-tabs tonen precies dat.

Eén beperking om te kennen: de koppeling gebeurt door het child-element te klonen, dus geef één element mee dat zijn props doorgeeft aan het DOM-element. Bij een fragment of meerdere children blijft de control ongewijzigd en zet je het attribuut zelf. Alle inputcomponenten in dit systeem spreiden `...props` door, dus die werken zonder aanpassing.

## Open vraag voor @rianrietveld

Het issue toont `aria-describedby="s4-error s4-description"`, dus error eerst. Ik heb de visuele volgorde aangehouden (description, error, status), zodat oog en screenreader dezelfde route lopen. Als jij vanuit screenreadertests reden ziet om de foutmelding vóór de description te zetten, draai ik dat om.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
