### PR TITLE
chore(ci): bump chromaui/action van v11 naar v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: pnpm build
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v11
+        uses: chromaui/action@v18
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           storybookBuildDir: packages/storybook/dist


### PR DESCRIPTION
Closes #341

Vervolg op #340. `chromaui/action@v11` was de laatste overgebleven `node20`-action in de repo. Na deze PR staat de teller in de CI-logs op nul: run vóór de bump had 1 regel "Node.js 20 is deprecated", de run op deze PR heeft er 0.

## Wat het onderzoek opleverde

`chromaui/action` is gepind aan de chromatic CLI: het versienummer in de `package.json` van de action is exact het CLI-versienummer. v11 → v18 is dus chromatic 11 → 18. De changelog van de action is de CLI-changelog.

Alle zeven majors doorgenomen op `💥 Breaking Change`:

| Versie | Breaking change | Raakt ons? |
| --- | --- | --- |
| v12 | git command logging, `--no-relative` bij `git diff` | Nee |
| v13 | Vier deprecated flags verwijderd | Nee, zie hieronder |
| v14 / v15 | Intern bijgewerkt naar Storybook 10.x | Nee, in ons voordeel |
| v16 | Node 18 laten vallen, action naar `node24` | Nee |
| v17 | Node 20 laten vallen, `engines` op `>=22.0.0` | Nee, runner draait Node 24 sinds #340 |
| v18 | CLI-tasklist rendert met Clack | Nee, alleen presentatie |

**v13 is de enige die aandacht verdiende.** Verwijderd zijn `--allow-console-errors`, `--app-code` (naar `--project-token`), `--diagnostics` (naar `--diagnostics-file`) en `--only` (naar `--only-story-names`). Als action-inputs zijn dat `allowConsoleErrors`, `appCode`, `diagnostics` en `only`. Een diff van `action.yml` tussen v11 en v18 bevestigt dat precies die vier verdwenen zijn, en dat er twee bij zijn gekomen (`chromaticSha`, `vitest`). Wij zetten geen van die zes.

De drie inputs die wij wél zetten bestaan onveranderd in v18, met dezelfde beschrijving: `projectToken`, `storybookBuildDir`, `autoAcceptChanges`.

Nog een prettige bijvangst: v14/v15 brachten de CLI naar Storybook 10.x. Wij draaien Storybook 10.3.6, dus op dat punt liep v11 juist achter op onze eigen setup. De v11-run logde dan ook `⚠ Using outdated package`; die waarschuwing is nu weg.

## Verificatie, met een belangrijke beperking

De CLI start op als v18.6.0 en publiceert zonder fouten. Beide runs, v11 en v18, vinden exact dezelfde inhoud: **85 components met 637 stories**. Dat is het sterkste signaal dat de nieuwere CLI onze Storybook identiek indexeert.

**Wat deze PR níét bewijst: dat er geen visuele diffs zijn.** De Chromatic-run meldt:

> ⚠ Snapshot quota reached. This build is limited because your account is out of snapshots for the month.

Gevolg: er draaiden 85 tests en werden er 552 overgeslagen, plus `No UI tests or UI review enabled`. De groene check betekent hier dus "Storybook is gepubliceerd", niet "visueel identiek bevonden".

Dit staat los van de bump: dezelfde quota-waarschuwing stond al in de v11-run op #340. Het is een accountconditie, geen regressie.

Praktisch betekent dat wel dat de gebruikelijke route (op de PR naar de Chromatic-diff kijken, want `autoAcceptChanges: main` accepteert na merge automatisch) deze maand niet beschikbaar is. Twee opties: mergen op basis van de bovenstaande onderbouwing plus de identieke component- en story-telling, of wachten tot de quota reset en dan pas mergen met een echte diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)