### PR TITLE
fix(storybook): leid token-CSS-pad af van document.baseURI

### DIFF
--- a/docs/05-storybook-configuration.md
+++ b/docs/05-storybook-configuration.md
@@ -174,20 +174,38 @@ export default preview;
 
 **Purpose:** Handles dynamic token loading in the preview iframe
 
+Dit script is de **enige bron van waarheid** voor het pad naar de token-CSS en
+voor het injecteren van de stylesheet. `preview.ts` (de decorator) en
+`TokenControls.tsx` laden zelf geen CSS; zij roepen de loader aan via
+`window.__DSN_TOKENS__`, getypeerd in `packages/storybook/src/token-loader.ts`.
+
 **Key features:**
 
 - Fetch-based CSS loading (no `<link>` tags)
+- Basispad afgeleid van `document.baseURI`, niet absoluut (zie hieronder)
 - `:root:root` selector for higher specificity
 - MutationObserver to keep styles at end of `<head>`
 - URL parameter parsing for toolbar state
+- Publieke API op `window.__DSN_TOKENS__` voor de rest van Storybook
+
+**Waarom geen absoluut pad?** Lokaal draait Storybook op base `/`, op GitHub
+Pages op `/design-system-starter-kit/` (`STORYBOOK_BASE_PATH` in het
+`build:gh-pages` script, doorgegeven als Vite `base` in `main.ts`). Een absoluut
+pad als `/design-tokens/dist/css` negeert die base en levert op Pages 404's op,
+terwijl het lokaal toevallig klopt. `preview-head.html` is platte HTML/JS en
+kent geen Vite-variabelen, dus het pad wordt met `new URL(..., document.baseURI)`
+afgeleid van de URL van de iframe.
 
 ```html
 <script>
   (function () {
-    const CONFIG_BASE_URL = '/design-tokens/dist/css';
+    // Lokaal: http://localhost:6006/design-tokens/dist/css/
+    // GitHub Pages: https://<user>.github.io/design-system-starter-kit/design-tokens/dist/css/
+    const CONFIG_BASE_URL = new URL('design-tokens/dist/css/', document.baseURI)
+      .href;
 
     function loadTokenConfig(configName) {
-      fetch(`${CONFIG_BASE_URL}/${configName}.css`)
+      return fetch(`${CONFIG_BASE_URL}${configName}.css`)
         .then((r) => r.text())
         .then((cssText) => {
           // Remove existing dynamic styles
@@ -220,8 +238,36 @@ export default preview;
         // Parse globals from URL and load config...
       }
     }, 100);
+
+    // Publieke API: preview.ts en TokenControls.tsx gebruiken deze,
+    // zodat het pad en de injectie op één plek staan.
+    window.__DSN_TOKENS__ = {
+      configUrl,
+      load: loadTokenConfig,
+      applyBodyClasses,
+      getCurrentConfigName: () => currentConfigName,
+    };
   })();
 </script>
+```
+
+### token-loader.ts
+
+**Location:** `packages/storybook/src/token-loader.ts`
+
+**Purpose:** Getypeerde toegang tot `window.__DSN_TOKENS__` vanuit TypeScript.
+
+Omdat `preview-head.html` als klassiek inline-script in de head van de iframe
+draait, staat de loader er al voordat de Storybook-bundel begint. `preview.ts`
+en `TokenControls.tsx` importeren `getTokenLoader()` en hoeven zo zelf niets te
+weten over het pad, de fetch of de `:root:root`-wrapper.
+
+```ts
+const loader = getTokenLoader();
+if (loader) {
+  void loader.load(toConfigName(theme, mode, projectType));
+  loader.applyBodyClasses(theme, mode, projectType);
+}
 ```
 
 ### preview-body.css
