### PR TITLE
chore(storybook): verwijder 96 redundante story name-annotaties

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,19 +291,38 @@ Bekijk `packages/storybook/src/Button.docs.md` als referentie voor toon en opmaa
 
 ## Storybook stories: naamgeving en canonieke teksten
 
-### Story namen: altijd Engels
+### Story namen: altijd Engels, en geen redundante `name`
 
-Story `name` waarden zijn altijd Engelstalig. Gebruik de Engelse variant van bekende patronen:
+Storybook leidt de naam in de sidebar af uit de **export-naam**: `WithImagePreview` wordt "With Image Preview". De Engelse eis geldt dus op de export-naam:
 
-| Patroon             | ✅ Correct             | ❌ Niet doen               |
-| ------------------- | ---------------------- | -------------------------- |
-| Overzicht           | `'All States'`         | `'Alle states'`            |
-| Lange tekst         | `'Long Text'`          | `'Lange tekst'`            |
-| Korte tekst         | `'Short Text'`         | `'Korte tekst'`            |
-| Met iets            | `'With Image Preview'` | `'Met afbeeldingspreview'` |
-| Interactief variant | `'Interactive'`        | `'Interactief'`            |
-| RTL                 | `'RTL'`                | —                          |
-| Bestandslijst       | `'File List'`          | `'Bestandslijst'`          |
+| Patroon             | ✅ Correct                      | ❌ Niet doen                         |
+| ------------------- | ------------------------------- | ------------------------------------ |
+| Overzicht           | `export const AllStates`        | `export const AlleStates`            |
+| Lange tekst         | `export const LongText`         | `export const LangeTekst`            |
+| Korte tekst         | `export const ShortText`        | `export const KorteTekst`            |
+| Met iets            | `export const WithImagePreview` | `export const MetAfbeeldingspreview` |
+| Interactief variant | `export const Interactive`      | `export const Interactief`           |
+| RTL                 | `export const RTL`              | `export const Rtl`                   |
+| Bestandslijst       | `export const FileList`         | `export const Bestandslijst`         |
+
+Voeg een expliciete `name` **alleen** toe wanneer die afwijkt van de afgeleide naam, bijvoorbeeld bij sentence case of leestekens die niet uit een export-naam te halen zijn. Een `name` die gelijk is aan de afgeleide naam is redundant, en de eslint-regel `storybook/no-redundant-story-name` klaagt erover.
+
+```tsx
+// ✅ Geen name nodig: Storybook maakt hier zelf 'RTL' van
+export const RTL: Story = {
+  decorators: [rtlDecorator],
+};
+
+// ✅ name wijkt af van de afgeleide naam ('With List Validation')
+export const WithListValidation: Story = {
+  name: 'With list (validation)',
+};
+
+// ❌ Redundant: dit is precies wat Storybook zelf al afleidt
+export const LongText: Story = {
+  name: 'Long Text',
+};
+```
 
 ### Canonieke teksten uit `story-helpers.tsx`
 

