### PR TITLE
docs: synchroniseer documentatie met de huidige staat van de codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Token categories:
 - **Shadows** - 3 elevation levels
 - **Focus States** - Accessible focus indicators
 - **Form Controls** - Border, spacing, typography, and color tokens for form elements (7 states)
-- **Form Components** - 19 complete form components with 26 token files
+- **Form Components** - 26 form components, covered by 22 token files (EmailInput, NumberInput, TelephoneInput, FormFieldset and FormFieldLegend define none of their own and reuse the shared `form-control` tokens)
 
 All tokens (~1380 per configuration) are built with [Style Dictionary](https://amzn.github.io/style-dictionary/) and exported as:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ This monorepo contains the following packages:
 - **[@dsn-starter-kit/components-web](./packages/components-web)** - Web Components (vanilla TypeScript)
 - **[@dsn-starter-kit/storybook](./packages/storybook)** - Documentation and component showcase
 
+Internal packages (not published to npm):
+
+- **[@dsn-starter-kit/figma-sync](./packages/figma-sync)** - Generates Figma node specs from the HTML/CSS layer
+- **[@dsn-starter-kit/figma-plugin](./packages/figma-plugin)** - Figma plugin that writes the generated variables and component specs into Figma
+- **[@dsn-starter-kit/color-palette-generator](./packages/color-palette-generator)** - Interactive OKLCH color palette generator for white-label themes
+
 ## Quick Start
 
 ### Option A: Install from npm (recommended for consumers)
@@ -77,13 +83,16 @@ pnpm build:core        # Core utilities
 pnpm build:components  # All component packages
 pnpm build:storybook   # Storybook static site
 
+# Build the Figma chain (tokens, variables, component specs, plugin)
+pnpm build:figma
+
 # Watch design tokens for changes
 pnpm --filter @dsn-starter-kit/design-tokens watch
 
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (1593 tests across 78 test suites)
+# Run tests (1661 tests across 80 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -155,7 +164,7 @@ Token categories:
 - **Form Controls** - Border, spacing, typography, and color tokens for form elements (7 states)
 - **Form Components** - 19 complete form components with 26 token files
 
-All tokens (~1050 per configuration) are built with [Style Dictionary](https://amzn.github.io/style-dictionary/) and exported as:
+All tokens (~1380 per configuration) are built with [Style Dictionary](https://amzn.github.io/style-dictionary/) and exported as:
 
 - CSS Custom Properties
 - SCSS Variables
@@ -200,7 +209,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **PageLayout**      | Yes      | Yes   | No            |
 | **Stack**           | Yes      | Yes   | No            |
 
-**Content Components (12)**
+**Content Components (13)**
 
 | Component         | HTML/CSS | React | Web Component |
 | ----------------- | -------- | ----- | ------------- |
@@ -209,6 +218,7 @@ All components are fully typed with TypeScript and include comprehensive JSDoc d
 | **Heading**       | Yes      | Yes   | Yes           |
 | **HeadingGroup**  | Yes      | Yes   | No            |
 | **Icon**          | Yes      | Yes   | Yes           |
+| **IconList**      | Yes      | Yes   | No            |
 | **Image**         | Yes      | Yes   | No            |
 | **Link**          | Yes      | Yes   | Yes           |
 | **LinkButton**    | Yes      | Yes   | No            |
@@ -437,7 +447,7 @@ Comprehensive documentation is available in the `/docs` folder:
 
 - **Pre-commit hooks** via Husky + lint-staged (ESLint + Prettier)
 - **Type checking** across all packages (`pnpm type-check`)
-- **1593 tests** covering React components, Web Components, and utilities
+- **1661 tests** covering React components, Web Components, and utilities
 - **CI/CD** via GitHub Actions (lint, type-check, test, build)
 
 ## Tech Stack

--- a/docs/00-getting-started.md
+++ b/docs/00-getting-started.md
@@ -169,7 +169,7 @@ Available Web Components: `Button`, `Heading`, `Icon`, `Link`, `OrderedList`, `P
 
 ## Where to go next
 
-- **[Live Storybook](https://jeffreylauwers.github.io/design-system-starter-kit/)** — browse all 71 components with interactive examples and usage guidelines
+- **[Live Storybook](https://jeffreylauwers.github.io/design-system-starter-kit/)** — browse all 75 components with interactive examples and usage guidelines
 - **[Design Tokens Reference](./02-design-tokens-reference.md)** — all token values, scales, and how to use them in your own CSS
 - **[Components Reference](./03-components.md)** — component API specifications
 - **[Contributing](../CONTRIBUTING.md)** — how to add or change components

--- a/docs/03-components.md
+++ b/docs/03-components.md
@@ -1056,7 +1056,7 @@ Brengt consistente verticale ruimte aan tussen directe child-elementen via `flex
 
 ## Display & Feedback Components
 
-**Status:** Complete (HTML/CSS, React): 16 components total
+**Status:** Complete (HTML/CSS, React): 17 components total
 
 ### Backdrop
 
@@ -3473,15 +3473,15 @@ defineButton('my-custom-button');
 
 ## Component Statistics
 
-**Total Components:** 71
+**Total Components:** 75
 
 **Implementations:**
 
-- **HTML/CSS:** 71 components
-- **React:** 71 components (1549 tests total, 75 test suites)
+- **HTML/CSS:** 75 components
+- **React:** 75 components (1661 tests total, 80 test suites)
 - **Web Component:** 7 components (Button, Heading, Icon, Link, OrderedList, Paragraph, UnorderedList)
 
-**Test Coverage:** 1549 tests across 75 test suites
+**Test Coverage:** 1661 tests across 80 test suites
 
 ---
 

--- a/docs/04-development-workflow.md
+++ b/docs/04-development-workflow.md
@@ -43,7 +43,7 @@ pnpm --filter @dsn-starter-kit/design-tokens watch
 # Start Storybook in development mode
 pnpm dev
 
-# Run tests (1549 tests across 75 test suites)
+# Run tests (1661 tests across 80 test suites)
 pnpm test
 
 # Run tests in watch mode
@@ -548,7 +548,7 @@ In Windows High Contrast mode / forced-colors mode worden `background-color`, `c
 
 ### Test Coverage
 
-- **Total tests:** 1549 across 75 test suites
+- **Total tests:** 1661 across 80 test suites
 - **Frameworks:** Vitest + React Testing Library
 - **Coverage areas:** React components, Web Components, utilities
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,11 +95,11 @@ Complete documentation voor het Design System Starter Kit.
 
 ## 📊 System Statistics
 
-- **Tokens per configuration:** ~1100 (400 semantic + 700 component)
+- **Tokens per configuration:** ~1380
 - **Configurations:** 8 (2 themes × 2 modes × 2 project types)
-- **Components:** 71 (HTML/CSS + React)
-- **Tests:** 1549 across 75 test suites
-- **Storybook stories:** 130+
+- **Components:** 75 (HTML/CSS + React)
+- **Tests:** 1661 across 80 test suites
+- **Storybook stories:** 637 across 88 component pages
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -149,6 +149,29 @@ Nog niet gepubliceerde wijzigingen. Schrijf nieuwe changelog-entries hieronder; 
   - Alles wat niet naar een Figma-variable te vertalen is (box shadows, transitions, `ch`-eenheden) staat met reden in `dist/figma/variables-report.json`
   - De Figma-build staat bewust los van `build:tokens`: de token-CSS is het hoofdproduct en hoort niet om te vallen door een generator die er alleen maar naast draait
 
+### Storybook
+
+#### Fixed
+
+- **Token-CSS wordt geladen vanaf het juiste basispad** (PR [#343](https://github.com/jeffreylauwers/design-system-starter-kit/pull/343)): het script in `preview-head.html` gebruikte het absolute pad `/design-tokens/dist/css`. Dat negeert de Vite `base`, die op GitHub Pages op `/design-system-starter-kit/` staat. Op de gedeployde Storybook gaf elke fetch daardoor een 404 met "Token config load error", en volgden docs-only pagina's zoals Introduction de theme-, mode- en density-keuze niet meer: de body kreeg wel `dsn-mode-dark`, maar de tokens bleven op `start-light-default` staan. Lokaal viel het niet op, omdat `base` daar `/` is en het absolute pad toevallig klopte.
+  - Het pad wordt nu afgeleid met `new URL(..., document.baseURI)`, zodat het zowel op `/` als op een subpad klopt. `preview-head.html` is platte HTML/JS en kent geen Vite-variabelen, dus dit is de aangewezen route
+  - Hetzelfde pad stond op drie plekken met elk een eigen laadimplementatie (`preview-head.html`, `preview.ts` en `TokenControls.tsx`). Alleen de eerste was fout, maar ze konden verder uit elkaar lopen. De loader in `preview-head.html` is nu de enige bron van waarheid en biedt een API op `window.__DSN_TOKENS__`, getypeerd in `packages/storybook/src/token-loader.ts`
+  - Bijvangst: `TokenControls` las de huidige configuratie met `split('-')` en maakte van `information-dense` de waarde `information`, waardoor de density-select leeg bleef. `fromConfigName()` lost dat op
+
+#### Changed
+
+- **96 redundante story `name`-annotaties verwijderd** (PR [#344](https://github.com/jeffreylauwers/design-system-starter-kit/pull/344)): de eslint-regel `storybook/no-redundant-story-name` gaf 96 warnings, verdeeld over 60 story-bestanden. Storybook leidt de naam in de sidebar zelf af uit de export-naam, dus `export const RTL` met `name: 'RTL'` leverde twee keer dezelfde naam op. `pnpm lint` gaat hiermee van 96 warnings naar 0.
+  - De 347 namen die wel afwijken van de afgeleide naam zijn ongemoeid gelaten
+  - Geverifieerd tegen de gebouwde storybook-index: alle 96 stories dragen daarin nog exact dezelfde naam, dus de sidebar en de Chromatic-snapshotnamen veranderen niet
+  - `CLAUDE.md` is meegenomen: de eis "story namen altijd Engels" gold op de `name`-waarde en geldt nu op de export-naam, met de instructie om `name` alleen te gebruiken wanneer die afwijkt van de afgeleide naam
+
+### CI
+
+#### Changed
+
+- **GitHub Actions bijgewerkt naar Node 24-compatibele versies** (issue [#314](https://github.com/jeffreylauwers/design-system-starter-kit/issues/314), PR [#340](https://github.com/jeffreylauwers/design-system-starter-kit/pull/340)): de acties in `ci.yml`, `deploy-storybook.yml` en `publish.yml` draaiden op runtimes die GitHub uitfaseert.
+- **`chromaui/action` van v11 naar v18** (PR [#342](https://github.com/jeffreylauwers/design-system-starter-kit/pull/342)).
+
 ---
 
 ## Version 2.0.0 (July 12, 2026)

--- a/packages/components-html/README.md
+++ b/packages/components-html/README.md
@@ -146,6 +146,7 @@ import '@dsn-starter-kit/components-html/modal-dialog';
 | HeadingGroup          | `dsn-heading-group`                                              | `./heading-group`            |
 | Hero                  | `dsn-hero`                                                       | `./hero`                     |
 | Icon                  | `dsn-icon`, `dsn-icon--size-{size}`                              | `./icon`                     |
+| IconList              | `dsn-icon-list`, `dsn-icon-list__item`, `dsn-icon-list__icon`    | `./icon-list`                |
 | Image                 | `dsn-image`                                                      | `./image`                    |
 | Link                  | `dsn-link`, `dsn-link--external`                                 | `./link`                     |
 | LinkButton            | `dsn-link`                                                       | `./link-button`              |


### PR DESCRIPTION
## Wat

Documentatie bijgewerkt naar de actuele staat van de codebase. Alleen documentatie: geen code, tokens of stories aangeraakt.

## Changelog aangevuld

Vier wijzigingen sinds [#339](https://github.com/jeffreylauwers/design-system-starter-kit/pull/339) hadden nog geen entry. Toegevoegd onder Unreleased:

- **Storybook / Fixed**: token-CSS wordt geladen vanaf het juiste basispad ([#343](https://github.com/jeffreylauwers/design-system-starter-kit/pull/343))
- **Storybook / Changed**: 96 redundante story `name`-annotaties verwijderd ([#344](https://github.com/jeffreylauwers/design-system-starter-kit/pull/344))
- **CI / Changed**: Actions naar Node 24-compatibele versies ([#340](https://github.com/jeffreylauwers/design-system-starter-kit/pull/340)) en `chromaui/action` v11 naar v18 ([#342](https://github.com/jeffreylauwers/design-system-starter-kit/pull/342))

## IconList ontbrak in de overzichten

Toegevoegd aan de root `README.md` (Content Components, 12 naar 13) en aan de componententabel in `packages/components-html/README.md`, waar de export `./icon-list` wel in de `exports`-map van package.json stond maar niet in de tabel. IconList stond al wel in `docs/03-components.md` en had al Storybook-docs.

## Statistieken opnieuw geteld

Niet overgeschreven maar gemeten in de codebase:

| Wat | Stond er | Werkelijk |
| --- | --- | --- |
| Tests | 1549 / 1593 across 75 / 78 suites | 1661 across 80 |
| Componenten | 71 | 75 |
| Display & Feedback | 16 | 17 |
| Storybook-stories | 130+ | 637 across 88 paginas |
| Tokens per configuratie | ~1050 / ~1100 | ~1380 |

De 75 verdient toelichting: er zijn 73 mappen in `packages/components-react/src` (`utils` niet meegeteld), plus GridItem en FileList, die geen eigen map hebben maar in de README-tabel altijd al een eigen rij kregen. Die telling is aangehouden zodat tabel en totaal met elkaar kloppen.

Het tokenaantal is geteld als unieke `--dsn-` custom properties in `start-light-default.css`.

## Form Components: telling die nooit klopte

De regel "19 complete form components with 26 token files" stamt uit de initiele commit `f319728` en is sindsdien niet aangeraakt. Beide getallen klopten toen al niet: de repo had op dat moment 24 component-tokenbestanden, waarvan 18 form-gerelateerd.

Vandaag geteld: 26 form-componenten, waarvan 21 met een eigen tokenbestand, plus `form-field-label-suffix.json` als helper zonder eigen componentrij, samen 22 form-tokenbestanden. De vijf zonder eigen tokens delegeren bewust: EmailInput, NumberInput en TelephoneInput renderen `dsn-text-input`, FormFieldset en FormFieldLegend leunen op de gedeelde `form-control`-tokens. Dat staat nu in de regel zelf, zodat het verschil tussen 26 en 22 uitgelegd is in plaats van als fout te lezen.

## Root README verder aangevuld

De drie interne packages (`figma-sync`, `figma-plugin`, `color-palette-generator`) en het `build:figma`-script stonden er niet in.

## Geen decision record

De commits sinds de vorige sync zijn bug fixes en opruimwerk binnen bestaande patronen. De enige echte open keuze is `--max-warnings 0` voor `pnpm lint`, en die ligt bewust in [issue #345](https://github.com/jeffreylauwers/design-system-starter-kit/issues/345).

## Kwaliteitscontrole

- `pnpm format:check`: schoon
- Geen code aangeraakt, dus lint, types en tests zijn ongewijzigd ten opzichte van `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)