@@ -267,7 +313,7 @@ body {
 1. User clicks "Dark Mode" in toolbar
 2. URL changes to `?globals=mode:dark`
 3. Script detects change
-4. Script fetches `/design-tokens/dist/css/start-dark-default.css`
+4. Script fetches `<base>/design-tokens/dist/css/start-dark-default.css`
 5. Script injects with `:root:root` selector
 6. All `--dsn-*` variables update
 7. Components re-render with new colors

--- a/packages/storybook/.storybook/preview-head.html
+++ b/packages/storybook/.storybook/preview-head.html
@@ -2,12 +2,32 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Comic+Neue:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" rel="stylesheet">
 <script>
-  // Dynamic token loading script for Storybook
-  // This runs in the preview iframe and handles theme/mode/density switching
+  // Dynamische token-loader voor de Storybook preview-iframe.
+  //
+  // Dit script is de ENIGE plek die token-CSS ophaalt en injecteert. Het draait
+  // als klassiek inline-script en dus vóór de (module) Storybook-bundel, zodat
+  // de tokens er al zijn bij de eerste render. preview.ts en TokenControls.tsx
+  // praten er via window.__DSN_TOKENS__ mee (zie src/token-loader.ts), zodat
+  // het pad naar de token-CSS maar op één plek staat.
+  //
+  // Het pad wordt afgeleid van document.baseURI en is bewust NIET absoluut:
+  // lokaal draait Storybook op base '/', op GitHub Pages op
+  // '/design-system-starter-kit/' (STORYBOOK_BASE_PATH in build:gh-pages).
+  // Een absoluut pad negeert die base en levert daar 404's op.
   (function() {
-    const CONFIG_BASE_URL = '/design-tokens/dist/css';
+    const CONFIG_BASE_URL = new URL(
+      'design-tokens/dist/css/',
+      document.baseURI
+    ).href;
+
     let currentConfigName = null;
     let styleElement = null;
+    let pendingConfigName = null;
+    let pendingPromise = null;
+
+    function configUrl(configName) {
+      return CONFIG_BASE_URL + configName + '.css';
+    }
 
     function getGlobalsFromUrl() {
       const url = new URL(window.location.href);
@@ -29,11 +49,19 @@
     }
 
     function loadTokenConfig(configName, forceReload = false) {
-      if (currentConfigName === configName && !forceReload) return;
+      if (!forceReload) {
+        if (currentConfigName === configName) return Promise.resolve();
+        // Preview-decorator en URL-poller kunnen dezelfde config tegelijk
+        // aanvragen; hergebruik dan de lopende fetch.
+        if (pendingConfigName === configName && pendingPromise) {
+          return pendingPromise;
+        }
+      }
 
-      const url = `${CONFIG_BASE_URL}/${configName}.css`;
+      const url = configUrl(configName);
 
-      fetch(url)
+      pendingConfigName = configName;
+      pendingPromise = fetch(url)
         .then(response => {
           if (!response.ok) throw new Error('Failed to load: ' + url);
           return response.text();
@@ -59,23 +87,43 @@
             detail: { configName }
           }));
         })
-        .catch(err => console.error('Token config load error:', err));
+        .catch(err => console.error('Token config load error:', err))
+        .finally(() => {
+          if (pendingConfigName === configName) {
+            pendingConfigName = null;
+            pendingPromise = null;
+          }
+        });
+
+      return pendingPromise;
+    }
+
+    // Zet de theme-klassen op <body>. Bestaande klassen (o.a. Storybook's eigen
+    // sb-* klassen en dsn-body) blijven staan.
+    function applyBodyClasses(theme, mode, projectType) {
+      if (!document.body) return;
+
+      const densityClass = projectType === 'information-dense' ? 'dense' : 'default';
+      const existingClasses = document.body.className.split(' ').filter(c =>
+        c && !c.startsWith('dsn-theme-') && !c.startsWith('dsn-mode-') && !c.startsWith('dsn-density-')
+      );
+      document.body.className = [...existingClasses, `dsn-theme-${theme}`, `dsn-mode-${mode}`, `dsn-density-${densityClass}`].join(' ');
     }
 
     function updateTokens() {
       const { theme, mode, projectType } = getGlobalsFromUrl();
-      const configName = `${theme}-${mode}-${projectType}`;
-      loadTokenConfig(configName);
-
-      // Update body classes when body is available
-      if (document.body) {
-        const densityClass = projectType === 'information-dense' ? 'dense' : 'default';
-        const existingClasses = document.body.className.split(' ').filter(c =>
-          !c.startsWith('dsn-theme-') && !c.startsWith('dsn-mode-') && !c.startsWith('dsn-density-')
-        );
-        document.body.className = [...existingClasses, `dsn-theme-${theme}`, `dsn-mode-${mode}`, `dsn-density-${densityClass}`].join(' ');
-      }
+      loadTokenConfig(`${theme}-${mode}-${projectType}`);
+      applyBodyClasses(theme, mode, projectType);
     }
