### PR TITLE
chore(ci): bump GitHub Actions naar Node 24-compatible versies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
-      - name: Setup Node.js 20
-        uses: actions/setup-node@v4
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies
@@ -53,15 +53,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
-      - name: Setup Node.js 20
-        uses: actions/setup-node@v4
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies
@@ -89,17 +89,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
-      - name: Setup Node.js 20
-        uses: actions/setup-node@v4
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -22,15 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies
@@ -59,10 +59,10 @@ jobs:
           cp -r packages/color-palette-generator/dist/. pages-artifact/color-palette-generator/
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./pages-artifact
 
@@ -76,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,15 +28,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
-      - name: Setup Node.js 20
-        uses: actions/setup-node@v4
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: pnpm
 


### PR DESCRIPTION
Closes #314

## Wat

Alle GitHub Actions die nog `node20` als runtime hadden, draaiden op de forced-fallback naar Node 24 die GitHub gaat intrekken ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Deze PR haalt ze naar majors die zelf op `node24` draaien.

Het issue noemde alleen `publish.yml`, maar dezelfde actions staan op zes plekken (`ci.yml` heeft drie jobs, plus `deploy-storybook.yml`). De check op andere workflows leverde daarnaast drie Pages-actions op die het issue niet noemde.

| Action | Van | Naar | Runtime nu |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | v7 | node24 |
| `actions/setup-node` | v4 | v7 | node24 |
| `pnpm/action-setup` | v4 | v6 | node24 |
| `actions/configure-pages` | v4 | v6 | node24 |
| `actions/upload-pages-artifact` | v3 | v5 | composite, nu via `upload-artifact@v7` |
| `actions/deploy-pages` | v4 | v5 | node24 |

`node-version` gaat van 20 naar 24. Node 20 is sinds april 2026 end-of-life, `engines` staat op `>=18.0.0`, en de toolchain (vitest 4, storybook 10, vite 6, playwright 1.58) draait lokaal al op Node 24.

## Breaking changes in de majors, en waarom ze ons niet raken

- **`setup-node` v5** introduceerde automatische package-manager caching op basis van het `packageManager`-veld. **v6** beperkte dat weer tot npm. Op v7 blijft onze expliciete `cache: pnpm` dus leidend.
- **`checkout` v7** blokkeert het uitchecken van fork-PR's bij `pull_request_target` en `workflow_run`. Wij triggeren op `push` en `pull_request`, dus niet van toepassing.
- **`checkout` v6** zet git-credentials in een apart bestand in plaats van in `.git/config`. Alleen relevant voor stappen die de token uit git config lezen. De Chromatic-job (`fetch-depth: 0`) leest git-historie, geen credentials.
- **`pnpm/action-setup` v6** voegt pnpm 11-support toe. Wij pinnen pnpm via `packageManager: pnpm@10.11.1`, dus er verandert niets.
- **`upload-pages-artifact` en `deploy-pages`** hebben een artifact-formaatafspraak en zijn daarom als paar gebumpt.

## Bewust niet meegenomen

`chromaui/action@v11` is de laatste overgebleven node20-action. Dat is een sprong van zeven majors op de action die de visuele baselines en `autoAcceptChanges: main` aanstuurt, en dat hoort niet in een routinebump. Apart issue aangemaakt.

## Verificatie

`ci.yml` bewijst zichzelf: deze PR draait alle drie de jobs op de nieuwe versies.

Twee workflows kunnen niet vooraf getest worden:
- `publish.yml` triggert alleen op een `v*`-tag, en `workflow_dispatch` erop publiceert echt naar npm. De stappen zijn identiek aan `ci.yml`, en een mislukte publish is herstelbaar met een nieuwe tag.
- `deploy-storybook.yml` draait pas na merge naar main. Hier zit ook de enige echte onbekende: het `upload-pages-artifact` + `deploy-pages` paar. Even naar de eerste run op main kijken.

Geen changelog-entry: dit raakt niets aan de gepubliceerde packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)