--- a/packages/storybook/src/ActionGroup.stories.tsx
+++ b/packages/storybook/src/ActionGroup.stories.tsx
@@ -68,7 +68,6 @@ export const Default: Story = {};
 // =============================================================================
 
 export const WithLink: Story = {
-  name: 'With Link',
   args: {
     children: (
       <>
@@ -93,7 +92,6 @@ export const CustomAriaLabel: Story = {
 };
 
 export const Wrapping: Story = {
-  name: 'Wrapping',
   render: () => (
     <div style={{ maxWidth: '280px' }}>
       <ActionGroup>
@@ -162,7 +160,6 @@ export const WithLinkButton: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <ActionGroup>

--- a/packages/storybook/src/Alert.stories.tsx
+++ b/packages/storybook/src/Alert.stories.tsx
@@ -278,7 +278,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div dir="rtl" lang="ar">

--- a/packages/storybook/src/BreadcrumbNavigation.stories.tsx
+++ b/packages/storybook/src/BreadcrumbNavigation.stories.tsx
@@ -84,7 +84,6 @@ type Story = StoryObj<typeof BreadcrumbNavigation>;
 // =============================================================================
 
 export const Default: Story = {
-  name: 'Default',
   render: (args: BreadcrumbNavigationProps) => (
     <BreadcrumbNavigation {...args}>
       <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
@@ -102,7 +101,6 @@ export const Default: Story = {
 // =============================================================================
 
 export const Compact: Story = {
-  name: 'Compact',
   render: (args: BreadcrumbNavigationProps) => (
     <BreadcrumbNavigation {...args} variant="compact">
       <BreadcrumbNavigationItem href="/home">Home</BreadcrumbNavigationItem>
@@ -153,7 +151,6 @@ export const ManyItems: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: (args: BreadcrumbNavigationProps) => (
     <div dir="rtl" lang="ar">

--- a/packages/storybook/src/Button.stories.tsx
+++ b/packages/storybook/src/Button.stories.tsx
@@ -479,7 +479,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>

--- a/packages/storybook/src/ButtonLink.stories.tsx
+++ b/packages/storybook/src/ButtonLink.stories.tsx
@@ -517,7 +517,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>

--- a/packages/storybook/src/Card.stories.tsx
+++ b/packages/storybook/src/Card.stories.tsx
@@ -380,7 +380,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ maxWidth: '22rem' }}>

--- a/packages/storybook/src/Checkbox.stories.tsx
+++ b/packages/storybook/src/Checkbox.stories.tsx
@@ -185,7 +185,6 @@ export const AllStates: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ display: 'flex', gap: '1.5rem', alignItems: 'center' }}>

--- a/packages/storybook/src/CheckboxGroup.stories.tsx
+++ b/packages/storybook/src/CheckboxGroup.stories.tsx
@@ -114,7 +114,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <CheckboxGroup>

--- a/packages/storybook/src/CheckboxOption.stories.tsx
+++ b/packages/storybook/src/CheckboxOption.stories.tsx
@@ -142,7 +142,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>

--- a/packages/storybook/src/DateInput.stories.tsx
+++ b/packages/storybook/src/DateInput.stories.tsx
@@ -151,7 +151,6 @@ export const AllStates: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { defaultValue: '2026-03-15' },
 };

--- a/packages/storybook/src/DateInputGroup.stories.tsx
+++ b/packages/storybook/src/DateInputGroup.stories.tsx
@@ -162,7 +162,6 @@ export const Disabled: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: (args) => <WithValueStory {...args} />,
 };

--- a/packages/storybook/src/Details.stories.tsx
+++ b/packages/storybook/src/Details.stories.tsx
@@ -87,7 +87,6 @@ export const WithList: Story = {
 // =============================================================================
 
 export const Multiple: Story = {
-  name: 'Multiple',
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
       <Details summary="Wat is de levertijd?">
@@ -133,7 +132,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div dir="rtl" lang="ar">

--- a/packages/storybook/src/DotBadge.stories.tsx
+++ b/packages/storybook/src/DotBadge.stories.tsx
@@ -175,7 +175,6 @@ export const WithPulse: Story = {
 // =============================================================================
 
 export const WithButton: Story = {
-  name: 'With Button',
   render: () => (
     <div
       style={{

--- a/packages/storybook/src/Drawer.stories.tsx
+++ b/packages/storybook/src/Drawer.stories.tsx
@@ -279,7 +279,6 @@ export const ShortText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div dir="rtl" lang="ar">

--- a/packages/storybook/src/EmailInput.stories.tsx
+++ b/packages/storybook/src/EmailInput.stories.tsx
@@ -213,7 +213,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { defaultValue: TEKST_AR },
 };

--- a/packages/storybook/src/File.stories.tsx
+++ b/packages/storybook/src/File.stories.tsx
@@ -168,14 +168,12 @@ export const Default: Story = {
 // =============================================================================
 
 export const Loading: Story = {
-  name: 'Loading',
   args: {
     status: 'loading',
   },
 };
 
 export const Uploaded: Story = {
-  name: 'Uploaded',
   args: {
     href: HREF,
     status: 'uploaded',
@@ -184,7 +182,6 @@ export const Uploaded: Story = {
 };
 
 export const Error: Story = {
-  name: 'Error',
   args: {
     status: 'error',
     errorMessage: 'Upload mislukt. Probeer het opnieuw.',
@@ -193,7 +190,6 @@ export const Error: Story = {
 };
 
 export const WithImagePreview: Story = {
-  name: 'With Image Preview',
   args: {
     fileName: 'foto.jpg',
     fileType: 'JPG',
@@ -213,7 +209,6 @@ export const InteractiveView: Story = {
 };
 
 export const InteractiveDownload: Story = {
-  name: 'Interactive Download',
   args: {
     href: HREF,
     ctaVariant: 'download',
@@ -295,7 +290,6 @@ export const AllStates: Story = {
 // =============================================================================
 
 export const ShortFileName: Story = {
-  name: 'Short File Name',
   args: {
     fileName: 'a.pdf',
     fileType: 'PDF',
@@ -306,7 +300,6 @@ export const ShortFileName: Story = {
 };
 
 export const LongFileName: Story = {
-  name: 'Long File Name',
   args: {
     fileName: `${VEEL_TEKST}.pdf`,
     fileType: 'PDF',
@@ -321,7 +314,6 @@ export const LongFileName: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ maxWidth: '560px' }}>

--- a/packages/storybook/src/FormField.stories.tsx
+++ b/packages/storybook/src/FormField.stories.tsx
@@ -270,7 +270,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: (args) => (
     <FormField

--- a/packages/storybook/src/FormFieldDescription.stories.tsx
+++ b/packages/storybook/src/FormFieldDescription.stories.tsx
@@ -61,7 +61,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { children: TEKST_AR },
 };

--- a/packages/storybook/src/FormFieldErrorMessage.stories.tsx
+++ b/packages/storybook/src/FormFieldErrorMessage.stories.tsx
@@ -90,7 +90,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { children: TEKST_AR },
 };

--- a/packages/storybook/src/FormFieldLabel.stories.tsx
+++ b/packages/storybook/src/FormFieldLabel.stories.tsx
@@ -98,7 +98,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { children: TEKST_AR },
 };

--- a/packages/storybook/src/FormFieldStatus.stories.tsx
+++ b/packages/storybook/src/FormFieldStatus.stories.tsx
@@ -133,7 +133,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { children: TEKST_AR },
 };

--- a/packages/storybook/src/FormFieldset.stories.tsx
+++ b/packages/storybook/src/FormFieldset.stories.tsx
@@ -250,7 +250,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: (args) => (
     <FormFieldset {...args} legend={TEKST_AR} description={TEKST_AR}>

--- a/packages/storybook/src/Heading.stories.tsx
+++ b/packages/storybook/src/Heading.stories.tsx
@@ -131,7 +131,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>

--- a/packages/storybook/src/HeadingGroup.stories.tsx
+++ b/packages/storybook/src/HeadingGroup.stories.tsx
@@ -60,7 +60,6 @@ export const Default: Story = {};
 // =============================================================================
 
 export const WithStep: Story = {
-  name: 'With Step',
   render: () => (
     <HeadingGroup
       level={2}
@@ -76,7 +75,6 @@ export const WithStep: Story = {
 };
 
 export const WithCategory: Story = {
-  name: 'With Category',
   render: () => (
     <HeadingGroup level={2} preHeading="Diensten">
       We helpen u groeien
@@ -85,7 +83,6 @@ export const WithCategory: Story = {
 };
 
 export const Level1: Story = {
-  name: 'Level 1',
   render: () => (
     <HeadingGroup level={1} preHeading="Meerstappenformulier">
       Uw aanvraag
@@ -94,7 +91,6 @@ export const Level1: Story = {
 };
 
 export const DifferentAppearance: Story = {
-  name: 'Different Appearance',
   render: () => (
     <HeadingGroup level={1} appearance="heading-2" preHeading="Stap 1 van 4">
       Persoonlijke gegevens
@@ -107,7 +103,6 @@ export const DifferentAppearance: Story = {
 // =============================================================================
 
 export const AllLevels: Story = {
-  name: 'All Levels',
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
       <HeadingGroup level={1} preHeading="Stap 1 van 4">
@@ -131,7 +126,6 @@ export const AllLevels: Story = {
 // =============================================================================
 
 export const LongText: Story = {
-  name: 'Long Text',
   render: () => (
     <HeadingGroup level={2} preHeading={VEEL_TEKST}>
       {VEEL_TEKST}
@@ -144,7 +138,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>

--- a/packages/storybook/src/Hero.stories.tsx
+++ b/packages/storybook/src/Hero.stories.tsx
@@ -434,7 +434,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   render: (args) => (
     <div dir="rtl" style={{ overflowX: 'clip' }}>
       <div

--- a/packages/storybook/src/Link.stories.tsx
+++ b/packages/storybook/src/Link.stories.tsx
@@ -252,7 +252,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>

--- a/packages/storybook/src/LinkButton.stories.tsx
+++ b/packages/storybook/src/LinkButton.stories.tsx
@@ -217,7 +217,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>

--- a/packages/storybook/src/Menu.stories.tsx
+++ b/packages/storybook/src/Menu.stories.tsx
@@ -119,7 +119,6 @@ export const Default: Story = {
 // =============================================================================
 
 export const Vertical: Story = {
-  name: 'Vertical',
   render: (args: React.ComponentProps<typeof Menu>) => (
     <Menu {...args} orientation="vertical">
       <MenuLink href="/home" current>
@@ -133,7 +132,6 @@ export const Vertical: Story = {
 };
 
 export const Horizontal: Story = {
-  name: 'Horizontal',
   render: (args: React.ComponentProps<typeof Menu>) => (
     <nav aria-label="Paginanavigatie">
       <Menu {...args} orientation="horizontal">

--- a/packages/storybook/src/MenuButton.stories.tsx
+++ b/packages/storybook/src/MenuButton.stories.tsx
@@ -227,7 +227,6 @@ export const AllStates: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>

--- a/packages/storybook/src/MenuLink.stories.tsx
+++ b/packages/storybook/src/MenuLink.stories.tsx
@@ -364,7 +364,6 @@ export const AllStates: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>

--- a/packages/storybook/src/ModalDialog.stories.tsx
+++ b/packages/storybook/src/ModalDialog.stories.tsx
@@ -191,7 +191,6 @@ export const ShortText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div dir="rtl" lang="ar">

--- a/packages/storybook/src/Note.stories.tsx
+++ b/packages/storybook/src/Note.stories.tsx
@@ -300,7 +300,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div dir="rtl" lang="ar">

--- a/packages/storybook/src/NumberBadge.stories.tsx
+++ b/packages/storybook/src/NumberBadge.stories.tsx
@@ -122,7 +122,6 @@ export const HighCount: Story = {
 // =============================================================================
 
 export const InButton: Story = {
-  name: 'In Button',
   render: () => (
     <div
       style={{

--- a/packages/storybook/src/NumberInput.stories.tsx
+++ b/packages/storybook/src/NumberInput.stories.tsx
@@ -205,7 +205,6 @@ export const AllStates: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { defaultValue: '٤٢' },
 };

--- a/packages/storybook/src/OptionLabel.stories.tsx
+++ b/packages/storybook/src/OptionLabel.stories.tsx
@@ -88,7 +88,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { children: TEKST_AR },
 };

--- a/packages/storybook/src/OrderedList.stories.tsx
+++ b/packages/storybook/src/OrderedList.stories.tsx
@@ -87,7 +87,6 @@ export const StartFrom: Story = {
 };
 
 export const Nested: Story = {
-  name: 'Nested',
   render: () => (
     <OrderedList>
       <li>
@@ -173,7 +172,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <OrderedList>

--- a/packages/storybook/src/PageBody.stories.tsx
+++ b/packages/storybook/src/PageBody.stories.tsx
@@ -247,7 +247,6 @@ type Story = StoryObj<typeof PageBody>;
 // =============================================================================
 
 export const Default: Story = {
-  name: 'Default',
   render: () => (
     <>
       <SkipLink href="#main-content" />

--- a/packages/storybook/src/PageFooter.stories.tsx
+++ b/packages/storybook/src/PageFooter.stories.tsx
@@ -188,12 +188,9 @@ type Story = StoryObj<typeof PageFooter>;
 // STORIES
 // =============================================================================
 
-export const Default: Story = {
-  name: 'Default',
-};
+export const Default: Story = {};
 
 export const Inverse: Story = {
-  name: 'Inverse',
   args: {
     colorScheme: 'inverse',
   },

--- a/packages/storybook/src/PageHeader.stories.tsx
+++ b/packages/storybook/src/PageHeader.stories.tsx
@@ -800,7 +800,6 @@ function PageContent() {
 // =============================================================================
 
 export const Compact: Story = {
-  name: 'Compact',
   args: {
     layout: 'compact',
     primaryNavigation: <PrimaryNavigationCompact />,

--- a/packages/storybook/src/PageLayout.stories.tsx
+++ b/packages/storybook/src/PageLayout.stories.tsx
@@ -258,7 +258,6 @@ type Story = StoryObj<typeof PageLayout>;
 // =============================================================================
 
 export const Default: Story = {
-  name: 'Default',
   render: () => (
     <>
       <SkipLink href="#main-content" />

--- a/packages/storybook/src/Paragraph.stories.tsx
+++ b/packages/storybook/src/Paragraph.stories.tsx
@@ -113,7 +113,6 @@ export const LongTextAllVariants: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { children: TEKST_AR },
 };

--- a/packages/storybook/src/PasswordInput.stories.tsx
+++ b/packages/storybook/src/PasswordInput.stories.tsx
@@ -201,7 +201,6 @@ export const AllStates: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { defaultValue: 'geheim123' },
 };

--- a/packages/storybook/src/Popover.stories.tsx
+++ b/packages/storybook/src/Popover.stories.tsx
@@ -126,7 +126,6 @@ export const Default: Story = {
 // =============================================================================
 
 export const WithHeader: Story = {
-  name: 'With Header',
   render: () => {
     function Demo() {
       const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -278,7 +277,6 @@ export const PlacementStart: Story = {
 // =============================================================================
 
 export const AllPlacements: Story = {
-  name: 'All Placements',
   render: () => (
     <div
       style={{

--- a/packages/storybook/src/PreHeading.stories.tsx
+++ b/packages/storybook/src/PreHeading.stories.tsx
@@ -47,7 +47,6 @@ export const Default: Story = {
 // =============================================================================
 
 export const InsideHeading1: Story = {
-  name: 'Inside Heading 1',
   render: () => (
     <Heading level={1}>
       <PreHeading>Meerstappenformulier</PreHeading>
@@ -57,7 +56,6 @@ export const InsideHeading1: Story = {
 };
 
 export const WithCategory: Story = {
-  name: 'With Category',
   render: () => (
     <Heading level={2}>
       <PreHeading>Diensten</PreHeading>
@@ -67,7 +65,6 @@ export const WithCategory: Story = {
 };
 
 export const WithVisuallyHiddenColon: Story = {
-  name: 'With Visually Hidden Colon',
   render: () => (
     <Heading level={2}>
       <PreHeading>
@@ -83,7 +80,6 @@ export const WithVisuallyHiddenColon: Story = {
 // =============================================================================
 
 export const AllHeadingLevels: Story = {
-  name: 'All Heading Levels',
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
       <Heading level={1}>
@@ -119,7 +115,6 @@ export const AllHeadingLevels: Story = {
 // =============================================================================
 
 export const ShortText: Story = {
-  name: 'Short Text',
   render: () => (
     <Heading level={2}>
       <PreHeading>{WEINIG_TEKST}</PreHeading>
@@ -129,7 +124,6 @@ export const ShortText: Story = {
 };
 
 export const LongText: Story = {
-  name: 'Long Text',
   render: () => (
     <Heading level={2}>
       <PreHeading>{VEEL_TEKST}</PreHeading>
@@ -143,7 +137,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>

--- a/packages/storybook/src/Radio.stories.tsx
+++ b/packages/storybook/src/Radio.stories.tsx
@@ -172,7 +172,6 @@ export const AllStates: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ display: 'flex', gap: '1.5rem', alignItems: 'center' }}>

--- a/packages/storybook/src/RadioGroup.stories.tsx
+++ b/packages/storybook/src/RadioGroup.stories.tsx
@@ -118,7 +118,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <RadioGroup>

--- a/packages/storybook/src/RadioOption.stories.tsx
+++ b/packages/storybook/src/RadioOption.stories.tsx
@@ -159,7 +159,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>

--- a/packages/storybook/src/SearchInput.stories.tsx
+++ b/packages/storybook/src/SearchInput.stories.tsx
@@ -214,7 +214,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { defaultValue: TEKST_AR },
 };

--- a/packages/storybook/src/Select.stories.tsx
+++ b/packages/storybook/src/Select.stories.tsx
@@ -205,7 +205,6 @@ export const AllStates: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => <Select defaultValue="nl">{OPTIONS_AR}</Select>,
 };

--- a/packages/storybook/src/SkipLink.stories.tsx
+++ b/packages/storybook/src/SkipLink.stories.tsx
@@ -152,7 +152,6 @@ export const MultipleSkipLinks: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { children: 'انتقل مباشرة إلى المحتوى الرئيسي' },
 };

--- a/packages/storybook/src/Spinner.stories.tsx
+++ b/packages/storybook/src/Spinner.stories.tsx
@@ -54,7 +54,6 @@ export const Default: Story = {};
 // =============================================================================
 
 export const Large: Story = {
-  name: 'Large',
   args: {
     size: 'large',
     label: 'Pagina wordt geladen',

--- a/packages/storybook/src/StatusBadge.stories.tsx
+++ b/packages/storybook/src/StatusBadge.stories.tsx
@@ -227,7 +227,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div dir="rtl" lang="ar">

--- a/packages/storybook/src/SummaryList.stories.tsx
+++ b/packages/storybook/src/SummaryList.stories.tsx
@@ -85,7 +85,6 @@ export const Default: Story = {
 // =============================================================================
 
 export const WithActions: Story = {
-  name: 'With Actions',
   render: () => (
     <SummaryList>
       <SummaryListRow>
@@ -122,7 +121,6 @@ export const WithActions: Story = {
 };
 
 export const WithMultipleActions: Story = {
-  name: 'With Multiple Actions',
   render: () => (
     <SummaryList>
       <SummaryListRow>
@@ -168,7 +166,6 @@ export const WithMultipleActions: Story = {
 };
 
 export const MixedRows: Story = {
-  name: 'Mixed Rows',
   render: () => (
     <SummaryList>
       <SummaryListRow>
@@ -202,7 +199,6 @@ export const MixedRows: Story = {
 };
 
 export const NoBorder: Story = {
-  name: 'No Border',
   render: () => (
     <SummaryList noBorder>
       <SummaryListRow>
@@ -226,7 +222,6 @@ export const NoBorder: Story = {
 // =============================================================================
 
 export const AllVariants: Story = {
-  name: 'All Variants',
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '3rem' }}>
       <div>
@@ -290,7 +285,6 @@ export const AllVariants: Story = {
 // =============================================================================
 
 export const ShortText: Story = {
-  name: 'Short Text',
   render: () => (
     <SummaryList>
       <SummaryListRow>
@@ -306,7 +300,6 @@ export const ShortText: Story = {
 };
 
 export const LongText: Story = {
-  name: 'Long Text',
   render: () => (
     <SummaryList>
       <SummaryListRow>

--- a/packages/storybook/src/Table.stories.tsx
+++ b/packages/storybook/src/Table.stories.tsx
@@ -764,7 +764,6 @@ export const AllTogether: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <Table caption="جدول المنتجات">

--- a/packages/storybook/src/TableOfContents.stories.tsx
+++ b/packages/storybook/src/TableOfContents.stories.tsx
@@ -80,7 +80,6 @@ export const Default: Story = {};
 // =============================================================================
 
 export const Plain: Story = {
-  name: 'Plain',
   args: {
     appearance: 'plain',
   },
@@ -128,7 +127,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <div dir="rtl" lang="ar">

--- a/packages/storybook/src/TelephoneInput.stories.tsx
+++ b/packages/storybook/src/TelephoneInput.stories.tsx
@@ -218,7 +218,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { defaultValue: TEKST_AR },
 };

--- a/packages/storybook/src/TextArea.stories.tsx
+++ b/packages/storybook/src/TextArea.stories.tsx
@@ -265,7 +265,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { defaultValue: TEKST_AR, readOnly: true },
 };

--- a/packages/storybook/src/TextInput.stories.tsx
+++ b/packages/storybook/src/TextInput.stories.tsx
@@ -213,7 +213,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { defaultValue: TEKST_AR },
 };

--- a/packages/storybook/src/TimeInput.stories.tsx
+++ b/packages/storybook/src/TimeInput.stories.tsx
@@ -151,7 +151,6 @@ export const AllStates: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   args: { defaultValue: '14:30' },
 };

--- a/packages/storybook/src/UnorderedList.stories.tsx
+++ b/packages/storybook/src/UnorderedList.stories.tsx
@@ -68,7 +68,6 @@ export const Default: Story = {};
 // =============================================================================
 
 export const Nested: Story = {
-  name: 'Nested',
   render: () => (
     <UnorderedList>
       <li>
@@ -122,7 +121,6 @@ export const LongText: Story = {
 // =============================================================================
 
 export const RTL: Story = {
-  name: 'RTL',
   decorators: [rtlDecorator],
   render: () => (
     <UnorderedList>


### PR DESCRIPTION
## Wat

`pnpm lint` gaf op `main` 96 warnings en 0 errors. Alle 96 kwamen van dezelfde regel: `storybook/no-redundant-story-name` uit `eslint-plugin-storybook@10.3.6`, verdeeld over 60 story-bestanden.

Storybook leidt de naam in de sidebar zelf af uit de export-naam (`WithImagePreview` wordt "With Image Preview"). De regel klaagt alleen wanneer de expliciete `name` letterlijk gelijk is aan die afgeleide naam:

```tsx
export const RTL: Story = {
  name: 'RTL', // redundant: Storybook maakt hier zelf al 'RTL' van
  decorators: [rtlDecorator],
```

Die 96 gevallen zijn verwijderd. Van de 443 expliciete `name:`-waarden blijven er 347 staan: die wijken echt af van de afgeleide naam (`'Default variant'`, `'No icon'`, `'With list (validation)'`) en zijn ongemoeid gelaten.

`pnpm lint` gaat hiermee van 96 warnings naar 0.

## Verificatie dat er niets zichtbaar verandert

Na `pnpm build` is de gegenereerde `packages/storybook/dist/index.json` (716 stories) vergeleken met de 96 verwijderde namen: alle 96 stories dragen daarin nog exact dezelfde naam. De sidebar en de Chromatic-snapshotnamen veranderen dus niet.

## Aanpak

De regel heeft geen fixer, dus `lint:fix` loste dit niet op. De verwijdering is gescript op de JSON-output van eslint, met een assertie dat elke te verwijderen regel het patroon `name: '...',` heeft. `PageFooter/Default` hield daarna een leeg object over, dat door prettier is samengetrokken tot `{}`.

## CLAUDE.md meegenomen

De sectie "Story namen: altijd Engels" gaf als voorbeelden precies de nu verwijderde vorm (`'All States'`, `'Long Text'`, `'RTL'`). Die eis gold op de `name`-waarde en geldt nu op de export-naam, met de expliciete instructie om `name` alleen te gebruiken wanneer die afwijkt van de afgeleide naam. Zonder die aanpassing zou de volgende story de warnings meteen weer introduceren.

## Kwaliteitscontrole

- `pnpm lint`: 0 errors, 0 warnings
- `pnpm format:check`: schoon
- `pnpm type-check`: schoon
- `pnpm --filter storybook exec tsc --noEmit`: schoon
- `pnpm test`: 1661 tests in 80 bestanden groen
- `pnpm build`: succesvol

Geen changelog-entry: de wijziging heeft geen effect op consumers, geen API-wijziging en geen visuele wijziging.

## Open vraag voor review

CI draait `pnpm lint` zonder `--max-warnings`, dus warnings blokkeren de build niet en konden daardoor oplopen tot 96. Zullen we er `--max-warnings 0` van maken in een aparte PR? Dat is een bewuste beleidskeuze: elke toekomstige warning wordt dan blokkerend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)