+
+    // Publieke API voor preview.ts en TokenControls.tsx.
+    // Getypeerd in src/token-loader.ts.
+    window.__DSN_TOKENS__ = {
+      configUrl,
+      load: loadTokenConfig,
+      applyBodyClasses,
+      getCurrentConfigName: () => currentConfigName
+    };
 
     // Ensure our style stays at the end of head (highest priority)
     function ensureStylePriority() {

--- a/packages/storybook/.storybook/preview.ts
+++ b/packages/storybook/.storybook/preview.ts
@@ -1,70 +1,15 @@
 import type { Preview } from '@storybook/react-vite';
+import { getTokenLoader, toConfigName } from '../src/token-loader';
 
 // NOTE: We do NOT import the token CSS statically here anymore.
-// The tokens are loaded dynamically by the decorator and preview-head.html
-// to support runtime theme/mode/density switching.
+// De tokens worden dynamisch geladen door de loader in preview-head.html,
+// zodat theme/mode/density tijdens runtime kunnen wisselen. Die loader kent
+// als enige het pad naar de token-CSS; de decorator hieronder vertelt hem
+// alleen welke configuratie de toolbar-globals vragen.
 
 // Core styles (layout, resets, etc. - NOT tokens)
 import '../../core/dist/core.css';
 import './preview-body.css';
-
-// =============================================================================
-// TOKEN CONFIGURATION LOADER
-// =============================================================================
-
-// Map of all available configurations
-// We'll dynamically fetch and apply these when globals change
-// Use relative path to support both local and GitHub Pages deployment
-const CONFIG_BASE_URL = './design-tokens/dist/css';
-
-/**
- * Loads a CSS configuration file and applies it to the document.
- * This overwrites the :root CSS variables with the new values.
- */
-async function loadTokenConfig(configName: string): Promise<void> {
-  const url = `${CONFIG_BASE_URL}/${configName}.css`;
-
-  try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      console.error(`Failed to load token config: ${url}`);
-      return;
-    }
-
-    const cssText = await response.text();
-
-    // Remove any existing dynamic style element
-    const existingStyle = document.querySelector('[data-dsn-tokens]');
-    if (existingStyle) {
-      existingStyle.remove();
-    }
-
-    // Create and inject new style element
-    const style = document.createElement('style');
-    style.setAttribute('data-dsn-tokens', configName);
-    style.textContent = cssText;
-    document.head.appendChild(style);
-
-    // Dispatch event for components that need to react
-    window.dispatchEvent(
-      new CustomEvent('storybook-globals-updated', {
-        detail: { configName },
-      })
-    );
-  } catch (error) {
-    console.error('Error loading token config:', error);
-  }
-}
-
-// =============================================================================
-// GLOBAL TYPES (Storybook Toolbar)
-// =============================================================================
-
-// Preload default tokens immediately when Storybook loads
-// This ensures tokens are available even on docs-only pages (like Introduction)
-if (typeof window !== 'undefined') {
-  loadTokenConfig('start-light-default');
-}
 
 const preview: Preview = {
   parameters: {
@@ -141,23 +86,16 @@ const preview: Preview = {
       const theme = context.globals.theme || 'start';
       const mode = context.globals.mode || 'light';
       const projectType = context.globals.projectType || 'default';
-      const configName = `${theme}-${mode}-${projectType}`;
 
-      // Load the appropriate token configuration
-      if (typeof window !== 'undefined') {
-        // Check if we need to load a new config
-        const currentConfig = document
-          .querySelector('[data-dsn-tokens]')
-          ?.getAttribute('data-dsn-tokens');
+      const loader = getTokenLoader();
+      if (loader) {
+        // De loader dedupliceert zelf; opnieuw dezelfde config vragen is gratis.
+        void loader.load(toConfigName(theme, mode, projectType));
+        loader.applyBodyClasses(theme, mode, projectType);
 
-        if (currentConfig !== configName) {
-          loadTokenConfig(configName);
-        }
-
-        // Update body classes for any CSS scoping
-        const densityClass =
-          projectType === 'information-dense' ? 'dense' : 'default';
-        document.body.className = `dsn-body dsn-theme-${theme} dsn-mode-${mode} dsn-density-${densityClass}`;
+        // Stories renderen op een body die zich als dsn-body gedraagt.
+        // Docs-pagina's bewust niet: die houden de Storybook-typografie.
+        document.body.classList.add('dsn-body');
       }
 
       return Story();

--- a/packages/storybook/src/components/TokenControls.tsx
+++ b/packages/storybook/src/components/TokenControls.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
+import { fromConfigName, getTokenLoader, toConfigName } from '../token-loader';
+
 interface TokenControlsProps {
   onRefresh?: () => void;
 }
@@ -11,18 +13,13 @@ export function TokenControls({ onRefresh }: TokenControlsProps) {
 
   // Load current values on mount
   useEffect(() => {
-    if (typeof window === 'undefined') return;
+    const currentConfig = getTokenLoader()?.getCurrentConfigName();
+    if (!currentConfig) return;
 
-    const currentConfig = document
-      .querySelector('[data-dsn-tokens]')
-      ?.getAttribute('data-dsn-tokens');
-
-    if (currentConfig) {
-      const [t, m, p] = currentConfig.split('-');
-      setTheme(t || 'start');
-      setMode(m || 'light');
-      setProjectType(p || 'default');
-    }
+    const current = fromConfigName(currentConfig);
+    setTheme(current.theme);
+    setMode(current.mode);
+    setProjectType(current.projectType);
   }, []);
 
   const applyTokens = (
@@ -30,40 +27,23 @@ export function TokenControls({ onRefresh }: TokenControlsProps) {
     newMode: string,
     newProjectType: string
   ) => {
-    if (typeof window === 'undefined') return;
+    // Het laden en injecteren gebeurt in de loader uit preview-head.html; die
+    // dispatcht ook zelf 'storybook-globals-updated' voor de TokenTables.
+    const loader = getTokenLoader();
+    if (!loader) return;
 
-    // Remove old token stylesheet
-    const oldLink = document.querySelector('[data-dsn-theme-css]');
-    if (oldLink) {
-      oldLink.remove();
-    }
+    void loader
+      .load(toConfigName(newTheme, newMode, newProjectType))
+      .then(() => {
+        loader.applyBodyClasses(newTheme, newMode, newProjectType);
 
-    // Create new token config
-    const config = `${newTheme}-${newMode}-${newProjectType}`;
-
-    // Add new stylesheet
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = `./design-tokens/dist/css/${config}.css`;
-    link.setAttribute('data-dsn-theme-css', config);
-    link.setAttribute('data-dsn-tokens', config);
-    document.head.appendChild(link);
-
-    // Wait for stylesheet to load, then trigger refresh
-    link.addEventListener('load', () => {
-      if (onRefresh) {
-        // Use multiple delays to catch all updates
-        setTimeout(onRefresh, 50);
-        setTimeout(onRefresh, 150);
-        setTimeout(onRefresh, 300);
-      }
-
-      // Dispatch custom event for TokenTable to listen to
-      window.dispatchEvent(new CustomEvent('storybook-globals-updated'));
-    });
-
-    // Update data attribute
-    document.body.setAttribute('data-dsn-tokens', config);
+        if (onRefresh) {
+          // Use multiple delays to catch all updates
+          setTimeout(onRefresh, 50);
+          setTimeout(onRefresh, 150);
+          setTimeout(onRefresh, 300);
+        }
+      });
   };
 
   const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/packages/storybook/src/token-loader.ts
+++ b/packages/storybook/src/token-loader.ts
@@ -1,0 +1,77 @@
+/**
+ * Getypeerde toegang tot de token-loader uit `.storybook/preview-head.html`.
+ *
+ * Dat script is de enige bron van waarheid voor het pad naar de token-CSS
+ * (`design-tokens/dist/css/`, afgeleid van `document.baseURI`) en voor het
+ * injecteren van de stylesheet. Het draait als klassiek inline-script in de
+ * head van de preview-iframe, dus vóór de Storybook-bundel: alles wat deze
+ * module importeert kan ervan uitgaan dat de loader er is.
+ *
+ * Voeg hier geen tweede implementatie toe. Wie het pad of het injecteren wil
+ * aanpassen, doet dat in `preview-head.html`.
+ */
+
+export interface DsnTokenLoader {
+  /** Volledige URL naar de CSS van een configuratie, bijv. `start-dark-default`. */
+  configUrl(configName: string): string;
+  /**
+   * Laadt een configuratie en injecteert de tokens. Idempotent: dezelfde
+   * configuratie tweemaal aanvragen doet niets (tenzij `forceReload`).
+   */
+  load(configName: string, forceReload?: boolean): Promise<void>;
+  /** Zet `dsn-theme-*`, `dsn-mode-*` en `dsn-density-*` op `<body>`. */
+  applyBodyClasses(theme: string, mode: string, projectType: string): void;
+  /** De configuratie die nu geladen is, of `null` als er nog niets geladen is. */
+  getCurrentConfigName(): string | null;
+}
+
+declare global {
+  interface Window {
+    __DSN_TOKENS__?: DsnTokenLoader;
+  }
+}
+
+/**
+ * Geeft de loader terug, of `undefined` buiten de preview-iframe (SSR, tests).
+ */
+export function getTokenLoader(): DsnTokenLoader | undefined {
+  if (typeof window === 'undefined') return undefined;
+
+  const loader = window.__DSN_TOKENS__;
+  if (!loader) {
+    console.error(
+      'Token loader ontbreekt op window.__DSN_TOKENS__; draait .storybook/preview-head.html wel?'
+    );
+  }
+
+  return loader;
+}
+
+/**
+ * Bouwt een configuratienaam uit de Storybook-globals.
+ */
+export function toConfigName(
+  theme: string,
+  mode: string,
+  projectType: string
+): string {
+  return `${theme}-${mode}-${projectType}`;
+}
+
+/**
+ * Splitst een configuratienaam weer uit. `projectType` kan zelf een streepje
+ * bevatten (`information-dense`), dus alles na het tweede segment hoort erbij.
+ */
+export function fromConfigName(configName: string): {
+  theme: string;
+  mode: string;
+  projectType: string;
+} {
+  const [theme, mode, ...projectType] = configName.split('-');
+
+  return {
+    theme: theme || 'start',
+    mode: mode || 'light',
+    projectType: projectType.join('-') || 'default',
+  };
+}


### PR DESCRIPTION
## Probleem

Op de gedeployde Storybook (GitHub Pages) gaf de console herhaaldelijk:

```
Failed to load resource: 404
Token config load error: Failed to load: /design-tokens/dist/css/start-light-default.css
```

`packages/storybook/.storybook/preview-head.html` gebruikte een absoluut pad (`/design-tokens/dist/css`). Dat negeert de Vite `base`, die op Pages `/design-system-starter-kit/` is (`STORYBOOK_BASE_PATH` in `build:gh-pages`, doorgegeven in `main.ts`). Lokaal viel het niet op omdat `base` daar `/` is en het pad toevallig klopt.

Staat er sinds d44bd37 (20 februari 2026), los van de CI-action bumps in #340 en #342.

## Wat het gevolg was (gemeten op de live site)

| | voor | na |
| --- | --- | --- |
| Console | 404 + `Token config load error` bij elke pagina en elke switch | schoon |
| Stories, theme/mode/density wisselen | werkte, maar via de decorator in `preview.ts` (relatief pad); de loader in `preview-head.html` deed niets | werkt via één loader |
| Docs-only pagina's (Introduction) | **stuk**: body kreeg `dsn-mode-dark`, maar tokens bleven `start-light-default` (`--dsn-color-neutral-bg-document: #fcfcfc`) | `#111111` |

Die laatste is de echte bug: op docs-only pagina's draait de decorator niet, daar is `preview-head.html` de enige loader. Klasse en tokens liepen dus uiteen.

## Oplossing

`preview-head.html` is platte HTML/JS en kent geen Vite-variabelen, dus het pad wordt afgeleid van `document.baseURI`:

```js
const CONFIG_BASE_URL = new URL('design-tokens/dist/css/', document.baseURI).href;
```

Dat klopt zowel op `/` als op een subpad.

## Eén bron van waarheid

Hetzelfde pad stond op drie plekken, elk met een eigen laadimplementatie:

| Plek | Pad | Injectie |
| --- | --- | --- |
| `preview-head.html` | absoluut (fout) | `fetch` + `<style>` met `:root:root` |
| `preview.ts` | relatief | `fetch` + `<style>` zonder `:root:root` |
| `TokenControls.tsx` | relatief | `<link rel=stylesheet>` |

Alleen de eerste was fout, maar ze konden verder uit elkaar lopen (en stampten elkaars `[data-dsn-tokens]`-element weg). De loader in `preview-head.html` is nu de enige die laadt en injecteert, en biedt een API op `window.__DSN_TOKENS__`. `preview.ts` en `TokenControls.tsx` gebruiken die via het nieuwe, getypeerde `packages/storybook/src/token-loader.ts`.

Bijvangst: `TokenControls` las bij mount de huidige configuratie met `split('-')` en maakte van `information-dense` de waarde `information`, waardoor de density-select leeg bleef. `fromConfigName()` lost dat op.

## Verificatie

Lokaal maskeert deze bug, dus getest tegen een build met de gh-pages base (`STORYBOOK_BASE_PATH=/design-system-starter-kit/`), geserveerd onder hetzelfde subpad:

- `configUrl('start-dark-default')` → `http://localhost:6099/design-system-starter-kit/design-tokens/dist/css/start-dark-default.css`, alle requests 200, console schoon
- Introduction (docs-only) met `globals=mode:dark` → `start-dark-default`, `#111111`
- Story met `theme:wireframe;mode:dark;projectType:information-dense` → `wireframe-dark-information-dense`, precies één `[data-dsn-tokens]`-element, `dsn-body` blijft op story-pagina's staan
- TokenControls op de Design Tokens-pagina: mode, density en theme wisselen alle drie correct, inclusief `information-dense`
- Toolbar-switch naar Dark Mode via de UI werkt onder het subpad
- Ook gecontroleerd op `storybook dev` (base `/`): geen regressie

Na merge nog te controleren op de echte deploy, want dat is de enige plek waar dit oorspronkelijk zichtbaar was.

`pnpm lint` (0 errors), `pnpm format:check`, `pnpm type-check`, `pnpm --filter storybook exec tsc --noEmit`, `pnpm test` (1661 tests) en `pnpm build` zijn groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
